### PR TITLE
Fail Travis CI build on compiler warnings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: generic
 env:
   global:
     - CLI_VERSION=latest
+    - EXTRA_COMPILER_WARNING_FLAGS="-Wpedantic -Werror"
 matrix:
   include:
     - env:
@@ -60,8 +61,8 @@ before_install:
   - arduino-cli lib install WiFi101
   - arduino-cli lib install WiFiNINA
   - arduino-cli lib install Ethernet
-  - buildExampleSketch() { arduino-cli compile --warnings all --fqbn $BOARD $PWD/examples/$1; }
-  - buildExampleUtilitySketch() { arduino-cli compile --warnings all --fqbn $BOARD $PWD/examples/utility/$1; }
+  - buildExampleSketch() { arduino-cli compile --warnings all --build-properties compiler.c.extra_flags="${EXTRA_COMPILER_WARNING_FLAGS}" --build-properties compiler.cpp.extra_flags="${EXTRA_COMPILER_WARNING_FLAGS}" --build-properties compiler.S.extra_flags="${EXTRA_COMPILER_WARNING_FLAGS}" --fqbn $BOARD $PWD/examples/$1; }
+  - buildExampleUtilitySketch() { arduino-cli compile --warnings all --build-properties compiler.c.extra_flags="${EXTRA_COMPILER_WARNING_FLAGS}" --build-properties compiler.cpp.extra_flags="${EXTRA_COMPILER_WARNING_FLAGS}" --build-properties compiler.S.extra_flags="${EXTRA_COMPILER_WARNING_FLAGS}" --fqbn $BOARD $PWD/examples/utility/$1; }
 install:
   - mkdir -p $HOME/Arduino/libraries
   - ln -s $PWD $HOME/Arduino/libraries/.


### PR DESCRIPTION
- In addition to the existing "All" compiler warning level (`-Wall -Wextra -Wno-expansion-to-defined`), add `-Wpedantic`
- Add `-Werror` to fail CI build if any warnings are encountered

`build.extra_flags` is used for other purposes in the Arduino SAMD Boards boards.txt so it would not have been ideal to use that property to set the warning flags. For this reason, I used `compiler.c.extra_flags`, `compiler.cpp.extra_flags`, and `compiler.S.extra_flags` instead.