### PR TITLE
Reduce public API by turning connect/disconnect into protected methods.

### DIFF
--- a/src/ArduinoIoTCloud.h
+++ b/src/ArduinoIoTCloud.h
@@ -133,7 +133,7 @@ class ArduinoIoTCloudClass
   protected:
 
     virtual int  connect   () = 0;
-    virtual bool disconnect() = 0;
+    virtual void disconnect() = 0;
 
     inline ArduinoIoTConnectionStatus getIoTStatus() { return _iot_status; }
 

--- a/src/ArduinoIoTCloud.h
+++ b/src/ArduinoIoTCloud.h
@@ -81,8 +81,6 @@ class ArduinoIoTCloudClass
     virtual ~ArduinoIoTCloudClass() { }
 
 
-    virtual int  connect       () = 0;
-    virtual bool disconnect    () = 0;
     virtual void update        () = 0;
     virtual int  connected     () = 0;
     virtual void printDebugInfo() = 0;
@@ -133,6 +131,9 @@ class ArduinoIoTCloudClass
     ArduinoCloudProperty& addPropertyReal(String& property, String name, Permission const permission);
 
   protected:
+
+    virtual int  connect   () = 0;
+    virtual bool disconnect() = 0;
 
     inline ArduinoIoTConnectionStatus getIoTStatus() { return _iot_status; }
 

--- a/src/ArduinoIoTCloudLPWAN.cpp
+++ b/src/ArduinoIoTCloudLPWAN.cpp
@@ -114,10 +114,9 @@ int ArduinoIoTCloudLPWAN::connect()
   return 1;
 }
 
-bool ArduinoIoTCloudLPWAN::disconnect()
+void ArduinoIoTCloudLPWAN::disconnect()
 {
   _connection->disconnect();
-  return true;
 }
 
 /******************************************************************************

--- a/src/ArduinoIoTCloudLPWAN.cpp
+++ b/src/ArduinoIoTCloudLPWAN.cpp
@@ -47,18 +47,6 @@ ArduinoIoTCloudLPWAN::ArduinoIoTCloudLPWAN()
  * PUBLIC MEMBER FUNCTIONS
  ******************************************************************************/
 
