### PR TITLE
Managed exit cases for GETTIME state. Removed IDLE state.

### DIFF
--- a/src/ConnectionManager.h
+++ b/src/ConnectionManager.h
@@ -9,7 +9,6 @@
 #include <Client.h>
 
 enum NetworkConnectionState {
-  CONNECTION_STATE_IDLE,
   CONNECTION_STATE_INIT,
   CONNECTION_STATE_CONNECTING,
   CONNECTION_STATE_CONNECTED,
@@ -30,7 +29,7 @@ public:
 
 protected:
   unsigned long lastValidTimestamp = 0;
-  NetworkConnectionState netConnectionState = CONNECTION_STATE_IDLE;
+  NetworkConnectionState netConnectionState = CONNECTION_STATE_INIT;
 
 };
 


### PR DESCRIPTION
Fix a bug for the CONNECTION_STATE_GETTIME state that keep the state machine in this state in se of:

- loss of WiFi connection: in this case the fix will put the state in CONNECTION_STATE_DISCONNECTED and restart the WiFi connection loop

- inability to return a valid network time: in this case the fix will put the state in CONNECTION_STATE_DISCONNECTED after MAX_GETTIME_RETRY times and restart the WiFi connection loop

