### PR TITLE
Add GitHub Actions workflow to run unit tests and check code coverage

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -1,0 +1,48 @@
+name: Unit Tests
+
+on:
+  pull_request:
+    paths:
+      - ".github/workflows/unit-tests.yml"
+      - 'extras/test/**'
+      - 'src/**'
+
+  push:
+    paths:
+      - ".github/workflows/unit-tests.yml"
+      - 'extras/test/**'
+      - 'src/**'
+
+jobs:
+  test:
+    name: Run unit tests
+    runs-on: ubuntu-latest
+
+    env:
+      BUILD_PATH: "${{ github.workspace }}/extras/test/build"
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Run unit tests
+        run: |
+          mkdir "$BUILD_PATH"
+          cd "$BUILD_PATH"
+          cmake ..
+          make
+          bin/testArduinoIoTCloud
+
+      - name: Check code coverage
+        run: |
+          cd "$BUILD_PATH"
+          sudo apt-get --assume-yes install lcov > /dev/null
+          lcov --directory . --capture --output-file coverage.info
+          lcov --quiet --remove coverage.info '*/extras/test/*' '/usr/*' --output-file coverage.info
+          lcov --list coverage.info
+
+      - name: Upload coverage report to Codecov
+        uses: codecov/codecov-action@v1
+        with:
+          file: "${{ env.BUILD_PATH }}/coverage.info"
+          fail_ci_if_error: true

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 =================
 [![Compile Examples](https://github.com/arduino-libraries/ArduinoIoTCloud/workflows/Compile%20Examples/badge.svg)](https://github.com/arduino-libraries/ArduinoIoTCloud/actions?workflow=Compile+Examples)
 [![Spell Check](https://github.com/arduino-libraries/ArduinoIoTCloud/workflows/Spell%20Check/badge.svg)](https://github.com/arduino-libraries/ArduinoIoTCloud/actions?workflow=Spell+Check)
+[![Unit Tests](https://github.com/arduino-libraries/ArduinoIoTCloud/workflows/Unit%20Tests/badge.svg)](https://github.com/arduino-libraries/ArduinoIoTCloud/actions?workflow=Unit+Tests)
+[![codecov](https://codecov.io/gh/arduino-libraries/ArduinoIoTCloud/branch/master/graph/badge.svg)](https://codecov.io/gh/arduino-libraries/ArduinoIoTCloud)
 
 ### What?
 The `ArduinoIoTCloud` library is the central element of the firmware enabling certain Arduino boards to connect to the [Arduino IoT Cloud](https://www.arduino.cc/en/IoT/HomePage). The following boards are supported:

--- a/extras/test/CMakeLists.txt
+++ b/extras/test/CMakeLists.txt
@@ -36,6 +36,9 @@ set(TEST_SRCS
 add_compile_definitions(HOST)
 add_compile_options(-Wall -Wextra -Wpedantic -Werror)
 
+set(CMAKE_C_FLAGS   ${CMAKE_C_FLAGS}   "--coverage")
+set(CMAKE_CXX_FLAGS ${CMAKE_CXX_FLAGS} "--coverage")
+
 ##########################################################################
 
 add_executable(


### PR DESCRIPTION
On every pull request or push that changes relevant files (anything under `extras/test/` or `src/`):
- Run unit tests
- Print coverage report to the workflow log
- Upload coverage report to Codecov

This PR is dependent on https://github.com/arduino-libraries/ArduinoIoTCloud/pull/118. The workflow is currently expected to fail because the unit tests won't be added until https://github.com/arduino-libraries/ArduinoIoTCloud/pull/118 is merged.

Demonstration:
https://github.com/per1234/ArduinoIoTCloud/runs/646210541?check_suite_focus=true

https://codecov.io/github/per1234/ArduinoIoTCloud/commit/77fe90bb786f3e0843cb03b2839d1fd58c94995e

Fixes https://github.com/arduino-libraries/ArduinoIoTCloud/issues/119