### PR TITLE
10 Hz data rate are too much for the actual use cases, decrease to 2Hz

### DIFF
--- a/src/ArduinoIoTCloud.h
+++ b/src/ArduinoIoTCloud.h
@@ -87,7 +87,7 @@ public:
 
   #define addProperty( v, ...) addPropertyReal(v, #v, __VA_ARGS__)
 
-  static unsigned long const DEFAULT_MIN_TIME_BETWEEN_UPDATES_MILLIS = 100; /* Data rate throttled to 10 Hz */
+  static unsigned long const DEFAULT_MIN_TIME_BETWEEN_UPDATES_MILLIS = 500; /* Data rate throttled to 2 Hz */
 
 
 


### PR DESCRIPTION
10 Hz data rate is too much for the actual use cases and the users use this feature when is not necessary so it better decrease to 2Hz.

Next step will be make this parameter configurable so the pro users can be publish until 10Hz 