### PR TITLE
Reducing available update functions

### DIFF
--- a/src/ArduinoIoTCloud.cpp
+++ b/src/ArduinoIoTCloud.cpp
@@ -211,7 +211,7 @@ bool ArduinoIoTCloudClass::disconnect() {
   return true;
 }
 
-void ArduinoIoTCloudClass::update(int const /* reconnectionMaxRetries */, int const /* reconnectionTimeoutMs */, CallbackFunc onSyncCompleteCallback) {
+void ArduinoIoTCloudClass::update(CallbackFunc onSyncCompleteCallback) {
   // Check if a primitive property wrapper is locally changed
   Thing.updateTimestampOnLocallyChangedProperties();
 

--- a/src/ArduinoIoTCloud.h
+++ b/src/ArduinoIoTCloud.h
@@ -79,8 +79,6 @@ class ArduinoIoTCloudClass {
     int begin(Client& net, String brokerAddress = DEFAULT_BROKER_ADDRESS, uint16_t brokerPort = DEFAULT_BROKER_PORT);
     // Class constant declaration
     static const int MQTT_TRANSMIT_BUFFER_SIZE = 256;
-    static const int MAX_RETRIES = 5;
-    static const int RECONNECTION_TIMEOUT = 2000;
     static const int TIMEOUT_FOR_LASTVALUES_SYNC = 10000;
 
     void onGetTime(unsigned long(*callback)(void));
@@ -91,14 +89,10 @@ class ArduinoIoTCloudClass {
     inline void update() {
       update(NULL);
     }
-    inline void update(CallbackFunc onSyncCompleteCallback) __attribute__((deprecated)) { /* Attention: Function is deprecated - use 'addCallback(ArduinoIoTCloudConnectionEvent::SYNC, &onSync)' for adding a onSyncCallback instead */
-      update(MAX_RETRIES, RECONNECTION_TIMEOUT, onSyncCompleteCallback);
+    inline void update(int const reconnectionMaxRetries, int const reconnectionTimeoutMs) __attribute__((deprecated)) {
+      update(NULL);
     }
-    // defined for users who want to specify max reconnections reties and timeout between them
-    inline void update(int const reconnectionMaxRetries, int const reconnectionTimeoutMs) {
-      update(reconnectionMaxRetries, reconnectionTimeoutMs, NULL);
-    }
-    void update(int const reconnectionMaxRetries, int const reconnectionTimeoutMs, CallbackFunc onSyncCompleteCallback) __attribute__((deprecated)); /* Attention: Function is deprecated - use 'addCallback(ArduinoIoTCloudConnectionEvent::SYNC, &onSync)' for adding a onSyncCallback instead */
+    void update(CallbackFunc onSyncCompleteCallback) __attribute__((deprecated)); /* Attention: Function is deprecated - use 'addCallback(ArduinoIoTCloudConnectionEvent::SYNC, &onSync)' for adding a onSyncCallback instead */
 
     int connected();
     // Clean up existing Mqtt connection, create a new one and initialize it


### PR DESCRIPTION
In 20cbb75e70d0360138189c5a8cf6992942ce1247 the implementation of

`ArduinoIoTCloudClass::update(int const reconnectionMaxRetries, int const reconnectionTimeoutMs)` 

was changed in such a way, that the function parameters `reconnectionMaxRetries` and `reconnectionTimeoutMs` ceased to have any meaning since they were no longer used. This fact was uncovered when enforcing stronger compile time checks in f43c0fb7b19c179be5b9f49ee6acacbd58f83ed3.

Capitalizing on this discovery we can drastically reduce the number of overloaded `update` functions provided. We may even remove the functions marked `deprecated` at a later point in time and we are left with a single `update` function.