### PR TITLE
Remove call to function init which is anyway implemented empty in LoRa_ConnectionHandler

### DIFF
--- a/src/ArduinoIoTCloudLPWAN.cpp
+++ b/src/ArduinoIoTCloudLPWAN.cpp
@@ -48,7 +48,6 @@ int ArduinoIoTCloudLPWAN::connected() {
 
 int ArduinoIoTCloudLPWAN::begin(ConnectionHandler& connection, bool retry) {
   _connection = &connection;
-  _connection->init();
   _retryEnable = retry;
   _maxNumRetry = 5;
   _intervalRetry = 1000;


### PR DESCRIPTION
See [here](https://github.com/arduino-libraries/Arduino_ConnectionHandler/blob/9f42a6cb2c05cf9da54e1a892716c73b853ab8d5/src/Arduino_LoRaConnectionHandler.cpp#L51:L52).