### PR TITLE
Fixing issue with sketches missing a Topic name (i.e.: Getting Started)

### DIFF
--- a/src/ArduinoIoTCloud.cpp
+++ b/src/ArduinoIoTCloud.cpp
@@ -191,13 +191,15 @@ int ArduinoIoTCloudClass::connect()
   if (!_mqttClient->connect(_brokerAddress.c_str(), _brokerPort)) {
     return CONNECT_FAILURE;
   }
+  if(_shadowTopicIn != "")
+  {
+    if(_mqttClient->subscribe(_stdinTopic   ) == 0) return CONNECT_FAILURE_SUBSCRIBE;
+    if(_mqttClient->subscribe(_dataTopicIn  ) == 0) return CONNECT_FAILURE_SUBSCRIBE;
+    if(_mqttClient->subscribe(_shadowTopicIn) == 0) return CONNECT_FAILURE_SUBSCRIBE;
 
-  if(_mqttClient->subscribe(_stdinTopic   ) == 0) return CONNECT_FAILURE_SUBSCRIBE;
-  if(_mqttClient->subscribe(_dataTopicIn  ) == 0) return CONNECT_FAILURE_SUBSCRIBE;
-  if(_mqttClient->subscribe(_shadowTopicIn) == 0) return CONNECT_FAILURE_SUBSCRIBE;
-
-  _syncStatus = ArduinoIoTSynchronizationStatus::SYNC_STATUS_WAIT_FOR_CLOUD_VALUES;
-  _lastSyncRequestTickTime = 0;
+    _syncStatus = ArduinoIoTSynchronizationStatus::SYNC_STATUS_WAIT_FOR_CLOUD_VALUES;
+    _lastSyncRequestTickTime = 0;
+  }
 
   return CONNECT_SUCCESS;
 }
@@ -236,7 +238,10 @@ void ArduinoIoTCloudClass::update(int const reconnectionMaxRetries, int const re
 
   switch (_syncStatus) {
     case ArduinoIoTSynchronizationStatus::SYNC_STATUS_SYNCHRONIZED:
-      sendPropertiesToCloud();
+      if(_shadowTopicIn != "")
+      {
+        sendPropertiesToCloud();
+      }
       break;
     case ArduinoIoTSynchronizationStatus::SYNC_STATUS_WAIT_FOR_CLOUD_VALUES:
       if (millis() - _lastSyncRequestTickTime > TIMEOUT_FOR_LASTVALUES_SYNC) {

--- a/src/ArduinoIoTCloud.cpp
+++ b/src/ArduinoIoTCloud.cpp
@@ -169,6 +169,8 @@ void ArduinoIoTCloudClass::mqttClientBegin()
   if(_thing_id == "") {
     _dataTopicIn  = "/a/d/" + _device_id + "/e/i";
     _dataTopicOut = "/a/d/" + _device_id + "/e/o";
+    _shadowTopicIn  = "";
+    _shadowTopicOut = "";
   }
   else {
     _dataTopicIn  = "/a/t/" + _thing_id + "/e/i";
@@ -238,10 +240,7 @@ void ArduinoIoTCloudClass::update(int const reconnectionMaxRetries, int const re
 
   switch (_syncStatus) {
     case ArduinoIoTSynchronizationStatus::SYNC_STATUS_SYNCHRONIZED:
-      if(_shadowTopicIn != "")
-      {
-        sendPropertiesToCloud();
-      }
+      sendPropertiesToCloud();
       break;
     case ArduinoIoTSynchronizationStatus::SYNC_STATUS_WAIT_FOR_CLOUD_VALUES:
       if (millis() - _lastSyncRequestTickTime > TIMEOUT_FOR_LASTVALUES_SYNC) {

--- a/src/ArduinoIoTCloud.cpp
+++ b/src/ArduinoIoTCloud.cpp
@@ -191,10 +191,10 @@ int ArduinoIoTCloudClass::connect()
   if (!_mqttClient->connect(_brokerAddress.c_str(), _brokerPort)) {
     return CONNECT_FAILURE;
   }
+  if(_mqttClient->subscribe(_stdinTopic   ) == 0) return CONNECT_FAILURE_SUBSCRIBE;
+  if(_mqttClient->subscribe(_dataTopicIn  ) == 0) return CONNECT_FAILURE_SUBSCRIBE;
   if(_shadowTopicIn != "")
   {
-    if(_mqttClient->subscribe(_stdinTopic   ) == 0) return CONNECT_FAILURE_SUBSCRIBE;
-    if(_mqttClient->subscribe(_dataTopicIn  ) == 0) return CONNECT_FAILURE_SUBSCRIBE;
     if(_mqttClient->subscribe(_shadowTopicIn) == 0) return CONNECT_FAILURE_SUBSCRIBE;
 
     _syncStatus = ArduinoIoTSynchronizationStatus::SYNC_STATUS_WAIT_FOR_CLOUD_VALUES;

--- a/src/ArduinoIoTCloud.cpp
+++ b/src/ArduinoIoTCloud.cpp
@@ -63,6 +63,13 @@ ArduinoIoTCloudClass::ArduinoIoTCloudClass() :
   _bearSslClient(NULL),
   _mqttClient   (NULL),
   connection    (NULL),
+  _stdinTopic     (""),
+  _stdoutTopic    (""),
+  _shadowTopicOut (""),
+  _shadowTopicIn  (""),
+  _dataTopicOut   (""),
+  _dataTopicIn    (""),
+  _otaTopic       (""),
   _lastSyncRequestTickTime(0)
 {
 }
@@ -169,8 +176,6 @@ void ArduinoIoTCloudClass::mqttClientBegin()
   if(_thing_id == "") {
     _dataTopicIn  = "/a/d/" + _device_id + "/e/i";
     _dataTopicOut = "/a/d/" + _device_id + "/e/o";
-    _shadowTopicIn  = "";
-    _shadowTopicOut = "";
   }
   else {
     _dataTopicIn  = "/a/t/" + _thing_id + "/e/i";

--- a/src/ArduinoIoTCloud.cpp
+++ b/src/ArduinoIoTCloud.cpp
@@ -195,8 +195,7 @@ int ArduinoIoTCloudClass::connect()
   }
   if(_mqttClient->subscribe(_stdinTopic   ) == 0) return CONNECT_FAILURE_SUBSCRIBE;
   if(_mqttClient->subscribe(_dataTopicIn  ) == 0) return CONNECT_FAILURE_SUBSCRIBE;
-  if(_shadowTopicIn != "")
-  {
+  if(_shadowTopicIn != "") {
     if(_mqttClient->subscribe(_shadowTopicIn) == 0) return CONNECT_FAILURE_SUBSCRIBE;
 
     _syncStatus = ArduinoIoTSynchronizationStatus::SYNC_STATUS_WAIT_FOR_CLOUD_VALUES;


### PR DESCRIPTION
- handling empty `_shadowTopicIn`
- preventing `_syncStatus` from being set to value other than `SYNC_STATUS_SYNCHRONIZED` when empty shadow topic