### PR TITLE
Revert "Managed exit cases for IOT_STATUS_CLOUD_CONNECTED, removed unused states"

### DIFF
--- a/src/ArduinoIoTCloud.cpp
+++ b/src/ArduinoIoTCloud.cpp
@@ -282,11 +282,15 @@ void ArduinoIoTCloudClass::handleMessage(int length)
 }
 
 void ArduinoIoTCloudClass::connectionCheck() {
-  if(connection != NULL) {
+  if(connection != NULL){
     connection->check();
+    
     if (connection->getStatus() != CONNECTION_STATE_CONNECTED) {
-      if (iotStatus == IOT_STATUS_CLOUD_CONNECTED)
-        setIoTConnectionState(IOT_STATUS_CLOUD_RECONNECTING);
+      if(iotStatus == IOT_STATUS_CLOUD_CONNECTED){
+        setIoTConnectionState(IOT_STATUS_CLOUD_DISCONNECTED);
+      }else{
+        //setIoTConnectionState(IOT_STATUS_CLOUD_CONNECTING);
+      }
       return;
     }
   }
@@ -295,7 +299,7 @@ void ArduinoIoTCloudClass::connectionCheck() {
   
 
   switch (iotStatus) {
-    case IOT_STATUS_CLOUD_IDLE:
+    case IOT_STATUS_IDLE:
     {
       int connectionAttempt;
       if(connection == NULL){
@@ -310,15 +314,17 @@ void ArduinoIoTCloudClass::connectionCheck() {
       }
       setIoTConnectionState(IOT_STATUS_CLOUD_CONNECTING);
       break;
-    }       
+    } 
+      
     case IOT_STATUS_CLOUD_ERROR:
       debugMessage("Cloud Error. Retrying...", 0);
       setIoTConnectionState(IOT_STATUS_CLOUD_RECONNECTING);
       break;
     case IOT_STATUS_CLOUD_CONNECTED:
       debugMessage(".", 4, false, true);
-      if (!_mqttClient->connected())
-        setIoTConnectionState(IOT_STATUS_CLOUD_RECONNECTING);
+      break;
+    case IOT_STATUS_CLOUD_DISCONNECTED:
+      setIoTConnectionState(IOT_STATUS_CLOUD_RECONNECTING);
       break;
     case IOT_STATUS_CLOUD_RECONNECTING:
       int arduinoIoTReconnectionAttempt;

--- a/src/ArduinoIoTCloud.h
+++ b/src/ArduinoIoTCloud.h
@@ -24,12 +24,14 @@ typedef struct {
 extern ConnectionManager *ArduinoIoTPreferredConnection;
 
 enum ArduinoIoTConnectionStatus {
+  IOT_STATUS_IDLE,/* only at start */
   IOT_STATUS_CLOUD_IDLE,
   IOT_STATUS_CLOUD_CONNECTING,
   IOT_STATUS_CLOUD_CONNECTED,
   IOT_STATUS_CLOUD_DISCONNECTED,
   IOT_STATUS_CLOUD_RECONNECTING,
-  IOT_STATUS_CLOUD_ERROR
+  IOT_STATUS_CLOUD_ERROR,
+  IOT_STATUS_ERROR_GENERIC
 };
 
 class ArduinoIoTCloudClass {
@@ -104,7 +106,7 @@ protected:
   ArduinoIoTConnectionStatus getIoTStatus() { return iotStatus; }
   void setIoTConnectionState(ArduinoIoTConnectionStatus _newState);
 private:
-  ArduinoIoTConnectionStatus iotStatus = IOT_STATUS_CLOUD_IDLE;
+  ArduinoIoTConnectionStatus iotStatus = IOT_STATUS_IDLE;
   ConnectionManager *connection;
   static void onMessage(int length);
   void handleMessage(int length);


### PR DESCRIPTION
Reverts arduino-libraries/ArduinoIoTCloud#28

I have noticed some glitches during network connection if network time was not acquired promptly.
@ilcato let's review your changes again