### PR TITLE
[CM-474] Notify user if thing id is wrong / thing does not exist

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=ArduinoIoTCloud
-version=0.5.3
+version=0.5.4
 author=Arduino
 maintainer=Arduino <info@arduino.cc>
 sentence=This library allows to connect to the Arduino IoT Cloud service.


### PR DESCRIPTION
Device will stay in mode `IOT_STATUS_CLOUD_CONNECTING` and display an error message for the user to inform him about the probable cause of the error.
```
[ 1742 ] ***** Arduino IoT Cloud - configuration info *****
[ 1742 ] Device ID: * 
[ 1743 ] Thing ID: *
[ 1743 ] MQTT Broker: mqtts-sa.iot.arduino.cc:8883
[ 2287 ] WiFi.status(): 0
[ 2288 ] Current WiFi Firmware: 19.5.4
[ 2288 ] Connecting to "my-wifi"
[ 26835 ] Connected to "my-wifi"
[ 27505 ] Connecting to Arduino IoT Cloud...
ERROR - Please verify your THING ID
```