### PR TITLE
Add size trends report step to CI workflow

### DIFF
--- a/.github/workflows/compile-examples.yml
+++ b/.github/workflows/compile-examples.yml
@@ -77,6 +77,14 @@ jobs:
           size-report-sketch: 'ArduinoIoTCloud_Travis_CI'
           enable-size-deltas-report: 'true'
 
+      - name: Write data to size trends report spreadsheet
+        # Update report on every push to the master branch
+        if: github.event_name == 'push' && github.ref == 'refs/heads/master'
+        uses: arduino/actions/libraries/report-size-trends@master
+        with:
+          google-key-file: ${{ secrets.GOOGLE_KEY_FILE }}
+          spreadsheet-id: 1I6NZkpZpf8KugBkE92adB1Z3_b7ZepOpCdYTOigJpN4
+
       - name: Save memory usage change report as artifact
         if: github.event_name == 'pull_request'
         uses: actions/upload-artifact@v1


### PR DESCRIPTION
On every push to the master branch, size data will be written to a Google Sheets spreadsheet.

This information will allow tracking the trends in memory usage over time.

The first row of data (in addition to the column headings row) should written to [the spreadsheet](https://docs.google.com/spreadsheets/d/1I6NZkpZpf8KugBkE92adB1Z3_b7ZepOpCdYTOigJpN4) when this PR is merged.

---
Question: do you think it's best to have a single spreadsheet for the size trends reports for all repositories (one sheet in the spreadsheet per repository), or a separate spreadsheet for each repository. The former seems more convenient, but my concern is that we could hit some limit at a distant date in the future when there are lots of repositories with trends reports. The latter results in more clutter by having multiple spreadsheets.

If we are planning to go with the single spreadsheet approach, I'd add the `sheet-name: ArduinoIoTCloud` input to the workflow in this PR.