### PR TITLE
print troubleshooting info, added broker port, general cleanup

### DIFF
--- a/examples/ArduinoIoTCloud_LED_switch/ArduinoIoTCloud_LED_switch.ino
+++ b/examples/ArduinoIoTCloud_LED_switch/ArduinoIoTCloud_LED_switch.ino
@@ -34,7 +34,7 @@ void setup() {
       
       setDebugMessageLevel(3);
   */
-
+  ArduinoCloud.printDebugInfo();
 }
 
 void loop() {
@@ -51,5 +51,5 @@ void loop() {
 void onLedChange() {
   Serial.print("LED set to ");
   Serial.println(led);
-  digitalWrite(LED_BUILTIN, ledSwitch);
+  digitalWrite(LED_BUILTIN, led);
 }

--- a/src/ArduinoIoTCloud.cpp
+++ b/src/ArduinoIoTCloud.cpp
@@ -53,32 +53,37 @@ ArduinoIoTCloudClass::~ArduinoIoTCloudClass()
   }
 }
 
-int ArduinoIoTCloudClass::begin(ConnectionManager *c, String brokerAddress)
+int ArduinoIoTCloudClass::begin(ConnectionManager *c, String brokerAddress, uint16_t brokerPort)
 {
   connection = c;
   Client &connectionClient = c->getClient();
   _brokerAddress = brokerAddress;
-  return begin(connectionClient, _brokerAddress);
+  _brokerPort = brokerPort;
+  return begin(connectionClient, _brokerAddress, _brokerPort);
 }
 
-int ArduinoIoTCloudClass::begin(Client& net, String brokerAddress)
+int ArduinoIoTCloudClass::begin(Client& net, String brokerAddress, uint16_t brokerPort)
 {
 
   _net = &net;
   // store the broker address as class member
   _brokerAddress = brokerAddress;
+  _brokerPort = brokerPort;
   byte thingIdBytes[72];
 
   if (!ECCX08.begin()) {
+    debugMessage("Cryptography processor failure. Make sure you have a compatible board.", 0);
     return 0;
   }
 
   if (!ECCX08.readSlot(thingIdSlot, thingIdBytes, sizeof(thingIdBytes))) {
+    debugMessage("Cryptography processor read failure.", 0);
     return 0;
   }
   _id = (char*)thingIdBytes;
 
   if (!ECCX08Cert.beginReconstruction(keySlot, compressedCertSlot, serialNumberAndAuthorityKeyIdentifierSlot)) {
+    debugMessage("Cryptography certificate reconstruction failure.", 0);
     return 0;
   }
 
@@ -89,6 +94,7 @@ int ArduinoIoTCloudClass::begin(Client& net, String brokerAddress)
   ECCX08Cert.setIssuerCommonName("Arduino");
 
   if (!ECCX08Cert.endReconstruction()) {
+    debugMessage("Cryptography certificate reconstruction failure.", 0);
     return 0;
   }
 
@@ -117,7 +123,6 @@ int ArduinoIoTCloudClass::begin(Client& net, String brokerAddress)
   mqttClientBegin();
 
   Thing.begin();
-
   return 1;
 }
 
@@ -152,7 +157,7 @@ int ArduinoIoTCloudClass::connect()
 {
   // Username: device id
   // Password: empty
-  if (!_mqttClient->connect(_brokerAddress.c_str(), 8883)) {
+  if (!_mqttClient->connect(_brokerAddress.c_str(), _brokerPort)) {
     return 0;
   }
   _mqttClient->subscribe(_stdinTopic);
@@ -298,15 +303,14 @@ void ArduinoIoTCloudClass::handleMessage(int length)
   }
 }
 
