### PR TITLE
Register a epoch timestamp retrieval function with ArduinoCloudThing

### DIFF
--- a/src/ArduinoIoTCloudTCP.cpp
+++ b/src/ArduinoIoTCloudTCP.cpp
@@ -146,6 +146,7 @@ int ArduinoIoTCloudTCP::begin(Client& net, String brokerAddress, uint16_t broker
   mqttClientBegin();
 
   Thing.begin();
+  Thing.registerGetTimeCallbackFunc(getTime);
   return 1;
 }
 


### PR DESCRIPTION
This allows class ArduinoCloudThing to obtain a 'epoch' timestamp which is used during synchronisation and which has been implemented so far via an 'extern' dependency to RTCZero. Since this kind of hidden dependency (basically a global object across 2 separate Arduino libraries) is very brittle the depdency is made clear by explicitly registering a function to provide the required timestamp.