### PR TITLE
Check for commonly misspelled words during the CI build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,6 +29,17 @@ matrix:
       script:
         # check code formatting
         - find . -regextype posix-extended -path './.git' -prune -or \( -iregex '.*\.((ino)|(h)|(hpp)|(hh)|(hxx)|(h\+\+)|(cpp)|(cc)|(cxx)|(c\+\+)|(cp)|(c)|(ipp)|(ii)|(ixx)|(inl)|(tpp)|(txx)|(tpl))$' -and -type f \) -print0 | xargs -0 -L1 bash -c 'if ! diff $0 <(astyle --options=${HOME}/astyle/examples_formatter.conf --dry-run < $0); then echo "Non-compliant code formatting in $0"; false; fi'
+    - env:
+        - NAME=Spell Check
+      language: python
+      python: 3.6
+      # must define an empty before_install phase, otherwise the default one is used
+      before_install: true
+      install:
+        # https://github.com/codespell-project/codespell
+        - pip install codespell
+      script:
+        - codespell --skip="${TRAVIS_BUILD_DIR}/.git" --ignore-words="${TRAVIS_BUILD_DIR}/extras/codespell-ignore-words-list.txt" "${TRAVIS_BUILD_DIR}"
 # default phases
 before_install:
   - wget http://downloads.arduino.cc/arduino-$IDE_VERSION-linux64.tar.xz

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ This library has multiple `begin(...)` methods allowing you to take more control
 
 - `disconnect()` closes the connection to the MQTT Client.
 
-- The `update()` method can be called periodically in the loop of the `.ino` file. If a `ConnectionManager` is implemented it checks network connnections. It also makes sure that a connection with the MQTT broker is active and tries to reconnect otherwise. During `update()` data from the Cloud is retrieved and changed values are posted to the proper MQTT topic.
+- The `update()` method can be called periodically in the loop of the `.ino` file. If a `ConnectionManager` is implemented it checks network connections. It also makes sure that a connection with the MQTT broker is active and tries to reconnect otherwise. During `update()` data from the Cloud is retrieved and changed values are posted to the proper MQTT topic.
 
 - `connected()` simply returns the current status of the MQTT connection.
 


### PR DESCRIPTION
If any word is found that is on a list of commonly misspelled words, the Travis CI build will fail and a correction will be suggested in the build log.

[codespell](https://github.com/codespell-project/codespell) is a blacklist-based spell checker. This approach is more appropriate for a CI build because it results in far less false positives than would traditional whitelist-based spell checking, with the disadvantage of having more false negatives. So it won't catch all the typos, but it also won't be spuriously breaking every other build.

When false positives do occur, they can be resolved by adding the problematic word to `extras/codespell-ignore-words-list.txt`. Note that it was not necessary to add any words to the ignore list so this file is currently unnecessary. I added it anyway with the idea that having the ignore words list system in place would make it very easy for anyone to resolve any future CI build failures caused by false positives. However, the extra folder and file does clutter up the repository a bit. If you prefer to wait to add the ignore words list system until it's actually needed, I'm happy to update this PR accordingly.

Example of a build that failed from a misspelled word being detected:
https://travis-ci.org/per1234/ArduinoIoTCloud/builds/520555912