-void ArduinoIoTCloudClass::connectionCheck() {
+void ArduinoIoTCloudClass::connectionCheck()
+{
   if(connection != NULL){
     connection->check();
     
     if (connection->getStatus() != CONNECTION_STATE_CONNECTED) {
       if(iotStatus == IOT_STATUS_CLOUD_CONNECTED){
         setIoTConnectionState(IOT_STATUS_CLOUD_DISCONNECTED);
-      }else{
-        //setIoTConnectionState(IOT_STATUS_CLOUD_CONNECTING);
       }
       return;
     }
@@ -320,9 +324,9 @@ void ArduinoIoTCloudClass::connectionCheck() {
     {
       int connectionAttempt;
       if(connection == NULL){
-        connectionAttempt = begin(*_net, _brokerAddress);
+        connectionAttempt = begin(*_net, _brokerAddress, _brokerPort);
       }else{
-        connectionAttempt = begin(connection, _brokerAddress);
+        connectionAttempt = begin(connection, _brokerAddress, _brokerPort);
       }
       if(!connectionAttempt){
         debugMessage("Error Starting Arduino Cloud\nTrying again in a few seconds", 0);
@@ -331,8 +335,7 @@ void ArduinoIoTCloudClass::connectionCheck() {
       }
       setIoTConnectionState(IOT_STATUS_CLOUD_CONNECTING);
       break;
-    } 
-      
+    }
     case IOT_STATUS_CLOUD_ERROR:
       debugMessage("Cloud Error. Retrying...", 0);
       setIoTConnectionState(IOT_STATUS_CLOUD_RECONNECTING);
@@ -346,7 +349,6 @@ void ArduinoIoTCloudClass::connectionCheck() {
     case IOT_STATUS_CLOUD_RECONNECTING:
       int arduinoIoTReconnectionAttempt;
       arduinoIoTReconnectionAttempt = reconnect(*_net);
-      *msgBuffer = 0;
       sprintf(msgBuffer, "ArduinoCloud.reconnect(): %d", arduinoIoTReconnectionAttempt);
       debugMessage(msgBuffer, 2);
       if (arduinoIoTReconnectionAttempt == 1) {
@@ -356,10 +358,8 @@ void ArduinoIoTCloudClass::connectionCheck() {
       }
       break;
     case IOT_STATUS_CLOUD_CONNECTING:
-      
       int arduinoIoTConnectionAttempt;
       arduinoIoTConnectionAttempt = connect();
-      *msgBuffer = 0;
       sprintf(msgBuffer, "ArduinoCloud.connect(): %d", arduinoIoTConnectionAttempt);
       debugMessage(msgBuffer, 4);
       if (arduinoIoTConnectionAttempt == 1) {
@@ -371,7 +371,8 @@ void ArduinoIoTCloudClass::connectionCheck() {
   }
 }
 
-void ArduinoIoTCloudClass::setIoTConnectionState(ArduinoIoTConnectionStatus _newState){
+void ArduinoIoTCloudClass::setIoTConnectionState(ArduinoIoTConnectionStatus _newState)
+{
   switch(_newState){
     case IOT_STATUS_CLOUD_ERROR:
       debugMessage("Arduino, we have a problem.", 0);
@@ -390,6 +391,18 @@ void ArduinoIoTCloudClass::setIoTConnectionState(ArduinoIoTConnectionStatus _new
       break;
   }
   iotStatus = _newState;
+}
+
+void ArduinoIoTCloudClass::printDebugInfo()
+{
+  char msgBuffer[120];
+  debugMessage("***** Arduino IoT Cloud - configuration info *****", 2);
+  sprintf(msgBuffer, "Device ID: %s", getDeviceId().c_str());
+  debugMessage(msgBuffer, 2);
+  sprintf(msgBuffer, "Thing ID: %s", getThingId().c_str());
+  debugMessage(msgBuffer, 2);
+  sprintf(msgBuffer, "MQTT Broker: %s:%d", _brokerAddress.c_str(), _brokerPort);
+  debugMessage(msgBuffer, 2);
 }
 
 ArduinoIoTCloudClass ArduinoCloud;

--- a/src/ArduinoIoTCloud.h
+++ b/src/ArduinoIoTCloud.h
@@ -25,6 +25,8 @@
 
 #include "CloudSerial.h"
 
+#define DEFAULT_BROKER_ADDRESS "mqtts-sa.iot.arduino.cc"
+#define DEFAULT_BROKER_PORT 8883
 typedef enum {
   READ      = 0x01,
   WRITE     = 0x02,
@@ -57,8 +59,8 @@ public:
   ArduinoIoTCloudClass();
   ~ArduinoIoTCloudClass();
 
-  int begin(ConnectionManager *connection = ArduinoIoTPreferredConnection, String brokerAddress = "mqtts-sa.iot.arduino.cc");
-  int begin(Client& net, String brokerAddress = "mqtts-sa.iot.arduino.cc");
+  int begin(ConnectionManager *connection = ArduinoIoTPreferredConnection, String brokerAddress = DEFAULT_BROKER_ADDRESS, uint16_t brokerPort = DEFAULT_BROKER_PORT);
+  int begin(Client& net, String brokerAddress = DEFAULT_BROKER_ADDRESS, uint16_t brokerPort = DEFAULT_BROKER_PORT);
   // Class constant declaration
   static const int MQTT_TRANSMIT_BUFFER_SIZE = 256;
   static const int MAX_RETRIES = 5;
@@ -89,6 +91,8 @@ public:
 
   static unsigned long const DEFAULT_MIN_TIME_BETWEEN_UPDATES_MILLIS = 100; /* Data rate throttled to 10 Hz */
 
+
+
   template<typename T, typename N=T>
   void addPropertyReal(T & property, String name, permissionType permission_type = READWRITE, long seconds = ON_CHANGE, void(*fn)(void) = NULL, N minDelta = N(0)) {
     Permission permission = Permission::ReadWrite;
@@ -110,6 +114,9 @@ public:
   }
 
   void connectionCheck();
+  String getBrokerAddress(){ return _brokerAddress; }
+  uint16_t getBrokerPort() { return _brokerPort; }
+  void printDebugInfo();
 
 protected:
   friend class CloudSerialClass;
@@ -131,6 +138,7 @@ private:
   String _id,
          _thing_id,
          _brokerAddress;
+  uint16_t _brokerPort;
   ArduinoCloudThing Thing;
   BearSSLClient* _bearSslClient;
   MqttClient* _mqttClient;


### PR DESCRIPTION
ArduinoIoTCloudClass:
- defined DEFAULT_BROKER_PORT (see next)
- added brokerPort private member (uint16_t because of how it is defined in MQTT client)
- added possibility to pass an alternative Broker port after the address
- added getBrokerPort() method
- added printDebugInfo() method to ArduinoIoTCloud, to allow user to print out info useful for troubleshooting: Broker address:port, Thing ID, Device ID
WiFiConnectionManager:
- tweaked interval time for GETTIME
- added check for firmwareVersion() required version (delays 5 seconds if version is older than latest fixed ones, but still moves forward)
- cleaned up a couple of debugMessage formatted strings
Both:
removed *msgBuffer=0 from anywhere the buffer was filled with a new message