### PR TITLE
Improve board-specific configuration system in compile-examples CI workflow

### DIFF
--- a/.github/workflows/compile-examples.yml
+++ b/.github/workflows/compile-examples.yml
@@ -17,36 +17,52 @@ jobs:
     runs-on: ubuntu-latest
 
     env:
-      # libraries to install
+      # libraries to install for all boards
       UNIVERSAL_LIBRARIES: '"ArduinoCloudThing" "Arduino_ConnectionHandler" "Arduino_DebugUtils" "ArduinoMqttClient"'
-      # board-specific libraries
-      WIFI_LIBRARIES: '"ArduinoBearSSL" "ArduinoECCX08" "RTCZero" "WiFi101" "WiFiNINA"'
-      WAN_LIBRARIES: '"ArduinoBearSSL" "ArduinoECCX08" "RTCZero" "MKRWAN"'
-      GSM_LIBRARIES: '"ArduinoBearSSL" "ArduinoECCX08" "RTCZero" "MKRGSM"'
-      NB_LIBRARIES: '"ArduinoBearSSL" "ArduinoECCX08" "RTCZero" "MKRNB"'
-      ESP8266_LIBRARIES: ''
-      # sketch paths to compile (recursive)
+      # sketch paths to compile (recursive) for all boards
       UNIVERSAL_SKETCH_PATHS: '"examples/ArduinoIoTCloud-Advanced" "examples/ArduinoIoTCloud-Basic" "examples/utility/ArduinoIoTCloud_Travis_CI"'
-      # board-specific sketches
-      WIFI_SKETCH_PATHS: '"examples/utility/Provisioning" "examples/utility/WiFi_Cloud_Blink"'
-      WAN_SKETCH_PATHS: ''
-      GSM_SKETCH_PATHS: '"examples/utility/Provisioning" "examples/utility/GSM_Cloud_Blink"'
-      NB_SKETCH_PATHS: '"examples/utility/Provisioning" "examples/utility/NB_Cloud_Blink"'
-      ESP8266_SKETCH_PATHS: '"examples/utility/WiFi_Cloud_Blink_with_security_credentials"'
 
     strategy:
       fail-fast: false
 
       matrix:
         board: [
-          {"fqbn": "arduino:samd:mkr1000", "type": "WIFI"},
-          {"fqbn": "arduino:samd:mkrwifi1010", "type": "WIFI"},
-          {"fqbn": "arduino:samd:nano_33_iot", "type": "WIFI"},
-          {"fqbn": "arduino:samd:mkrwan1300", "type": "WAN"},
-          {"fqbn": "arduino:samd:mkrgsm1400", "type": "GSM"},
-          {"fqbn": "arduino:samd:mkrnb1500", "type": "NB"},
-          {"fqbn": '"esp8266:esp8266:huzzah" "https://arduino.esp8266.com/stable/package_esp8266com_index.json"', "type": "ESP8266"}
+          {"fqbn": "arduino:samd:mkr1000", "type": "wifi"},
+          {"fqbn": "arduino:samd:mkrwifi1010", "type": "wifi"},
+          {"fqbn": "arduino:samd:nano_33_iot", "type": "wifi"},
+          {"fqbn": "arduino:samd:mkrwan1300", "type": "wan"},
+          {"fqbn": "arduino:samd:mkrgsm1400", "type": "gsm"},
+          {"fqbn": "arduino:samd:mkrnb1500", "type": "nb"},
+          {"fqbn": '"esp8266:esp8266:huzzah" "https://arduino.esp8266.com/stable/package_esp8266com_index.json"', "type": "esp8266"}
         ]
+
+        # make board type-specific customizations to the matrix jobs
+        include:
+          # WiFi boards
+          - board:
+              type: "wifi"
+            libraries: '"ArduinoBearSSL" "ArduinoECCX08" "RTCZero" "WiFi101" "WiFiNINA"'
+            sketch-paths: '"examples/utility/Provisioning" "examples/utility/WiFi_Cloud_Blink"'
+          # LoRaWAN boards
+          - board:
+              type: "wan"
+            libraries: '"ArduinoBearSSL" "ArduinoECCX08" "RTCZero" "MKRWAN"'
+            sketch-paths:
+          # GSM boards
+          - board:
+              type: "gsm"
+            libraries: '"ArduinoBearSSL" "ArduinoECCX08" "RTCZero" "MKRGSM"'
+            sketch-paths: '"examples/utility/Provisioning" "examples/utility/GSM_Cloud_Blink"'
+          # NB boards
+          - board:
+              type: "nb"
+            libraries: '"ArduinoBearSSL" "ArduinoECCX08" "RTCZero" "MKRNB"'
+            sketch-paths: '"examples/utility/Provisioning" "examples/utility/NB_Cloud_Blink"'
+          # ESP8266 boards
+          - board:
+              type: "esp8266"
+            libraries:
+            sketch-paths: '"examples/utility/WiFi_Cloud_Blink_with_security_credentials"'
 
     steps:
       - name: Checkout
@@ -56,8 +72,8 @@ jobs:
         uses: arduino/actions/libraries/compile-examples@master
         with:
           fqbn: ${{ matrix.board.fqbn }}
-          libraries: "${{ env.UNIVERSAL_LIBRARIES }} ${{ env[format('{0}{1}', matrix.board.type, '_LIBRARIES')] }}"
-          sketch-paths: "${{ env.UNIVERSAL_SKETCH_PATHS }} ${{ env[format('{0}{1}', matrix.board.type, '_SKETCH_PATHS')] }}"
+          libraries: "${{ env.UNIVERSAL_LIBRARIES }} ${{ matrix.libraries }}"
+          sketch-paths: "${{ env.UNIVERSAL_SKETCH_PATHS }} ${{ matrix.sketch-paths }}"
           size-report-sketch: 'ArduinoIoTCloud_Travis_CI'
           enable-size-deltas-report: 'true'
 


### PR DESCRIPTION
Use the matrix.include key to customize the compile-examples CI workflow's matrix jobs with board type-specific configurations.

This GitHub Actions feature allows defining additional properties for matrix jobs that match the filter:
https://help.github.com/en/actions/reference/workflow-syntax-for-github-actions#jobsjob_idstrategymatrix

The previous approach for doing this was to use generated environment variable names, which worked but seemed likely to be confusing for anyone trying to decipher the workflow. I think the new approach is a little easier to understand and less hacky.

I had hoped this would allow me to do away with the `board.type` system, but supplying lists of values to the filter keys isn't supported, you can't reference the `env` key from matrix, and YAML anchors aren't supported by GitHub Actions. So the `board.type` system remains the only way I can see to avoid redefining the configuration options for each board of the same type.