### PR TITLE
Fix - Don't loose messages when MQTT connection was broken on message send

### DIFF
--- a/src/ArduinoIoTCloud.h
+++ b/src/ArduinoIoTCloud.h
@@ -78,7 +78,7 @@ class ArduinoIoTCloudClass {
 
     virtual int connected() = 0;
 
-    virtual void connectionCheck() = 0;
+    virtual ArduinoIoTConnectionStatus connectionCheck() = 0;
 
     virtual void printDebugInfo() = 0;
 

--- a/src/ArduinoIoTCloudLPWAN.cpp
+++ b/src/ArduinoIoTCloudLPWAN.cpp
@@ -60,11 +60,7 @@ void ArduinoIoTCloudLPWAN::update() {
   // Check if a primitive property wrapper is locally changed
   Thing.updateTimestampOnLocallyChangedProperties();
 
-  connectionCheck();
-
-  if (_iotStatus != ArduinoIoTConnectionStatus::CONNECTED) {
-    return;
-  }
+  if(connectionCheck() != ArduinoIoTConnectionStatus::CONNECTED) return;
 
   if (_connection->available()) {
     uint8_t msgBuf[DEFAULT_CBOR_LORA_MSG_SIZE];
@@ -86,7 +82,7 @@ void ArduinoIoTCloudLPWAN::update() {
 
 }
 
-void ArduinoIoTCloudLPWAN::connectionCheck() {
+ArduinoIoTConnectionStatus ArduinoIoTCloudLPWAN::connectionCheck() {
   if (_connection != NULL) {
 
     _connection->check();
@@ -96,7 +92,7 @@ void ArduinoIoTCloudLPWAN::connectionCheck() {
         _iotStatus = ArduinoIoTConnectionStatus::DISCONNECTED;
         printConnectionStatus(_iotStatus);
       }
-      return;
+      return _iotStatus;
     }
   }
 
@@ -147,6 +143,8 @@ void ArduinoIoTCloudLPWAN::connectionCheck() {
       }
       break;
   }
+
+  return _iotStatus;
 }
 
 void ArduinoIoTCloudLPWAN::printDebugInfo() {

--- a/src/ArduinoIoTCloudLPWAN.h
+++ b/src/ArduinoIoTCloudLPWAN.h
@@ -31,7 +31,7 @@ class ArduinoIoTCloudLPWAN : public ArduinoIoTCloudClass {
     bool disconnect();
     int connected();
     void update();
-    void connectionCheck();
+    ArduinoIoTConnectionStatus connectionCheck();
     void printDebugInfo();
     int begin(LPWANConnectionHandler& connection, bool retry = false);
     inline LPWANConnectionHandler* getConnection() {

--- a/src/ArduinoIoTCloudTCP.cpp
+++ b/src/ArduinoIoTCloudTCP.cpp
@@ -201,11 +201,7 @@ void ArduinoIoTCloudTCP::update() {
   // Check if a primitive property wrapper is locally changed
   Thing.updateTimestampOnLocallyChangedProperties();
 
-  connectionCheck();
-
-  if (_iotStatus != ArduinoIoTConnectionStatus::CONNECTED) {
-    return;
-  }
+  if(connectionCheck() != ArduinoIoTConnectionStatus::CONNECTED) return;
 
   // MTTQClient connected!, poll() used to retrieve data from MQTT broker
   _mqttClient->poll();
@@ -337,7 +333,7 @@ void ArduinoIoTCloudTCP::requestLastValue() {
   writeShadowOut(CBOR_REQUEST_LAST_VALUE_MSG, sizeof(CBOR_REQUEST_LAST_VALUE_MSG));
 }
 
-void ArduinoIoTCloudTCP::connectionCheck() {
+ArduinoIoTConnectionStatus ArduinoIoTCloudTCP::connectionCheck() {
 
   if (_connection != NULL) {
 
@@ -348,7 +344,7 @@ void ArduinoIoTCloudTCP::connectionCheck() {
         _iotStatus = ArduinoIoTConnectionStatus::DISCONNECTED;
         printConnectionStatus(_iotStatus);
       }
-      return;
+      return _iotStatus;
     }
   }
 
@@ -403,6 +399,8 @@ void ArduinoIoTCloudTCP::connectionCheck() {
       }
       break;
   }
+
+  return _iotStatus;
 }
 
 void ArduinoIoTCloudTCP::printDebugInfo() {

--- a/src/ArduinoIoTCloudTCP.h
+++ b/src/ArduinoIoTCloudTCP.h
@@ -44,7 +44,7 @@ class ArduinoIoTCloudTCP: public ArduinoIoTCloudClass {
     bool disconnect();
     int connected();
     void update();
-    void connectionCheck();
+    ArduinoIoTConnectionStatus connectionCheck();
     void printDebugInfo();
     #ifdef BOARD_HAS_ECCX08
     int begin(TcpIpConnectionHandler & connection, String brokerAddress = DEFAULT_BROKER_ADDRESS_SECURE_AUTH, uint16_t brokerPort = DEFAULT_BROKER_PORT_SECURE_AUTH);

--- a/src/ArduinoIoTCloudTCP.h
+++ b/src/ArduinoIoTCloudTCP.h
@@ -95,6 +95,9 @@ class ArduinoIoTCloudTCP: public ArduinoIoTCloudClass {
     TcpIpConnectionHandler * _connection;
     String _brokerAddress;
     uint16_t _brokerPort;
+    uint8_t _mqtt_data_buf[MQTT_TRANSMIT_BUFFER_SIZE];
+    int _mqtt_data_len;
+    bool _mqtt_data_request_retransmit;
 
     #ifdef BOARD_HAS_ECCX08
     BearSSLClient* _sslClient;


### PR DESCRIPTION
This fixes #96.

The TCP load balancer of the Arduino IoT Cloud terminates a TCP connnection after 350 seconds. Unfortunately this termination is only detected after transmitting the next data set to the Arduino IoT Cloud. This has the unfortunate side effect that the data set sent to the cloud is lost. This change buffers every transmission to the server and requests a retransmission in case of loosing the connection.

**Note**: This can only happen if the keep-alive interval is set to a value > 350 seconds, e.g. to 1 hour:
```C++
_mqttClient->setKeepAliveInterval(60 * 60 * 1000);
```