### PR TITLE
Refactoring - Converting all enum's to enum classes + braces for all switch-case statements

### DIFF
--- a/src/ArduinoIoTCloud.cpp
+++ b/src/ArduinoIoTCloud.cpp
@@ -378,7 +378,7 @@ void ArduinoIoTCloudClass::connectionCheck()
   if(connection != NULL){
     connection->check();
     
-    if (connection->getStatus() != ArduinoIoTConnectionStatus::CONNECTED) {
+    if (connection->getStatus() != NetworkConnectionState::CONNECTED) {
       if(iotStatus == ArduinoIoTConnectionStatus::CONNECTED){
         setIoTConnectionState(ArduinoIoTConnectionStatus::DISCONNECTED);
       }

--- a/src/ArduinoIoTCloud.cpp
+++ b/src/ArduinoIoTCloud.cpp
@@ -387,22 +387,26 @@ void ArduinoIoTCloudClass::connectionCheck()
   }
   
   switch (iotStatus) {
-    case IOT_STATUS_CLOUD_IDLE:
+    case IOT_STATUS_CLOUD_IDLE: {
       setIoTConnectionState(IOT_STATUS_CLOUD_CONNECTING);
-      break;
-    case IOT_STATUS_CLOUD_ERROR:
+    }
+    break;
+    case IOT_STATUS_CLOUD_ERROR: {
       debugMessage(DebugLevel::Error, "Cloud Error. Retrying...");
       setIoTConnectionState(IOT_STATUS_CLOUD_RECONNECTING);
-      break;
-    case IOT_STATUS_CLOUD_CONNECTED:
+    }
+    break;
+    case IOT_STATUS_CLOUD_CONNECTED: {
       debugMessageNoTimestamp(DebugLevel::Verbose, ".");
       if (!_mqttClient->connected()){
         setIoTConnectionState(IOT_STATUS_CLOUD_DISCONNECTED);
       }
-      break;
-    case IOT_STATUS_CLOUD_DISCONNECTED:
+    }
+    break;
+    case IOT_STATUS_CLOUD_DISCONNECTED: {
       setIoTConnectionState(IOT_STATUS_CLOUD_RECONNECTING);
-      break;
+    }
+    break;
     case IOT_STATUS_CLOUD_RECONNECTING: {
       int const ret_code_reconnect = reconnect(*_net);
       debugMessage(DebugLevel::Info, "ArduinoCloud.reconnect(): %d", ret_code_reconnect);
@@ -412,8 +416,8 @@ void ArduinoIoTCloudClass::connectionCheck()
         CloudSerial.println("Hello from Cloud Serial!");
       }
     }
-      break;
-    case IOT_STATUS_CLOUD_CONNECTING:
+    break;
+    case IOT_STATUS_CLOUD_CONNECTING: {
       int const ret_code_connect = connect();
       debugMessage(DebugLevel::Verbose, "ArduinoCloud.connect(): %d", ret_code_connect);
       if (ret_code_connect == CONNECT_SUCCESS) {
@@ -424,28 +428,19 @@ void ArduinoIoTCloudClass::connectionCheck()
       else if (ret_code_connect == CONNECT_FAILURE_SUBSCRIBE) {
         debugMessage(DebugLevel::Info, "ERROR - Please verify your THING ID");
       }
-      break;
+    }
+    break;
   }
 }
 
 void ArduinoIoTCloudClass::setIoTConnectionState(ArduinoIoTConnectionStatus _newState)
 {
   switch(_newState){
-    case IOT_STATUS_CLOUD_ERROR:
-      debugMessage(DebugLevel::Error, "Arduino, we have a problem.");
-      break;
-    case IOT_STATUS_CLOUD_CONNECTING:
-      debugMessage(DebugLevel::Error, "Connecting to Arduino IoT Cloud...");
-      break;
-    case IOT_STATUS_CLOUD_RECONNECTING:
-      debugMessage(DebugLevel::Error, "Reconnecting to Arduino IoT Cloud...");
-      break;
-    case IOT_STATUS_CLOUD_CONNECTED:
-      debugMessage(DebugLevel::Error, "Connected to Arduino IoT Cloud");
-      break;
-    case IOT_STATUS_CLOUD_DISCONNECTED:
-      debugMessage(DebugLevel::Error, "Disconnected from Arduino IoT Cloud");
-      break;
+    case IOT_STATUS_CLOUD_ERROR:        debugMessage(DebugLevel::Error, "Arduino, we have a problem.");          break;
+    case IOT_STATUS_CLOUD_CONNECTING:   debugMessage(DebugLevel::Error, "Connecting to Arduino IoT Cloud...");   break;
+    case IOT_STATUS_CLOUD_RECONNECTING: debugMessage(DebugLevel::Error, "Reconnecting to Arduino IoT Cloud..."); break;
+    case IOT_STATUS_CLOUD_CONNECTED:    debugMessage(DebugLevel::Error, "Connected to Arduino IoT Cloud");       break;
+    case IOT_STATUS_CLOUD_DISCONNECTED: debugMessage(DebugLevel::Error, "Disconnected from Arduino IoT Cloud");  break;
   }
   iotStatus = _newState;
 }

--- a/src/ArduinoIoTCloud.cpp
+++ b/src/ArduinoIoTCloud.cpp
@@ -235,7 +235,7 @@ void ArduinoIoTCloudClass::update(int const reconnectionMaxRetries, int const re
   if(timestamp != 0) Thing.updateTimestampOnChangedProperties(timestamp);
     
   connectionCheck();
-  if(iotStatus != IOT_STATUS_CLOUD_CONNECTED){
+  if(iotStatus != ArduinoIoTConnectionStatus::CONNECTED){
     return;
   }
 
@@ -378,50 +378,50 @@ void ArduinoIoTCloudClass::connectionCheck()
   if(connection != NULL){
     connection->check();
     
-    if (connection->getStatus() != CONNECTION_STATE_CONNECTED) {
-      if(iotStatus == IOT_STATUS_CLOUD_CONNECTED){
-        setIoTConnectionState(IOT_STATUS_CLOUD_DISCONNECTED);
+    if (connection->getStatus() != ArduinoIoTConnectionStatus::CONNECTED) {
+      if(iotStatus == ArduinoIoTConnectionStatus::CONNECTED){
+        setIoTConnectionState(ArduinoIoTConnectionStatus::DISCONNECTED);
       }
       return;
     }
   }
   
   switch (iotStatus) {
-    case IOT_STATUS_CLOUD_IDLE: {
-      setIoTConnectionState(IOT_STATUS_CLOUD_CONNECTING);
+    case ArduinoIoTConnectionStatus::IDLE: {
+      setIoTConnectionState(ArduinoIoTConnectionStatus::CONNECTING);
     }
     break;
-    case IOT_STATUS_CLOUD_ERROR: {
+    case ArduinoIoTConnectionStatus::ERROR: {
       debugMessage(DebugLevel::Error, "Cloud Error. Retrying...");
-      setIoTConnectionState(IOT_STATUS_CLOUD_RECONNECTING);
+      setIoTConnectionState(ArduinoIoTConnectionStatus::RECONNECTING);
     }
     break;
-    case IOT_STATUS_CLOUD_CONNECTED: {
+    case ArduinoIoTConnectionStatus::CONNECTED: {
       debugMessageNoTimestamp(DebugLevel::Verbose, ".");
       if (!_mqttClient->connected()){
-        setIoTConnectionState(IOT_STATUS_CLOUD_DISCONNECTED);
+        setIoTConnectionState(ArduinoIoTConnectionStatus::DISCONNECTED);
       }
     }
     break;
-    case IOT_STATUS_CLOUD_DISCONNECTED: {
-      setIoTConnectionState(IOT_STATUS_CLOUD_RECONNECTING);
+    case ArduinoIoTConnectionStatus::DISCONNECTED: {
+      setIoTConnectionState(ArduinoIoTConnectionStatus::RECONNECTING);
     }
     break;
-    case IOT_STATUS_CLOUD_RECONNECTING: {
+    case ArduinoIoTConnectionStatus::RECONNECTING: {
       int const ret_code_reconnect = reconnect(*_net);
       debugMessage(DebugLevel::Info, "ArduinoCloud.reconnect(): %d", ret_code_reconnect);
       if (ret_code_reconnect == CONNECT_SUCCESS) {
-        setIoTConnectionState(IOT_STATUS_CLOUD_CONNECTED);
+        setIoTConnectionState(ArduinoIoTConnectionStatus::CONNECTED);
         CloudSerial.begin(9600);
         CloudSerial.println("Hello from Cloud Serial!");
       }
     }
     break;
-    case IOT_STATUS_CLOUD_CONNECTING: {
+    case ArduinoIoTConnectionStatus::CONNECTING: {
       int const ret_code_connect = connect();
       debugMessage(DebugLevel::Verbose, "ArduinoCloud.connect(): %d", ret_code_connect);
       if (ret_code_connect == CONNECT_SUCCESS) {
-        setIoTConnectionState(IOT_STATUS_CLOUD_CONNECTED);
+        setIoTConnectionState(ArduinoIoTConnectionStatus::CONNECTED);
         CloudSerial.begin(9600);
         CloudSerial.println("Hello from Cloud Serial!");
       }
@@ -436,11 +436,11 @@ void ArduinoIoTCloudClass::connectionCheck()
 void ArduinoIoTCloudClass::setIoTConnectionState(ArduinoIoTConnectionStatus _newState)
 {
   switch(_newState){
-    case IOT_STATUS_CLOUD_ERROR:        debugMessage(DebugLevel::Error, "Arduino, we have a problem.");          break;
-    case IOT_STATUS_CLOUD_CONNECTING:   debugMessage(DebugLevel::Error, "Connecting to Arduino IoT Cloud...");   break;
-    case IOT_STATUS_CLOUD_RECONNECTING: debugMessage(DebugLevel::Error, "Reconnecting to Arduino IoT Cloud..."); break;
-    case IOT_STATUS_CLOUD_CONNECTED:    debugMessage(DebugLevel::Error, "Connected to Arduino IoT Cloud");       break;
-    case IOT_STATUS_CLOUD_DISCONNECTED: debugMessage(DebugLevel::Error, "Disconnected from Arduino IoT Cloud");  break;
+    case ArduinoIoTConnectionStatus::ERROR:        debugMessage(DebugLevel::Error, "Arduino, we have a problem.");          break;
+    case ArduinoIoTConnectionStatus::CONNECTING:   debugMessage(DebugLevel::Error, "Connecting to Arduino IoT Cloud...");   break;
+    case ArduinoIoTConnectionStatus::RECONNECTING: debugMessage(DebugLevel::Error, "Reconnecting to Arduino IoT Cloud..."); break;
+    case ArduinoIoTConnectionStatus::CONNECTED:    debugMessage(DebugLevel::Error, "Connected to Arduino IoT Cloud");       break;
+    case ArduinoIoTConnectionStatus::DISCONNECTED: debugMessage(DebugLevel::Error, "Disconnected from Arduino IoT Cloud");  break;
   }
   iotStatus = _newState;
 }

--- a/src/ArduinoIoTCloud.h
+++ b/src/ArduinoIoTCloud.h
@@ -44,13 +44,13 @@ typedef void (*CallbackFunc)(void);
 
 extern ConnectionManager *ArduinoIoTPreferredConnection;
 
-enum ArduinoIoTConnectionStatus {
-  IOT_STATUS_CLOUD_IDLE,
-  IOT_STATUS_CLOUD_CONNECTING,
-  IOT_STATUS_CLOUD_CONNECTED,
-  IOT_STATUS_CLOUD_DISCONNECTED,
-  IOT_STATUS_CLOUD_RECONNECTING,
-  IOT_STATUS_CLOUD_ERROR,
+enum class ArduinoIoTConnectionStatus {
+  IDLE,
+  CONNECTING,
+  CONNECTED,
+  DISCONNECTED,
+  RECONNECTING,
+  ERROR,
 };
 
 enum class ArduinoIoTSynchronizationStatus {
@@ -139,7 +139,7 @@ protected:
   ArduinoIoTConnectionStatus getIoTStatus() { return iotStatus; }
   void setIoTConnectionState(ArduinoIoTConnectionStatus _newState);
 private:
-  ArduinoIoTConnectionStatus iotStatus = IOT_STATUS_CLOUD_IDLE;
+  ArduinoIoTConnectionStatus iotStatus = ArduinoIoTConnectionStatus::IDLE;
   ConnectionManager *connection;
   static void onMessage(int length);
   void handleMessage(int length);

--- a/src/ConnectionManager.h
+++ b/src/ConnectionManager.h
@@ -32,14 +32,14 @@
  * TYPEDEFS
  ******************************************************************************/
 
-enum NetworkConnectionState {
-  CONNECTION_STATE_INIT,
-  CONNECTION_STATE_CONNECTING,
-  CONNECTION_STATE_CONNECTED,
-  CONNECTION_STATE_GETTIME,
-  CONNECTION_STATE_DISCONNECTING,
-  CONNECTION_STATE_DISCONNECTED,
-  CONNECTION_STATE_ERROR
+enum class NetworkConnectionState {
+  INIT,
+  CONNECTING,
+  CONNECTED,
+  GETTIME,
+  DISCONNECTING,
+  DISCONNECTED,
+  ERROR
 };
 
 /******************************************************************************
@@ -58,7 +58,7 @@ public:
 
 protected:
   unsigned long lastValidTimestamp = 0;
-  NetworkConnectionState netConnectionState = CONNECTION_STATE_INIT;
+  NetworkConnectionState netConnectionState = NetworkConnectionState::INIT;
 
 };
 

--- a/src/EthernetConnectionManager.cpp
+++ b/src/EthernetConnectionManager.cpp
@@ -57,7 +57,7 @@ void EthConnectionManager::check() {
   int networkStatus = 0;
   if (now - lastConnectionTickTime > connectionTickTimeInterval) {
     switch (netConnectionState) {
-      case CONNECTION_STATE_INIT:
+      case CONNECTION_STATE_INIT: {
         if (ss_pin == -1) {
           networkStatus = Ethernet.begin(mac);
         } else {
@@ -83,8 +83,9 @@ void EthConnectionManager::check() {
         }
         debugMessage(DebugLevel::Error, "Ethernet shield recognized: ID", Ethernet.hardwareStatus());
         changeConnectionState(CONNECTION_STATE_CONNECTING);
-        break;
-      case CONNECTION_STATE_CONNECTING:
+      }
+      break;
+      case CONNECTION_STATE_CONNECTING: {
         debugMessage(DebugLevel::Info, "Connecting via dhcp");
         if (ss_pin == -1) {
           networkStatus = Ethernet.begin(mac);
@@ -102,8 +103,9 @@ void EthConnectionManager::check() {
           changeConnectionState(CONNECTION_STATE_GETTIME);
           return;
         }
-        break;
-      case CONNECTION_STATE_GETTIME:
+      }
+      break;
+      case CONNECTION_STATE_GETTIME: {
         debugMessage(DebugLevel::Debug, "Acquiring Time from Network");
         unsigned long networkTime;
         networkTime = getTime();
@@ -112,8 +114,9 @@ void EthConnectionManager::check() {
           lastValidTimestamp = networkTime;
           changeConnectionState(CONNECTION_STATE_CONNECTED);
         }
-        break;
-      case CONNECTION_STATE_CONNECTED:
+      }
+      break;
+      case CONNECTION_STATE_CONNECTED: {
         // keep testing connection
         Ethernet.maintain();
         networkStatus = Ethernet.linkStatus();
@@ -123,13 +126,15 @@ void EthConnectionManager::check() {
           return;
         }
         debugMessage(DebugLevel::Info, "Connected");
-        break;
-      case CONNECTION_STATE_DISCONNECTED:
+      }
+      break;
+      case CONNECTION_STATE_DISCONNECTED: {
         debugMessage(DebugLevel::Error, "Connection lost.");
         debugMessage(DebugLevel::Info, "Attempting reconnection");
         changeConnectionState(CONNECTION_STATE_CONNECTING);
-        //wifiClient.stop();
-        break;
+      //wifiClient.stop();
+      }
+      break;
     }
     lastConnectionTickTime = now;
   }
@@ -143,22 +148,11 @@ void EthConnectionManager::changeConnectionState(NetworkConnectionState _newStat
   netConnectionState = _newState;
   int newInterval = CHECK_INTERVAL_IDLE;
   switch (_newState) {
-    case CONNECTION_STATE_INIT:
-      newInterval = CHECK_INTERVAL_INIT;
-      break;
-    case CONNECTION_STATE_CONNECTING:
-      newInterval = CHECK_INTERVAL_CONNECTING;
-      break;
-    case CONNECTION_STATE_GETTIME:
-      newInterval = CHECK_INTERVAL_GETTIME;
-      break;
-    case CONNECTION_STATE_CONNECTED:
-      newInterval = CHECK_INTERVAL_CONNECTED;
-      break;
-    case CONNECTION_STATE_DISCONNECTED:
-      newInterval = CHECK_INTERVAL_DISCONNECTED;
-
-      break;
+    case CONNECTION_STATE_INIT:         newInterval = CHECK_INTERVAL_INIT;         break;
+    case CONNECTION_STATE_CONNECTING:   newInterval = CHECK_INTERVAL_CONNECTING;   break;
+    case CONNECTION_STATE_GETTIME:      newInterval = CHECK_INTERVAL_GETTIME;      break;
+    case CONNECTION_STATE_CONNECTED:    newInterval = CHECK_INTERVAL_CONNECTED;    break;
+    case CONNECTION_STATE_DISCONNECTED: newInterval = CHECK_INTERVAL_DISCONNECTED; break;
   }
   connectionTickTimeInterval = newInterval;
   lastConnectionTickTime = millis();

--- a/src/GSMConnectionManager.cpp
+++ b/src/GSMConnectionManager.cpp
@@ -67,10 +67,11 @@ void GSMConnectionManager::check() {
   int gsmAccessAlive;
   if (now - lastConnectionTickTime > connectionTickTimeInterval) {
     switch (netConnectionState) {
-      case CONNECTION_STATE_INIT:
+      case CONNECTION_STATE_INIT: {
         init();
-        break;
-      case CONNECTION_STATE_CONNECTING:
+      }
+      break;
+      case CONNECTION_STATE_CONNECTING: {
         // NOTE: Blocking Call when 4th parameter == true
         GSM3_NetworkStatus_t networkStatus;
         networkStatus = gprs.attachGPRS(apn, login, pass, true);
@@ -93,8 +94,9 @@ void GSMConnectionManager::check() {
           changeConnectionState(CONNECTION_STATE_CONNECTED);
           return;
         }
-        break;
-      case CONNECTION_STATE_CONNECTED:
+      }
+      break;
+      case CONNECTION_STATE_CONNECTED: {
         gsmAccessAlive = gsmAccess.isAccessAlive();
         debugMessage(DebugLevel::Verbose, "GPRS.isAccessAlive(): %d", gsmAccessAlive);
         if (gsmAccessAlive != 1) {
@@ -102,11 +104,13 @@ void GSMConnectionManager::check() {
           return;
         }
         debugMessage(DebugLevel::Verbose, "Connected to Cellular Network");
-        break;
-      case CONNECTION_STATE_DISCONNECTED:
+      }
+      break;
+      case CONNECTION_STATE_DISCONNECTED: {
         gprs.detachGPRS();
         changeConnectionState(CONNECTION_STATE_CONNECTING);
-        break;
+      }
+      break;
     }
     lastConnectionTickTime = now;
   }
@@ -117,29 +121,33 @@ void GSMConnectionManager::check() {
  ******************************************************************************/
 
 void GSMConnectionManager::changeConnectionState(NetworkConnectionState _newState) {
-  char msgBuffer[120];
   int newInterval = CHECK_INTERVAL_IDLE;
   switch (_newState) {
-    case CONNECTION_STATE_INIT:
+    case CONNECTION_STATE_INIT: {
       newInterval = CHECK_INTERVAL_INIT;
-      break;
-    case CONNECTION_STATE_CONNECTING:
+    }
+    break;
+    case CONNECTION_STATE_CONNECTING: {
       debugMessage(DebugLevel::Info, "Connecting to Cellular Network");
       newInterval = CHECK_INTERVAL_CONNECTING;
-      break;
-    case CONNECTION_STATE_CONNECTED:
+    }
+    break;
+    case CONNECTION_STATE_CONNECTED: {
       newInterval = CHECK_INTERVAL_CONNECTED;
-      break;
-    case CONNECTION_STATE_DISCONNECTED:
+    }
+    break;
+    case CONNECTION_STATE_DISCONNECTED: {
       if(netConnectionState == CONNECTION_STATE_CONNECTED){
         debugMessage(DebugLevel::Error, "Disconnected from Cellular Network");
         debugMessage(DebugLevel::Error, "Attempting reconnection");
       }
       newInterval = CHECK_INTERVAL_DISCONNECTED;
-      break;
-    case CONNECTION_STATE_ERROR:
+    }
+    break;
+    case CONNECTION_STATE_ERROR: {
       debugMessage(DebugLevel::Error, "GPRS attach failed\n\rMake sure the antenna is connected and reset your board.");
-      break;
+    }
+    break;
   }
   connectionTickTimeInterval = newInterval;
   lastConnectionTickTime = millis();

--- a/src/WiFiConnectionManager.cpp
+++ b/src/WiFiConnectionManager.cpp
@@ -56,7 +56,7 @@ void WiFiConnectionManager::check() {
   int networkStatus = 0;
   if (now - lastConnectionTickTime > connectionTickTimeInterval) {
     switch (netConnectionState) {
-      case CONNECTION_STATE_INIT:
+      case CONNECTION_STATE_INIT: {
         networkStatus = WiFi.status();
         debugMessage(DebugLevel::Info, "WiFi.status(): %d", networkStatus);
         if (networkStatus == NETWORK_HARDWARE_ERROR) {
@@ -72,8 +72,9 @@ void WiFiConnectionManager::check() {
           delay(5000);
         }
         changeConnectionState(CONNECTION_STATE_CONNECTING);
-        break;
-      case CONNECTION_STATE_CONNECTING:
+      }
+      break;
+      case CONNECTION_STATE_CONNECTING: {
         networkStatus = WiFi.begin(ssid, pass);
         debugMessage(DebugLevel::Verbose, "WiFi.status(): %d", networkStatus);
         if (networkStatus != NETWORK_CONNECTED) {
@@ -86,8 +87,9 @@ void WiFiConnectionManager::check() {
           changeConnectionState(CONNECTION_STATE_CONNECTED);
           return;
         }
-        break;
-      case CONNECTION_STATE_CONNECTED:
+      }
+      break;
+      case CONNECTION_STATE_CONNECTED: {
         // keep testing connection
         networkStatus = WiFi.status();
         debugMessage(DebugLevel::Verbose, "WiFi.status(): %d", networkStatus);
@@ -96,11 +98,13 @@ void WiFiConnectionManager::check() {
           return;
         }
         debugMessage(DebugLevel::Verbose, "Connected to \"%s\"", ssid);
-        break;
-      case CONNECTION_STATE_DISCONNECTED:
+      }
+      break;
+      case CONNECTION_STATE_DISCONNECTED: {
         WiFi.end();
         changeConnectionState(CONNECTION_STATE_CONNECTING);
-        break;
+      }
+      break;
     }
     lastConnectionTickTime = now;
   }
@@ -111,29 +115,33 @@ void WiFiConnectionManager::check() {
  ******************************************************************************/
 
 void WiFiConnectionManager::changeConnectionState(NetworkConnectionState _newState) {
-  char msgBuffer[120];
   int newInterval = CHECK_INTERVAL_INIT;
   switch (_newState) {
-    case CONNECTION_STATE_INIT:
+    case CONNECTION_STATE_INIT: {
       newInterval = CHECK_INTERVAL_INIT;
-      break;
-    case CONNECTION_STATE_CONNECTING:
+    }
+    break;
+    case CONNECTION_STATE_CONNECTING: {
       debugMessage(DebugLevel::Info, "Connecting to \"%s\"", ssid);
       newInterval = CHECK_INTERVAL_CONNECTING;
-      break;
-    case CONNECTION_STATE_CONNECTED:
+    }
+    break;
+    case CONNECTION_STATE_CONNECTED: {
       newInterval = CHECK_INTERVAL_CONNECTED;
-      break;
-    case CONNECTION_STATE_DISCONNECTED:
+    }
+    break;
+    case CONNECTION_STATE_DISCONNECTED: {
       debugMessage(DebugLevel::Verbose, "WiFi.status(): %d", WiFi.status());
       debugMessage(DebugLevel::Error, "Connection to \"%s\" lost.", ssid);
       debugMessage(DebugLevel::Error, "Attempting reconnection");
       newInterval = CHECK_INTERVAL_DISCONNECTED;
-      break;
-    case CONNECTION_STATE_ERROR:
+    }
+    break;
+    case CONNECTION_STATE_ERROR: {
       debugMessage(DebugLevel::Error, "WiFi Hardware failure.\nMake sure you are using a WiFi enabled board/shield.");
       debugMessage(DebugLevel::Error, "Then reset and retry.");
-      break;
+    }
+    break;
   }
   connectionTickTimeInterval = newInterval;
   lastConnectionTickTime = millis();

--- a/src/WiFiConnectionManager.cpp
+++ b/src/WiFiConnectionManager.cpp
@@ -56,12 +56,12 @@ void WiFiConnectionManager::check() {
   int networkStatus = 0;
   if (now - lastConnectionTickTime > connectionTickTimeInterval) {
     switch (netConnectionState) {
-      case CONNECTION_STATE_INIT: {
+      case NetworkConnectionState::INIT: {
         networkStatus = WiFi.status();
         debugMessage(DebugLevel::Info, "WiFi.status(): %d", networkStatus);
         if (networkStatus == NETWORK_HARDWARE_ERROR) {
           // NO FURTHER ACTION WILL FOLLOW THIS
-          changeConnectionState(CONNECTION_STATE_ERROR);
+          changeConnectionState(NetworkConnectionState::ERROR);
           lastConnectionTickTime = now;
           return;
         }
@@ -71,38 +71,38 @@ void WiFiConnectionManager::check() {
           debugMessage(DebugLevel::Error, "Please update to the latest version for best performance.");
           delay(5000);
         }
-        changeConnectionState(CONNECTION_STATE_CONNECTING);
+        changeConnectionState(NetworkConnectionState::CONNECTING);
       }
       break;
-      case CONNECTION_STATE_CONNECTING: {
+      case NetworkConnectionState::CONNECTING: {
         networkStatus = WiFi.begin(ssid, pass);
         debugMessage(DebugLevel::Verbose, "WiFi.status(): %d", networkStatus);
         if (networkStatus != NETWORK_CONNECTED) {
           debugMessage(DebugLevel::Error, "Connection to \"%s\" failed", ssid);
           debugMessage(DebugLevel::Info, "Retrying in  \"%d\" milliseconds", connectionTickTimeInterval);
-          //changeConnectionState(CONNECTION_STATE_CONNECTING);
+          //changeConnectionState(NetworkConnectionState::CONNECTING);
           return;
         } else {
           debugMessage(DebugLevel::Info, "Connected to \"%s\"", ssid);
-          changeConnectionState(CONNECTION_STATE_CONNECTED);
+          changeConnectionState(NetworkConnectionState::CONNECTED);
           return;
         }
       }
       break;
-      case CONNECTION_STATE_CONNECTED: {
+      case NetworkConnectionState::CONNECTED: {
         // keep testing connection
         networkStatus = WiFi.status();
         debugMessage(DebugLevel::Verbose, "WiFi.status(): %d", networkStatus);
         if (networkStatus != WL_CONNECTED) {
-          changeConnectionState(CONNECTION_STATE_DISCONNECTED);
+          changeConnectionState(NetworkConnectionState::DISCONNECTED);
           return;
         }
         debugMessage(DebugLevel::Verbose, "Connected to \"%s\"", ssid);
       }
       break;
-      case CONNECTION_STATE_DISCONNECTED: {
+      case NetworkConnectionState::DISCONNECTED: {
         WiFi.end();
-        changeConnectionState(CONNECTION_STATE_CONNECTING);
+        changeConnectionState(NetworkConnectionState::CONNECTING);
       }
       break;
     }
@@ -117,27 +117,27 @@ void WiFiConnectionManager::check() {
 void WiFiConnectionManager::changeConnectionState(NetworkConnectionState _newState) {
   int newInterval = CHECK_INTERVAL_INIT;
   switch (_newState) {
-    case CONNECTION_STATE_INIT: {
+    case NetworkConnectionState::INIT: {
       newInterval = CHECK_INTERVAL_INIT;
     }
     break;
-    case CONNECTION_STATE_CONNECTING: {
+    case NetworkConnectionState::CONNECTING: {
       debugMessage(DebugLevel::Info, "Connecting to \"%s\"", ssid);
       newInterval = CHECK_INTERVAL_CONNECTING;
     }
     break;
-    case CONNECTION_STATE_CONNECTED: {
+    case NetworkConnectionState::CONNECTED: {
       newInterval = CHECK_INTERVAL_CONNECTED;
     }
     break;
-    case CONNECTION_STATE_DISCONNECTED: {
+    case NetworkConnectionState::DISCONNECTED: {
       debugMessage(DebugLevel::Verbose, "WiFi.status(): %d", WiFi.status());
       debugMessage(DebugLevel::Error, "Connection to \"%s\" lost.", ssid);
       debugMessage(DebugLevel::Error, "Attempting reconnection");
       newInterval = CHECK_INTERVAL_DISCONNECTED;
     }
     break;
-    case CONNECTION_STATE_ERROR: {
+    case NetworkConnectionState::ERROR: {
       debugMessage(DebugLevel::Error, "WiFi Hardware failure.\nMake sure you are using a WiFi enabled board/shield.");
       debugMessage(DebugLevel::Error, "Then reset and retry.");
     }


### PR DESCRIPTION
* Converting all enum's into enum classes will increase type safety (can't be mistaken for integers) while increasing readability.
* Braces for all switch-case statements prevent local variables from being visible in other case blocks than their own

**No changes to functional logic!**