### PR TITLE
Managed exit cases for IOT_STATUS_CLOUD_CONNECTED, removed unused states

### DIFF
--- a/src/ArduinoIoTCloud.cpp
+++ b/src/ArduinoIoTCloud.cpp
@@ -282,15 +282,11 @@ void ArduinoIoTCloudClass::handleMessage(int length)
 }
 
 void ArduinoIoTCloudClass::connectionCheck() {
-  if(connection != NULL){
+  if(connection != NULL) {
     connection->check();
-    
     if (connection->getStatus() != CONNECTION_STATE_CONNECTED) {
-      if(iotStatus == IOT_STATUS_CLOUD_CONNECTED){
-        setIoTConnectionState(IOT_STATUS_CLOUD_DISCONNECTED);
-      }else{
-        //setIoTConnectionState(IOT_STATUS_CLOUD_CONNECTING);
-      }
+      if (iotStatus == IOT_STATUS_CLOUD_CONNECTED)
+        setIoTConnectionState(IOT_STATUS_CLOUD_RECONNECTING);
       return;
     }
   }
@@ -299,7 +295,7 @@ void ArduinoIoTCloudClass::connectionCheck() {
   
 
   switch (iotStatus) {
-    case IOT_STATUS_IDLE:
+    case IOT_STATUS_CLOUD_IDLE:
     {
       int connectionAttempt;
       if(connection == NULL){
@@ -314,17 +310,15 @@ void ArduinoIoTCloudClass::connectionCheck() {
       }
       setIoTConnectionState(IOT_STATUS_CLOUD_CONNECTING);
       break;
-    } 
-      
+    }       
     case IOT_STATUS_CLOUD_ERROR:
       debugMessage("Cloud Error. Retrying...", 0);
       setIoTConnectionState(IOT_STATUS_CLOUD_RECONNECTING);
       break;
     case IOT_STATUS_CLOUD_CONNECTED:
       debugMessage(".", 4, false, true);
-      break;
-    case IOT_STATUS_CLOUD_DISCONNECTED:
-      setIoTConnectionState(IOT_STATUS_CLOUD_RECONNECTING);
+      if (!_mqttClient->connected())
+        setIoTConnectionState(IOT_STATUS_CLOUD_RECONNECTING);
       break;
     case IOT_STATUS_CLOUD_RECONNECTING:
       int arduinoIoTReconnectionAttempt;

--- a/src/ArduinoIoTCloud.h
+++ b/src/ArduinoIoTCloud.h
@@ -24,14 +24,12 @@ typedef struct {
 extern ConnectionManager *ArduinoIoTPreferredConnection;
 
 enum ArduinoIoTConnectionStatus {
-  IOT_STATUS_IDLE,/* only at start */
   IOT_STATUS_CLOUD_IDLE,
   IOT_STATUS_CLOUD_CONNECTING,
   IOT_STATUS_CLOUD_CONNECTED,
   IOT_STATUS_CLOUD_DISCONNECTED,
   IOT_STATUS_CLOUD_RECONNECTING,
-  IOT_STATUS_CLOUD_ERROR,
-  IOT_STATUS_ERROR_GENERIC
+  IOT_STATUS_CLOUD_ERROR
 };
 
 class ArduinoIoTCloudClass {
@@ -106,7 +104,7 @@ protected:
   ArduinoIoTConnectionStatus getIoTStatus() { return iotStatus; }
   void setIoTConnectionState(ArduinoIoTConnectionStatus _newState);
 private:
-  ArduinoIoTConnectionStatus iotStatus = IOT_STATUS_IDLE;
+  ArduinoIoTConnectionStatus iotStatus = IOT_STATUS_CLOUD_IDLE;
   ConnectionManager *connection;
   static void onMessage(int length);
   void handleMessage(int length);


### PR DESCRIPTION
Check MQTT status and transition in IOT_STATUS_CLOUD_RECONNECTING in case of loss of connection.