### PR TITLE
Removing deprecated `update` functions

### DIFF
--- a/src/ArduinoIoTCloud.h
+++ b/src/ArduinoIoTCloud.h
@@ -75,8 +75,6 @@ class ArduinoIoTCloudClass {
     virtual bool disconnect() = 0;
 
     virtual void update() = 0;
-    virtual void update(int const reconnectionMaxRetries, int const reconnectionTimeoutMs) __attribute__((deprecated)) = 0;
-    virtual void update(CallbackFunc onSyncCompleteCallback) __attribute__((deprecated)) = 0; /* Attention: Function is deprecated - use 'addCallback(ArduinoIoTCloudConnectionEvent::SYNC, &onSync)' for adding a onSyncCallback instead */
 
     virtual int connected() = 0;
 

--- a/src/ArduinoIoTCloudLPWAN.cpp
+++ b/src/ArduinoIoTCloudLPWAN.cpp
@@ -56,7 +56,7 @@ int ArduinoIoTCloudLPWAN::begin(LPWANConnectionHandler& connection, bool retry) 
   return 1;
 }
 
-void ArduinoIoTCloudLPWAN::update(CallbackFunc onSyncCompleteCallback) {
+void ArduinoIoTCloudLPWAN::update() {
   // Check if a primitive property wrapper is locally changed
   Thing.updateTimestampOnLocallyChangedProperties();
 
@@ -82,9 +82,6 @@ void ArduinoIoTCloudLPWAN::update(CallbackFunc onSyncCompleteCallback) {
   sendPropertiesToCloud();
 
 
-  if (onSyncCompleteCallback != NULL) {
-    (*onSyncCompleteCallback)();
-  }
   execCloudEventCallback(_on_sync_event_callback, 0 /* callback_arg */);
 
 }

--- a/src/ArduinoIoTCloudLPWAN.h
+++ b/src/ArduinoIoTCloudLPWAN.h
@@ -30,13 +30,7 @@ class ArduinoIoTCloudLPWAN : public ArduinoIoTCloudClass {
     int connect();
     bool disconnect();
     int connected();
-    inline void update() {
-      update(NULL);
-    }
-    inline void update(int const reconnectionMaxRetries, int const reconnectionTimeoutMs) __attribute__((deprecated)) {
-      update(NULL);
-    }
-    void update(CallbackFunc onSyncCompleteCallback) __attribute__((deprecated));
+    void update();
     void connectionCheck();
     void printDebugInfo();
     int begin(LPWANConnectionHandler& connection, bool retry = false);

--- a/src/ArduinoIoTCloudTCP.cpp
+++ b/src/ArduinoIoTCloudTCP.cpp
@@ -219,7 +219,7 @@ bool ArduinoIoTCloudTCP::disconnect() {
   return true;
 }
 
-void ArduinoIoTCloudTCP::update(CallbackFunc onSyncCompleteCallback) {
+void ArduinoIoTCloudTCP::update() {
   // Check if a primitive property wrapper is locally changed
   Thing.updateTimestampOnLocallyChangedProperties();
 
@@ -245,9 +245,6 @@ void ArduinoIoTCloudTCP::update(CallbackFunc onSyncCompleteCallback) {
       }
       break;
     case ArduinoIoTSynchronizationStatus::SYNC_STATUS_VALUES_PROCESSED: {
-        if (onSyncCompleteCallback != NULL) {
-          (*onSyncCompleteCallback)();
-        }
         execCloudEventCallback(_on_sync_event_callback, 0 /* callback_arg */);
         _syncStatus = ArduinoIoTSynchronizationStatus::SYNC_STATUS_SYNCHRONIZED;
       }

--- a/src/ArduinoIoTCloudTCP.h
+++ b/src/ArduinoIoTCloudTCP.h
@@ -53,13 +53,7 @@ class ArduinoIoTCloudTCP: public ArduinoIoTCloudClass {
     int connect();
     bool disconnect();
     int connected();
-    inline void update() {
-      update(NULL);
-    }
-    inline void update(int const reconnectionMaxRetries, int const reconnectionTimeoutMs) __attribute__((deprecated)) {
-      update(NULL);
-    }
-    void update(CallbackFunc onSyncCompleteCallback) __attribute__((deprecated));
+    void update();
     void connectionCheck();
     void printDebugInfo();
     #ifdef BOARD_HAS_ECCX08


### PR DESCRIPTION
This PR removes overloaded `update` functions which have been marked `deprecated` for quite some time. If users want to register a callback to be called when synchronisation is complete this should be done via `addCallback` instead of directly passing a function pointer to `update(CallbackFunc onSyncCompleteCallback)` which is removed within this PR.