### PR TITLE
Add debug print for broker host string

### DIFF
--- a/src/ArduinoIoTCloud.cpp
+++ b/src/ArduinoIoTCloud.cpp
@@ -150,6 +150,7 @@ void ArduinoIoTCloudClass::mqttClientBegin()
 
 int ArduinoIoTCloudClass::connect()
 {
+  debugMessage("Connecting to " + _brokerAddress.c_str() + ":8883", 3);
   // Username: device id
   // Password: empty
   if (!_mqttClient->connect(_brokerAddress.c_str(), 8883)) {


### PR DESCRIPTION
One of possible reasons for not being able to connect to the IoT Cloud could be trying to connect to the wrong broker address.

This is particularly true in testing environments.

Adding a low priority debug message showing the broker connection string just before connecting can help debug this kind of issues.