### PR TITLE
Use arduino-cli for Travis CI build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: generic
 env:
   global:
-    - IDE_VERSION=1.8.9
+    - CLI_VERSION=latest
 matrix:
   include:
     - env:
@@ -42,23 +42,26 @@ matrix:
         - codespell --skip="${TRAVIS_BUILD_DIR}/.git" --ignore-words="${TRAVIS_BUILD_DIR}/extras/codespell-ignore-words-list.txt" "${TRAVIS_BUILD_DIR}"
 # default phases
 before_install:
-  - wget http://downloads.arduino.cc/arduino-$IDE_VERSION-linux64.tar.xz
-  - tar xf arduino-$IDE_VERSION-linux64.tar.xz
-  - mv arduino-$IDE_VERSION $HOME/arduino-ide
-  - export PATH=$PATH:$HOME/arduino-ide
+  - wget http://downloads.arduino.cc/arduino-cli/arduino-cli-$CLI_VERSION-linux64.tar.bz2
+  - tar xf arduino-cli-$CLI_VERSION-linux64.tar.bz2
+  - mkdir -p "$HOME/bin"
+  - mv arduino-cli-*-linux64 $HOME/bin/arduino-cli
+  - export PATH="$PATH:$HOME/bin"
+  - arduino-cli core update-index
   - if [[ "$BOARD" =~ "arduino:samd:" ]]; then
-      arduino --install-boards arduino:samd;
+      arduino-cli core install arduino:samd;
     fi
-  - arduino --install-library ArduinoCloudThing
-  - arduino --install-library ArduinoECCX08
-  - arduino --install-library ArduinoIoTCloudBearSSL
-  - arduino --install-library ArduinoMqttClient
-  - arduino --install-library MKRGSM
-  - arduino --install-library RTCZero
-  - arduino --install-library WiFi101
-  - arduino --install-library WiFiNINA
-  - buildExampleSketch() { arduino --verify --board $BOARD $PWD/examples/$1/$1.ino; }
-  - buildExampleUtilitySketch() { arduino --verify --board $BOARD $PWD/examples/utility/$1/$1.ino; }
+  - arduino-cli lib install ArduinoCloudThing
+  - arduino-cli lib install ArduinoECCX08
+  - arduino-cli lib install ArduinoIoTCloudBearSSL
+  - arduino-cli lib install ArduinoMqttClient
+  - arduino-cli lib install MKRGSM
+  - arduino-cli lib install RTCZero
+  - arduino-cli lib install WiFi101
+  - arduino-cli lib install WiFiNINA
+  - arduino-cli lib install Ethernet
+  - buildExampleSketch() { arduino-cli compile --warnings all --fqbn $BOARD $PWD/examples/$1; }
+  - buildExampleUtilitySketch() { arduino-cli compile --warnings all --fqbn $BOARD $PWD/examples/utility/$1; }
 install:
   - mkdir -p $HOME/Arduino/libraries
   - ln -s $PWD $HOME/Arduino/libraries/.


### PR DESCRIPTION
Use [`arduino-cli`](https://github.com/arduino/arduino-cli) instead of the Arduino IDE for the Travis CI build.

`arduino-cli` does not result in the many "SocketListener" warnings that end up interspersed with the compilation output when using the Arduino IDE with Travis CI. These warnings make it more likely that Travis CI's maximum build log length will be exceeded, resulting in an errored job. The warnings also make the build log hard to read.

Due to a smaller download size, using `arduino-cli` results in a shorter CI build duration. In my test, the build duration was decreased from 13 min 53 sec to 10 min 5 sec.