### PR TITLE
Optimized getTime management

### DIFF
--- a/src/ArduinoIoTCloud.cpp
+++ b/src/ArduinoIoTCloud.cpp
@@ -39,6 +39,9 @@ static unsigned long getTime() {
     debugMessage("Bogus NTP time from API, fallback to UDP method", 0);
     time = NTPUtils(getTimeConnection->getUDP()).getTime();
   }
+  #ifdef ARDUINO_ARCH_SAMD
+    rtc.setEpoch(time);
+  #endif
   return time;
 }
 
@@ -411,11 +414,6 @@ void ArduinoIoTCloudClass::connectionCheck()
         CloudSerial.begin(9600);
         CloudSerial.println("Hello from Cloud Serial!");
       }
-      #ifdef ARDUINO_ARCH_SAMD
-        unsigned long const epoch = getTime();
-        if (epoch!=0)
-          rtc.setEpoch(epoch);
-      #endif
       break;
   }
 }

--- a/src/GSMConnectionManager.cpp
+++ b/src/GSMConnectionManager.cpp
@@ -39,8 +39,7 @@ GSMConnectionManager::GSMConnectionManager(const char *pin, const char *apn, con
   login(login),
   pass(pass),
   lastConnectionTickTime(millis()),
-  connectionTickTimeInterval(CHECK_INTERVAL_IDLE),
-  getTimeRetries(MAX_GETTIME_RETRIES) {
+  connectionTickTimeInterval(CHECK_INTERVAL_IDLE) {
 }
 
 /******************************************************************************
@@ -96,24 +95,8 @@ void GSMConnectionManager::check() {
         } else {
           sprintf(msgBuffer, "Connected to GPRS Network");
           debugMessage(msgBuffer, 2);
-          changeConnectionState(CONNECTION_STATE_GETTIME);
-          return;
-        }
-        break;
-      case CONNECTION_STATE_GETTIME:
-        debugMessage("Acquiring Time from Network", 3);
-        unsigned long networkTime;
-        networkTime = getTime();
-        debugMessage(".", 3, false, false);
-        if(networkTime > lastValidTimestamp){
-          lastValidTimestamp = networkTime;
-          sprintf(msgBuffer, "Network Time: %u", networkTime);
-          debugMessage(msgBuffer, 3);
           changeConnectionState(CONNECTION_STATE_CONNECTED);
-        }else if(gsmAccess.isAccessAlive() != 1){
-          changeConnectionState(CONNECTION_STATE_DISCONNECTED);
-        }else if (!getTimeRetries--) {
-           changeConnectionState(CONNECTION_STATE_DISCONNECTED);
+          return;
         }
         break;
       case CONNECTION_STATE_CONNECTED:
@@ -152,11 +135,6 @@ void GSMConnectionManager::changeConnectionState(NetworkConnectionState _newStat
       debugMessage(msgBuffer, 2);
       newInterval = CHECK_INTERVAL_CONNECTING;
       break;
-    case CONNECTION_STATE_GETTIME:
-      debugMessage("Acquiring Time from Network", 3);
-      newInterval = CHECK_INTERVAL_GETTIME;
-      getTimeRetries = MAX_GETTIME_RETRIES;
-      break;
     case CONNECTION_STATE_CONNECTED:
       newInterval = CHECK_INTERVAL_CONNECTED;
       break;
@@ -164,8 +142,6 @@ void GSMConnectionManager::changeConnectionState(NetworkConnectionState _newStat
       if(netConnectionState == CONNECTION_STATE_CONNECTED){
         debugMessage("Disconnected from Cellular Network", 0);
         debugMessage("Attempting reconnection", 0);
-      }else if(netConnectionState == CONNECTION_STATE_GETTIME){
-        debugMessage("Connection to Cellular Network lost during Time acquisition.\nAttempting reconnection", 0);
       }
       newInterval = CHECK_INTERVAL_DISCONNECTED;
       break;

--- a/src/GSMConnectionManager.h
+++ b/src/GSMConnectionManager.h
@@ -52,17 +52,13 @@ private:
   const int CHECK_INTERVAL_IDLE = 100;
   const int CHECK_INTERVAL_INIT = 100;
   const int CHECK_INTERVAL_CONNECTING = 500;
-  const int CHECK_INTERVAL_GETTIME = 666;
   const int CHECK_INTERVAL_CONNECTED = 10000;
   const int CHECK_INTERVAL_RETRYING = 5000;
   const int CHECK_INTERVAL_DISCONNECTED = 1000;
   const int CHECK_INTERVAL_ERROR = 500;
 
-  const int MAX_GETTIME_RETRIES = 30;
-
   const char *pin, *apn, *login, *pass;
   unsigned long lastConnectionTickTime;
-  unsigned long getTimeRetries;
   int connectionTickTimeInterval;
 
 };

--- a/src/WiFiConnectionManager.cpp
+++ b/src/WiFiConnectionManager.cpp
@@ -37,8 +37,7 @@ WiFiConnectionManager::WiFiConnectionManager(const char *ssid, const char *pass)
   ssid(ssid),
   pass(pass),
   lastConnectionTickTime(millis()),
-  connectionTickTimeInterval(CHECK_INTERVAL_IDLE),
-  getTimeRetries(MAX_GETTIME_RETRIES) {
+  connectionTickTimeInterval(CHECK_INTERVAL_IDLE) {
 }
 
 /******************************************************************************
@@ -92,25 +91,9 @@ void WiFiConnectionManager::check() {
         } else {
           sprintf(msgBuffer, "Connected to \"%s\"", ssid);
           debugMessage(msgBuffer, 2);
-          changeConnectionState(CONNECTION_STATE_GETTIME);
+          changeConnectionState(CONNECTION_STATE_CONNECTED);
           return;
         }
-        break;
-      case CONNECTION_STATE_GETTIME:
-        unsigned long networkTime;
-        networkTime = getTime();
-        debugMessage(".", 3, false, false);
-        if(networkTime > lastValidTimestamp){
-          debugMessage("", 3, false, true);
-          lastValidTimestamp = networkTime;
-          sprintf(msgBuffer, "Network Time: %u", networkTime);
-          debugMessage(msgBuffer, 3);
-          changeConnectionState(CONNECTION_STATE_CONNECTED);
-        } else if (WiFi.status() != WL_CONNECTED) {
-           changeConnectionState(CONNECTION_STATE_DISCONNECTED);
-        } else if (!getTimeRetries--) {
-           changeConnectionState(CONNECTION_STATE_DISCONNECTED);
-        } 
         break;
       case CONNECTION_STATE_CONNECTED:
         // keep testing connection
@@ -148,11 +131,6 @@ void WiFiConnectionManager::changeConnectionState(NetworkConnectionState _newSta
       sprintf(msgBuffer, "Connecting to \"%s\"", ssid);
       debugMessage(msgBuffer, 2);
       newInterval = CHECK_INTERVAL_CONNECTING;
-      break;
-    case CONNECTION_STATE_GETTIME:
-      newInterval = CHECK_INTERVAL_GETTIME;
-      debugMessage("Acquiring Time from Network", 3);
-      getTimeRetries = MAX_GETTIME_RETRIES;
       break;
     case CONNECTION_STATE_CONNECTED:
       newInterval = CHECK_INTERVAL_CONNECTED;

--- a/src/WiFiConnectionManager.h
+++ b/src/WiFiConnectionManager.h
@@ -51,17 +51,13 @@ private:
   const int CHECK_INTERVAL_IDLE = 100;
   const int CHECK_INTERVAL_INIT = 100;
   const int CHECK_INTERVAL_CONNECTING = 500;
-  const int CHECK_INTERVAL_GETTIME = 666;
   const int CHECK_INTERVAL_CONNECTED = 10000;
   const int CHECK_INTERVAL_RETRYING = 5000;
   const int CHECK_INTERVAL_DISCONNECTED = 1000;
   const int CHECK_INTERVAL_ERROR = 500;
 
-  const int MAX_GETTIME_RETRIES = 30;
-
   const char *ssid, *pass;
   unsigned long lastConnectionTickTime;
-  unsigned long getTimeRetries;
 
   WiFiClient wifiClient;
   int connectionTickTimeInterval;

--- a/src/utility/NTPUtils.cpp
+++ b/src/utility/NTPUtils.cpp
@@ -29,7 +29,6 @@ static time_t cvt_TIME(char const *time) {
 NTPUtils::NTPUtils(UDP& Udp) : Udp(Udp) {}
 
 bool NTPUtils::isTimeValid(unsigned long time) {
-    Serial.println("Compile time: " + String(cvt_TIME(__DATE__)));
     return (time > cvt_TIME(__DATE__));
 }
 


### PR DESCRIPTION
Removed CONNECTION_STATE_GETTIME state in the connection manager classes. 
The status IOT_STATUS_CLOUD_CONNECTING and IOT_STATUS_CLOUD_RECONNECTING are able to loop until a valid time is returned. Furthermore, with the fallback to time.arduino.cc the need to retry has a very low probability.