### PR TITLE
Revert "Fail Travis CI build on compiler warnings"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: generic
 env:
   global:
     - CLI_VERSION=latest
-    - EXTRA_COMPILER_WARNING_FLAGS="-Wpedantic -Werror"
 matrix:
   include:
     - env:
@@ -74,8 +73,8 @@ before_install:
   - installLibrary arduino-libraries/WiFi101
   - installLibrary arduino-libraries/WiFiNINA
   - installLibrary arduino-libraries/Ethernet
-  - buildExampleSketch() { arduino-cli compile --warnings all --build-properties compiler.c.extra_flags="${EXTRA_COMPILER_WARNING_FLAGS}" --build-properties compiler.cpp.extra_flags="${EXTRA_COMPILER_WARNING_FLAGS}" --build-properties compiler.S.extra_flags="${EXTRA_COMPILER_WARNING_FLAGS}" --fqbn $BOARD $PWD/examples/$1; }
-  - buildExampleUtilitySketch() { arduino-cli compile --warnings all --build-properties compiler.c.extra_flags="${EXTRA_COMPILER_WARNING_FLAGS}" --build-properties compiler.cpp.extra_flags="${EXTRA_COMPILER_WARNING_FLAGS}" --build-properties compiler.S.extra_flags="${EXTRA_COMPILER_WARNING_FLAGS}" --fqbn $BOARD $PWD/examples/utility/$1; }
+  - buildExampleSketch() { arduino-cli compile --warnings all --fqbn $BOARD $PWD/examples/$1; }
+  - buildExampleUtilitySketch() { arduino-cli compile --warnings all --fqbn $BOARD $PWD/examples/utility/$1; }
 install:
   - mkdir -p $HOME/Arduino/libraries
   - ln -s $PWD $HOME/Arduino/libraries/.


### PR DESCRIPTION
This reverts commit f43c0fb7b19c179be5b9f49ee6acacbd58f83ed3.

It was eventually determined that failing the CI build on compiler warnings while compiling examples was too problematic due to the fact that warnings may be caused by external code.

Reference: https://github.com/arduino-libraries/ArduinoIoTCloud/pull/68#issuecomment-494687559