-int ArduinoIoTCloudLPWAN::connect()
-{
-  _connection->connect();
-  return 1;
-}
-
-bool ArduinoIoTCloudLPWAN::disconnect()
-{
-  _connection->disconnect();
-  return true;
-}
-
 int ArduinoIoTCloudLPWAN::connected()
 {
   return (_connection->getStatus() == NetworkConnectionState::CONNECTED) ? 1 : 0;
@@ -114,6 +102,22 @@ void ArduinoIoTCloudLPWAN::printDebugInfo()
 {
   Debug.print(DBG_INFO, "***** Arduino IoT Cloud LPWAN - configuration info *****");
   Debug.print(DBG_INFO, "Thing ID: %s", getThingId().c_str());
+}
+
+/******************************************************************************
+ * PROTECTED MEMBER FUNCTIONS
+ ******************************************************************************/
+
+int ArduinoIoTCloudLPWAN::connect()
+{
+  _connection->connect();
+  return 1;
+}
+
+bool ArduinoIoTCloudLPWAN::disconnect()
+{
+  _connection->disconnect();
+  return true;
 }
 
 /******************************************************************************

--- a/src/ArduinoIoTCloudLPWAN.h
+++ b/src/ArduinoIoTCloudLPWAN.h
@@ -53,7 +53,7 @@ class ArduinoIoTCloudLPWAN : public ArduinoIoTCloudClass
   protected:
 
     virtual int  connect       () override;
-    virtual bool disconnect    () override;
+    virtual void disconnect    () override;
 
 
   private:

--- a/src/ArduinoIoTCloudLPWAN.h
+++ b/src/ArduinoIoTCloudLPWAN.h
@@ -35,8 +35,6 @@ class ArduinoIoTCloudLPWAN : public ArduinoIoTCloudClass
              ArduinoIoTCloudLPWAN();
     virtual ~ArduinoIoTCloudLPWAN() { }
 
-    virtual int  connect       () override;
-    virtual bool disconnect    () override;
     virtual void update        () override;
     virtual int  connected     () override;
     virtual void printDebugInfo() override;
@@ -50,6 +48,12 @@ class ArduinoIoTCloudLPWAN : public ArduinoIoTCloudClass
     inline void enableRetry     (bool val) { _retryEnable = val; }
     inline void setMaxRetry     (int val)  { _maxNumRetry = val; }
     inline void setIntervalRetry(long val) { _intervalRetry = val; }
+
+
+  protected:
+
+    virtual int  connect       () override;
+    virtual bool disconnect    () override;
 
 
   private:

--- a/src/ArduinoIoTCloudTCP.cpp
+++ b/src/ArduinoIoTCloudTCP.cpp
@@ -207,19 +207,13 @@ int ArduinoIoTCloudTCP::reconnect()
 
 int ArduinoIoTCloudTCP::connect()
 {
-  if (!_mqttClient->connect(_brokerAddress.c_str(), _brokerPort)) {
-    return CONNECT_FAILURE;
-  }
-  if (_mqttClient->subscribe(_stdinTopic) == 0) {
-    return CONNECT_FAILURE_SUBSCRIBE;
-  }
-  if (_mqttClient->subscribe(_dataTopicIn) == 0) {
-    return CONNECT_FAILURE_SUBSCRIBE;
-  }
-  if (_shadowTopicIn != "") {
-    if (_mqttClient->subscribe(_shadowTopicIn) == 0) {
-      return CONNECT_FAILURE_SUBSCRIBE;
-    }
+  if (!_mqttClient->connect(_brokerAddress.c_str(), _brokerPort)) return CONNECT_FAILURE;
+  if (_mqttClient->subscribe(_stdinTopic) == 0)                   return CONNECT_FAILURE_SUBSCRIBE;
+  if (_mqttClient->subscribe(_dataTopicIn) == 0)                  return CONNECT_FAILURE_SUBSCRIBE;
+
+  if (_shadowTopicIn != "")
+  {
+    if (_mqttClient->subscribe(_shadowTopicIn) == 0)              return CONNECT_FAILURE_SUBSCRIBE;
     _syncStatus = ArduinoIoTSynchronizationStatus::SYNC_STATUS_WAIT_FOR_CLOUD_VALUES;
     _lastSyncRequestTickTime = 0;
   }

--- a/src/ArduinoIoTCloudTCP.cpp
+++ b/src/ArduinoIoTCloudTCP.cpp
@@ -227,10 +227,9 @@ int ArduinoIoTCloudTCP::connect()
   return CONNECT_SUCCESS;
 }
 
-bool ArduinoIoTCloudTCP::disconnect()
+void ArduinoIoTCloudTCP::disconnect()
 {
   _mqttClient->stop();
-  return true;
 }
 
 /******************************************************************************

--- a/src/ArduinoIoTCloudTCP.cpp
+++ b/src/ArduinoIoTCloudTCP.cpp
@@ -141,35 +141,6 @@ int ArduinoIoTCloudTCP::begin(String brokerAddress, uint16_t brokerPort)
   return 1;
 }
 
-int ArduinoIoTCloudTCP::connect()
-{
-  if (!_mqttClient->connect(_brokerAddress.c_str(), _brokerPort)) {
-    return CONNECT_FAILURE;
-  }
-  if (_mqttClient->subscribe(_stdinTopic) == 0) {
-    return CONNECT_FAILURE_SUBSCRIBE;
-  }
-  if (_mqttClient->subscribe(_dataTopicIn) == 0) {
-    return CONNECT_FAILURE_SUBSCRIBE;
-  }
-  if (_shadowTopicIn != "") {
-    if (_mqttClient->subscribe(_shadowTopicIn) == 0) {
-      return CONNECT_FAILURE_SUBSCRIBE;
-    }
-    _syncStatus = ArduinoIoTSynchronizationStatus::SYNC_STATUS_WAIT_FOR_CLOUD_VALUES;
-    _lastSyncRequestTickTime = 0;
-  }
-
-  return CONNECT_SUCCESS;
-}
-
-
-bool ArduinoIoTCloudTCP::disconnect()
-{
-  _mqttClient->stop();
-  return true;
-}
-
 void ArduinoIoTCloudTCP::update()
 {
   // Check if a primitive property wrapper is locally changed
@@ -209,6 +180,11 @@ void ArduinoIoTCloudTCP::update()
   }
 }
 
+int ArduinoIoTCloudTCP::connected()
+{
+  return _mqttClient->connected();
+}
+
 void ArduinoIoTCloudTCP::printDebugInfo()
 {
   Debug.print(DBG_INFO, "***** Arduino IoT Cloud - configuration info *****");
@@ -225,10 +201,36 @@ int ArduinoIoTCloudTCP::reconnect()
   return connect();
 }
 
+/******************************************************************************
+ * PROTECTED MEMBER FUNCTIONS
+ ******************************************************************************/
 
-int ArduinoIoTCloudTCP::connected()
+int ArduinoIoTCloudTCP::connect()
 {
-  return _mqttClient->connected();
+  if (!_mqttClient->connect(_brokerAddress.c_str(), _brokerPort)) {
+    return CONNECT_FAILURE;
+  }
+  if (_mqttClient->subscribe(_stdinTopic) == 0) {
+    return CONNECT_FAILURE_SUBSCRIBE;
+  }
+  if (_mqttClient->subscribe(_dataTopicIn) == 0) {
+    return CONNECT_FAILURE_SUBSCRIBE;
+  }
+  if (_shadowTopicIn != "") {
+    if (_mqttClient->subscribe(_shadowTopicIn) == 0) {
+      return CONNECT_FAILURE_SUBSCRIBE;
+    }
+    _syncStatus = ArduinoIoTSynchronizationStatus::SYNC_STATUS_WAIT_FOR_CLOUD_VALUES;
+    _lastSyncRequestTickTime = 0;
+  }
+
+  return CONNECT_SUCCESS;
+}
+
+bool ArduinoIoTCloudTCP::disconnect()
+{
+  _mqttClient->stop();
+  return true;
 }
 
 /******************************************************************************

--- a/src/ArduinoIoTCloudTCP.h
+++ b/src/ArduinoIoTCloudTCP.h
@@ -53,8 +53,7 @@ class ArduinoIoTCloudTCP: public ArduinoIoTCloudClass
              ArduinoIoTCloudTCP();
     virtual ~ArduinoIoTCloudTCP();
 
-    virtual int  connect       () override;
-    virtual bool disconnect    () override;
+
     virtual void update        () override;
     virtual int  connected     () override;
     virtual void printDebugInfo() override;
@@ -78,6 +77,13 @@ class ArduinoIoTCloudTCP: public ArduinoIoTCloudClass
     int reconnect();
 
     friend class CloudSerialClass;
+
+
+  protected:
+
+    virtual int  connect       () override;
+    virtual bool disconnect    () override;
+
 
   private:
     static const int MQTT_TRANSMIT_BUFFER_SIZE = 256;

--- a/src/ArduinoIoTCloudTCP.h
+++ b/src/ArduinoIoTCloudTCP.h
@@ -82,7 +82,7 @@ class ArduinoIoTCloudTCP: public ArduinoIoTCloudClass
   protected:
 
     virtual int  connect       () override;
-    virtual bool disconnect    () override;
+    virtual void disconnect    () override;
 
 
   private:


### PR DESCRIPTION
The public `ArduinoIoTCloud` member methods `connect` and `disconnect` should not be called by the user of the library (they are called internally) and are therefore transformed to `protected` member functions. In the future a `end` function should be added (see #73) which works the opposite way to the the `begin` method and cleans everything up.