### PR TITLE
Add new cloud blink sketch version working with security credentials

### DIFF
--- a/examples/ArduinoIoTCloud_ESP8266/thingProperties.h
+++ b/examples/ArduinoIoTCloud_ESP8266/thingProperties.h
@@ -2,7 +2,7 @@
 #include <Arduino_ConnectionHandler.h>
 
 #define THING_ID "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx" /* "Thing ID" when selecting thing within Arduino Create */
-#define DEVICE_LOGIN_NAME "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
+#define BOARD_ID "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
 
 void onLedChange();
 
@@ -10,7 +10,7 @@ bool led;
 
 void initProperties() {
   ArduinoCloud.setThingId(THING_ID);
-  ArduinoCloud.setDeviceLoginName(DEVICE_LOGIN_NAME);
+  ArduinoCloud.setBoardId(BOARD_ID);
   ArduinoCloud.setSecretDeviceKey(SECRET_DEVICE_KEY);
   ArduinoCloud.addProperty(led, READWRITE, ON_CHANGE, onLedChange);
 }

--- a/examples/WiFi_Cloud_Blink_with_security_credentials/WiFi_Cloud_Blink_with_security_credentials.ino
+++ b/examples/WiFi_Cloud_Blink_with_security_credentials/WiFi_Cloud_Blink_with_security_credentials.ino
@@ -1,0 +1,78 @@
+/* This sketch is used during the getting started tutorial when
+   initialising a Arduino cloud-enabled board with the Arduino
+   cloud for the first time.
+
+   This sketch is compatible with:
+     - ESP8266 boards
+*/
+
+#include <ArduinoIoTCloud.h>
+#include <Arduino_ConnectionHandler.h>
+
+#include "arduino_secrets.h"
+
+String cloudSerialBuffer = ""; // the string used to compose network messages from the received characters
+// handles connection to the network
+WiFiConnectionHandler ArduinoIoTPreferredConnection(SECRET_WIFI_NAME, SECRET_PASSWORD);
+
+void setup() {
+  setDebugMessageLevel(3); // used to set a level of granularity in information output [0...4]
+  Serial.begin(9600);
+  while (!Serial); // waits for the serial to become available
+  ArduinoCloud.setBoardId(SECRET_BOARD_ID);
+  ArduinoCloud.setSecretDeviceKey(SECRET_DEVICE_KEY);
+  ArduinoCloud.begin(ArduinoIoTPreferredConnection); // initialize a connection to the Arduino IoT Cloud
+  pinMode(LED_BUILTIN, OUTPUT);
+}
+
+void loop() {
+  ArduinoCloud.update();
+  // check if there is something waiting to be read
+  if (ArduinoCloud.connected()) {
+    if (CloudSerial.available()) {
+      char character = CloudSerial.read();
+      cloudSerialBuffer += character;
+      // if a \n character has been received, there should be a complete command inside cloudSerialBuffer
+      if (character == '\n') {
+        handleString();
+      }
+    } else { // if there is nothing to read, it could be that the last command didn't end with a '\n'. Check.
+      handleString();
+    }
+    // Just to be able to simulate the board responses through the serial monitor
+    if (Serial.available()) {
+      CloudSerial.write(Serial.read());
+    }
+  }
+}
+void handleString() {
+  // Don't proceed if the string is empty
+  if (cloudSerialBuffer.equals("")) {
+    return;
+  }
+  // Remove leading and trailing whitespaces
+  cloudSerialBuffer.trim();
+  // Make it uppercase;
+  cloudSerialBuffer.toUpperCase();
+  if (cloudSerialBuffer.equals("ON")) {
+    digitalWrite(LED_BUILTIN, HIGH);
+  } else if (cloudSerialBuffer.equals("OFF")) {
+    digitalWrite(LED_BUILTIN, LOW);
+  }
+  sendString(cloudSerialBuffer);
+  // Reset cloudSerialBuffer
+  cloudSerialBuffer = "";
+}
+// sendString sends a string to the Arduino Cloud.
+void sendString(String stringToSend) {
+  // send the characters one at a time
+  char lastSentChar = 0;
+  for (unsigned int i = 0; i < stringToSend.length(); i++) {
+    lastSentChar = stringToSend.charAt(i);
+    CloudSerial.write(lastSentChar);
+  }
+  // if the last sent character wasn't a '\n' add it
+  if (lastSentChar != '\n') {
+    CloudSerial.write('\n');
+  }
+}

--- a/examples/WiFi_Cloud_Blink_with_security_credentials/arduino_secrets.h
+++ b/examples/WiFi_Cloud_Blink_with_security_credentials/arduino_secrets.h
@@ -1,0 +1,19 @@
+#ifndef SECRET_WIFI_NAME
+  #define SECRET_WIFI_NAME ""
+  #warning "You need to define SECRET_WIFI_NAME in tab/arduino_secrets.h"
+#endif
+
+#ifndef SECRET_PASSWORD
+  #define SECRET_PASSWORD ""
+  #warning "You need to define SECRET_PASSWORD in tab/arduino_secrets.h"
+#endif
+
+#ifndef SECRET_BOARD_ID
+  #define SECRET_BOARD_ID ""  
+  #warning "You need to define SECRET_BOARD_ID in tab/arduino_secrets.h"
+#endif
+
+#ifndef SECRET_DEVICE_KEY
+  #define SECRET_DEVICE_KEY ""
+  #warning "You need to define SECRET_DEVICE_KEY in tab/arduino_secrets.h"
+#endif

--- a/examples/WiFi_Cloud_Blink_with_security_credentials/arduino_secrets.h
+++ b/examples/WiFi_Cloud_Blink_with_security_credentials/arduino_secrets.h
@@ -9,7 +9,7 @@
 #endif
 
 #ifndef SECRET_BOARD_ID
-  #define SECRET_BOARD_ID ""  
+  #define SECRET_BOARD_ID ""
   #warning "You need to define SECRET_BOARD_ID in tab/arduino_secrets.h"
 #endif
 

--- a/src/ArduinoIoTCloud.h
+++ b/src/ArduinoIoTCloud.h
@@ -113,7 +113,7 @@ class ArduinoIoTCloudClass {
       _thing_id = thing_id;
     };
     #ifdef BOARD_ESP
-    inline void setDeviceLoginName(String const device_id) {
+    inline void setBoardId(String const device_id) {
       _device_id = device_id;
     }
     inline void setSecretDeviceKey(String const password) {


### PR DESCRIPTION
We need to had a new example sketch for the Getting Started flow for ESP8266.
Also, since the `DEVICE_LOGIN_NAME` was actually the board id, I changed it to `BOARD_ID`, which I believe makes more sense for the users.