### PR TITLE
Refresh spell check CI workflow

### DIFF
--- a/.github/workflows/spell-check.yml
+++ b/.github/workflows/spell-check.yml
@@ -14,4 +14,4 @@ jobs:
         uses: arduino/actions/libraries/spell-check@master
         with:
           ignore-words-list: extras/codespell-ignore-words-list.txt
-            skip-paths: ./extras/test/external
+          skip-paths: ./extras/test/external

--- a/.github/workflows/spell-check.yml
+++ b/.github/workflows/spell-check.yml
@@ -14,4 +14,4 @@ jobs:
         uses: arduino/actions/libraries/spell-check@master
         with:
           ignore-words-list: extras/codespell-ignore-words-list.txt
-          skip-paths: ./extras/test/external
+          skip-paths: ./extras/test/external,./src/cbor/lib/tinycbor

--- a/extras/codespell-ignore-words-list.txt
+++ b/extras/codespell-ignore-words-list.txt
@@ -4,3 +4,4 @@ atleast
 derrived
 aline
 anid
+alocation

--- a/extras/codespell-ignore-words-list.txt
+++ b/extras/codespell-ignore-words-list.txt
@@ -1,7 +1,2 @@
 wan
-nd
-atleast
-derrived
-aline
-anid
 alocation

--- a/src/property/PropertyContainer.cpp
+++ b/src/property/PropertyContainer.cpp
@@ -48,7 +48,7 @@ void PropertyContainer::begin(GetTimeCallbackFunc func)
 
 Property & PropertyContainer::addPropertyReal(Property & property, String const & name, Permission const permission, int propertyIdentifier)
 {
-  /* Check wether or not the property already has been added to the container */
+  /* Check whether or not the property already has been added to the container */
   Property * p = getProperty(name);
   if(p != nullptr) return (*p);
 


### PR DESCRIPTION
- Fix workflow format
- Fix misspelled word in comment that would cause the check to fail
- Exclude externally maintained resource folder that contains misspelled words
- Add name causing a false positive to the ignore list
- Remove entries from ignore list that are no longer needed now that it's possible to ignore paths containing externally maintained resources