### PR TITLE
Removal of references to Client class since it's not used anymore.

### DIFF
--- a/src/ArduinoIoTCloudTCP.cpp
+++ b/src/ArduinoIoTCloudTCP.cpp
@@ -78,13 +78,11 @@ int ArduinoIoTCloudTCP::begin(TcpIpConnectionHandler & connection, String broker
   _brokerAddress = brokerAddress;
   _brokerPort = brokerPort;
   time_service.begin(&connection);
-  return begin(_connection->getClient(), _brokerAddress, _brokerPort);
+  return begin(_brokerAddress, _brokerPort);
 }
 
-int ArduinoIoTCloudTCP::begin(Client& net, String brokerAddress, uint16_t brokerPort) {
+int ArduinoIoTCloudTCP::begin(String brokerAddress, uint16_t brokerPort) {
 
-  _net = &net;
-  // store the broker address as class member
   _brokerAddress = brokerAddress;
   _brokerPort = brokerPort;
 
@@ -126,11 +124,7 @@ int ArduinoIoTCloudTCP::begin(Client& net, String brokerAddress, uint16_t broker
   }
 
   #ifdef BOARD_HAS_ECCX08
-  if (_connection != NULL) {
-    _sslClient = new BearSSLClient(_connection->getClient(), ArduinoIoTCloudTrustAnchor, ArduinoIoTCloudTrustAnchor_NUM);
-  } else {
-    _sslClient = new BearSSLClient(*_net, ArduinoIoTCloudTrustAnchor, ArduinoIoTCloudTrustAnchor_NUM);
-  }
+  _sslClient = new BearSSLClient(_connection->getClient(), ArduinoIoTCloudTrustAnchor, ArduinoIoTCloudTrustAnchor_NUM);
   _sslClient->setEccSlot(keySlot, ECCX08Cert.bytes(), ECCX08Cert.length());
   #elif defined(BOARD_ESP)
   _sslClient = new WiFiClientSecure();
@@ -246,7 +240,7 @@ void ArduinoIoTCloudTCP::sendPropertiesToCloud() {
 }
 
 
-int ArduinoIoTCloudTCP::reconnect(Client& /* net */) {
+int ArduinoIoTCloudTCP::reconnect() {
   if (_mqttClient->connected()) {
     _mqttClient->stop();
   }
@@ -382,7 +376,7 @@ void ArduinoIoTCloudTCP::connectionCheck() {
       }
       break;
     case ArduinoIoTConnectionStatus::RECONNECTING: {
-        int const ret_code_reconnect = reconnect(*_net);
+        int const ret_code_reconnect = reconnect();
         Debug.print(DBG_INFO, "ArduinoCloud.reconnect(): %d", ret_code_reconnect);
         if (ret_code_reconnect == CONNECT_SUCCESS) {
           _iotStatus = ArduinoIoTConnectionStatus::CONNECTED;

--- a/src/ArduinoIoTCloudTCP.h
+++ b/src/ArduinoIoTCloudTCP.h
@@ -51,7 +51,7 @@ class ArduinoIoTCloudTCP: public ArduinoIoTCloudClass {
     #else
     int begin(TcpIpConnectionHandler & connection, String brokerAddress = DEFAULT_BROKER_ADDRESS_USER_PASS_AUTH, uint16_t brokerPort = DEFAULT_BROKER_PORT_USER_PASS_AUTH);
     #endif
-    int begin(Client& net, String brokerAddress = DEFAULT_BROKER_ADDRESS_SECURE_AUTH, uint16_t brokerPort = DEFAULT_BROKER_PORT_SECURE_AUTH);
+    int begin(String brokerAddress = DEFAULT_BROKER_ADDRESS_SECURE_AUTH, uint16_t brokerPort = DEFAULT_BROKER_PORT_SECURE_AUTH);
     // Class constant declaration
     static const int MQTT_TRANSMIT_BUFFER_SIZE = 256;
 
@@ -76,7 +76,7 @@ class ArduinoIoTCloudTCP: public ArduinoIoTCloudClass {
     }
 
     // Clean up existing Mqtt connection, create a new one and initialize it
-    int reconnect(Client& /* net */);
+    int reconnect();
 
   protected:
     friend class CloudSerialClass;
@@ -113,7 +113,6 @@ class ArduinoIoTCloudTCP: public ArduinoIoTCloudClass {
     String _dataTopicOut;
     String _dataTopicIn;
     String _otaTopic;
-    Client* _net;
 
     static void onMessage(int length);
 


### PR DESCRIPTION
Cleaning up by removing pointer to a Client class which does not make sense any longer because we always use the connection handler to access any kind of connection