### PR TITLE
Managed exit cases for IOT_STATUS_CLOUD_CONNECTED, removed unused states

### DIFF
--- a/src/ArduinoIoTCloud.cpp
+++ b/src/ArduinoIoTCloud.cpp
@@ -310,7 +310,7 @@ void ArduinoIoTCloudClass::connectionCheck()
     
     if (connection->getStatus() != CONNECTION_STATE_CONNECTED) {
       if(iotStatus == IOT_STATUS_CLOUD_CONNECTED){
-        setIoTConnectionState(IOT_STATUS_CLOUD_DISCONNECTED);
+        setIoTConnectionState(IOT_STATUS_CLOUD_RECONNECTING);
       }
       return;
     }
@@ -320,7 +320,7 @@ void ArduinoIoTCloudClass::connectionCheck()
   
 
   switch (iotStatus) {
-    case IOT_STATUS_IDLE:
+    case IOT_STATUS_CLOUD_IDLE:
     {
       int connectionAttempt;
       if(connection == NULL){
@@ -342,9 +342,8 @@ void ArduinoIoTCloudClass::connectionCheck()
       break;
     case IOT_STATUS_CLOUD_CONNECTED:
       debugMessage(".", 4, false, true);
-      break;
-    case IOT_STATUS_CLOUD_DISCONNECTED:
-      setIoTConnectionState(IOT_STATUS_CLOUD_RECONNECTING);
+      if (!_mqttClient->connected())
+        setIoTConnectionState(IOT_STATUS_CLOUD_RECONNECTING);
       break;
     case IOT_STATUS_CLOUD_RECONNECTING:
       int arduinoIoTReconnectionAttempt;
@@ -385,9 +384,6 @@ void ArduinoIoTCloudClass::setIoTConnectionState(ArduinoIoTConnectionStatus _new
       break;
     case IOT_STATUS_CLOUD_CONNECTED:
       debugMessage("Connected to Arduino IoT Cloud", 0);
-      break;
-    case IOT_STATUS_CLOUD_DISCONNECTED:
-      debugMessage("Disconnected from Arduino IoT Cloud", 0);
       break;
   }
   iotStatus = _newState;

--- a/src/ArduinoIoTCloud.h
+++ b/src/ArduinoIoTCloud.h
@@ -43,14 +43,11 @@ typedef struct {
 extern ConnectionManager *ArduinoIoTPreferredConnection;
 
 enum ArduinoIoTConnectionStatus {
-  IOT_STATUS_IDLE,/* only at start */
   IOT_STATUS_CLOUD_IDLE,
   IOT_STATUS_CLOUD_CONNECTING,
   IOT_STATUS_CLOUD_CONNECTED,
-  IOT_STATUS_CLOUD_DISCONNECTED,
   IOT_STATUS_CLOUD_RECONNECTING,
-  IOT_STATUS_CLOUD_ERROR,
-  IOT_STATUS_ERROR_GENERIC
+  IOT_STATUS_CLOUD_ERROR
 };
 
 class ArduinoIoTCloudClass {
@@ -130,7 +127,7 @@ protected:
   ArduinoIoTConnectionStatus getIoTStatus() { return iotStatus; }
   void setIoTConnectionState(ArduinoIoTConnectionStatus _newState);
 private:
-  ArduinoIoTConnectionStatus iotStatus = IOT_STATUS_IDLE;
+  ArduinoIoTConnectionStatus iotStatus = IOT_STATUS_CLOUD_IDLE;
   ConnectionManager *connection;
   static void onMessage(int length);
   void handleMessage(int length);


### PR DESCRIPTION
It manages the case in which despite having the underlying network connection the board loses the connection to the mqtt broker. Without this change it would remain locked indefinitely into this state until restart.