### PR TITLE
Specify library dependencies in library.properties

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -8,4 +8,4 @@ category=Communication
 url=https://github.com/arduino-libraries/ArduinoIoTCloud
 architectures=samd
 includes=ArduinoIoTCloud.h
-depends=Arduino_ConnectionHandler,Arduino_DebugUtils,ArduinoCloudThing,ArduinoMqttClient,ArduinoBearSSL
+depends=Arduino_ConnectionHandler,Arduino_DebugUtils,ArduinoCloudThing,ArduinoMqttClient,ArduinoBearSSL,ArduinoECCX08,RTCZero

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=ArduinoIoTCloud
-version=0.8.0
+version=0.8.1
 author=Arduino
 maintainer=Arduino <info@arduino.cc>
 sentence=This library allows to connect to the Arduino IoT Cloud service.


### PR DESCRIPTION
Specifying the library dependencies in the `depends` field of library.properties causes Library Manager to offer to install the dependencies during installation of this library.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#libraryproperties-file-format