### PR TITLE
Simplifying getting started examples ...

### DIFF
--- a/examples/ArduinoIoTCloud_LED_switch/ArduinoIoTCloud_LED_switch.ino
+++ b/examples/ArduinoIoTCloud_LED_switch/ArduinoIoTCloud_LED_switch.ino
@@ -10,6 +10,10 @@
   By default, settings for WiFi are chosen. If you prefer to use a GSM board take a look at thingProperties.h arduino_secrets.h,
   to make sure you uncomment what's needed and comment incompatible instructions.
 
+  This sketch is compatible with:
+   - MKR 1000
+   - MKR WIFI 1010
+   - MKR GSM 1400
 */
 #include "arduino_secrets.h"
 #include "thingProperties.h"

--- a/examples/ArduinoIoTCloud_Travis_CI/ArduinoIoTCloud_Travis_CI.ino
+++ b/examples/ArduinoIoTCloud_Travis_CI/ArduinoIoTCloud_Travis_CI.ino
@@ -2,6 +2,11 @@
    This sketch is used in combination with Travis CI to check if
    unintentional breaking changes are made to the used facing
    Arduino IoT Cloud API.
+
+   This sketch is compatible with:
+     - MKR 1000
+     - MKR WIFI 1010
+     - MKR GSM 1400
 */
 
 #include "arduino_secrets.h"

--- a/examples/GSM_Cloud_Blink/GSM_Cloud_Blink.ino
+++ b/examples/GSM_Cloud_Blink/GSM_Cloud_Blink.ino
@@ -2,25 +2,7 @@
 #include <ConnectionManager.h>
 #include <GSMConnectionManager.h>
 
-#ifndef SECRET_PIN
-  #define SECRET_PIN ""
-  #pragma message "You need to define SECRET_PIN in tab/arduino_secrets.h"
-#endif
-
-#ifndef SECRET_APN
-  #define SECRET_APN ""
-  #pragma message "You need to define SECRET_PIN in tab/arduino_secrets.h"
-#endif
-
-#ifndef SECRET_USER_NAME
-  #define SECRET_USER_NAME ""
-  #pragma message "You need to define SECRET_USER_NAME in tab/arduino_secrets.h"
-#endif
-
-#ifndef SECRET_PASSWORD
-  #define SECRET_PASSWORD ""
-  #pragma message "You need to define SECRET_PASSWORD in tab/arduino_secrets.h"
-#endif
+#include "arduino_secrets.h"
 
 String cloudSerialBuffer = ""; // the string used to compose network messages from the received characters
 // handles connection to the network

--- a/examples/GSM_Cloud_Blink/GSM_Cloud_Blink.ino
+++ b/examples/GSM_Cloud_Blink/GSM_Cloud_Blink.ino
@@ -1,3 +1,11 @@
+/* This sketch is used during the getting started tutorial when
+   initialising a Arduino cloud-enabled board with the Arduino
+   cloud for the first time.
+
+   This sketch is compatible with:
+     - MKR GSM 1400
+*/
+
 #include <ArduinoIoTCloud.h>
 #include <ConnectionManager.h>
 #include <GSMConnectionManager.h>

--- a/examples/GSM_Cloud_Blink/arduino_secrets.h
+++ b/examples/GSM_Cloud_Blink/arduino_secrets.h
@@ -1,0 +1,19 @@
+#ifndef SECRET_PIN
+  #define SECRET_PIN ""
+  #warning "You need to define SECRET_PIN in tab/arduino_secrets.h"
+#endif
+
+#ifndef SECRET_APN
+  #define SECRET_APN ""
+  #warning "You need to define SECRET_PIN in tab/arduino_secrets.h"
+#endif
+
+#ifndef SECRET_USER_NAME
+  #define SECRET_USER_NAME ""
+  #warning "You need to define SECRET_USER_NAME in tab/arduino_secrets.h"
+#endif
+
+#ifndef SECRET_PASSWORD
+  #define SECRET_PASSWORD ""
+  #warning "You need to define SECRET_PASSWORD in tab/arduino_secrets.h"
+#endif

--- a/examples/MultiValue_example/MultiValue_example.ino
+++ b/examples/MultiValue_example/MultiValue_example.ino
@@ -12,6 +12,10 @@
   Properties which are marked as READ/WRITE in the Cloud Thing will also have functions
   which are called when their values are changed from the Dashboard.
   These functions are generated with the Thing and added at the end of this sketch.
+
+  This sketch is compatible with:
+    - MKR 1000
+    - MKR WIFI 1010
 */
 
 #include "thingProperties.h"

--- a/examples/WiFi_Cloud_Blink/WiFi_Cloud_Blink.ino
+++ b/examples/WiFi_Cloud_Blink/WiFi_Cloud_Blink.ino
@@ -1,3 +1,12 @@
+/* This sketch is used during the getting started tutorial when
+   initialising a Arduino cloud-enabled board with the Arduino
+   cloud for the first time.
+
+   This sketch is compatible with:
+     - MKR 1000
+     - MKR WIFI 1010
+*/
+
 #include <ArduinoIoTCloud.h>
 #include <ConnectionManager.h>
 #include <WiFiConnectionManager.h>

--- a/examples/WiFi_Cloud_Blink/WiFi_Cloud_Blink.ino
+++ b/examples/WiFi_Cloud_Blink/WiFi_Cloud_Blink.ino
@@ -2,19 +2,11 @@
 #include <ConnectionManager.h>
 #include <WiFiConnectionManager.h>
 
-#ifndef SECRET_WIFI_NAME
-  #define SECRET_WIFI_NAME ""
-  #pragma message "You need to define SECRET_WIFI_NAME in tab/arduino_secrets.h"
-#endif
-
-#ifndef SECRET_PASSWORD
-  #define SECRET_PASSWORD ""
-  #pragma message "You need to define SECRET_PASSWORD in tab/arduino_secrets.h"
-#endif
+#include "arduino_secrets.h"
 
 String cloudSerialBuffer = ""; // the string used to compose network messages from the received characters
 // handles connection to the network
-ConnectionManager * ArduinoIoTPreferredConnection = new WiFiConnectionManager(SECRET_WIFI_NAME, SECRET_PASSWORD);
+ConnectionManager * ArduinoIoTPreferredConnection = new WiFiConnectionManager(SECRET_SSID, SECRET_PASS);
 
 void setup() {
   setDebugMessageLevel(3); // used to set a level of granularity in information output [0...4]

--- a/examples/WiFi_Cloud_Blink/arduino_secrets.h
+++ b/examples/WiFi_Cloud_Blink/arduino_secrets.h
@@ -1,0 +1,9 @@
+#ifndef SECRET_SSID
+  #define SECRET_SSID ""
+  #warning "You need to define SECRET_SSID in tab/arduino_secrets.h"
+#endif
+
+#ifndef SECRET_PASS
+  #define SECRET_PASS ""
+  #warning "You need to define SECRET_PASS in tab/arduino_secrets.h"
+#endif


### PR DESCRIPTION
by extracting the arduino_secrets into separate file.

@ubidefeo @AlbyIanna @umbynos I further suggest to rename the examples into something which contains *getting started* as a reminder of what's the purpose of those examples, e.g. `GSM_Cloud_Blink` -> `MKR_GSM_1400_Getting_Started` or `MKR_GSM_1400_Getting_Started_Cloud_Blink`. What's your opinion?