### PR TITLE
Report memory usage change caused by PRs

### DIFF
--- a/.github/workflows/compile-examples.yml
+++ b/.github/workflows/compile-examples.yml
@@ -48,3 +48,12 @@ jobs:
           fqbn: ${{ matrix.board.fqbn }}
           libraries: "${{ env.UNIVERSAL_LIBRARIES }} ${{ env[format('{0}{1}', matrix.board.type, '_LIBRARIES')] }}"
           sketch-paths: "${{ env.UNIVERSAL_SKETCH_PATHS }} ${{ env[format('{0}{1}', matrix.board.type, '_SKETCH_PATHS')] }}"
+          size-report-sketch: 'ArduinoIoTCloud_Travis_CI'
+          enable-size-deltas-report: 'true'
+
+      - name: Save memory usage change report as artifact
+        if: github.event_name == 'pull_request'
+        uses: actions/upload-artifact@v1
+        with:
+          name: 'size-deltas-reports'
+          path: 'size-deltas-reports'

--- a/.github/workflows/report-size-deltas.yml
+++ b/.github/workflows/report-size-deltas.yml
@@ -1,0 +1,11 @@
+on:
+  schedule:
+    - cron:  '*/5 * * * *'
+
+jobs:
+  report:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Comment size deltas reports to PRs
+        uses: arduino/actions/libraries/report-size-deltas@master


### PR DESCRIPTION
On every push to a pull request, the change in memory usage of `examples/utility/ArduinoIoTCloud_Travis_CI` between the PR's head and base branch for each of the boards in the board matrix will be:
- Shown in the log
- Saved to a workflow artifact (you can see the artifact for this PR's run here: https://github.com/arduino-libraries/ArduinoIoTCloud/pull/116/checks?check_run_id=594325065)
- Commented to the PR's thread as a table (after a delay of ~7 minutes max.)

Demo:
https://github.com/per1234/ArduinoIoTCloud/pull/1#issuecomment-614684874

Partial fix for https://github.com/arduino-libraries/ArduinoIoTCloud/issues/112 (still need to add size trends reporting)