### PR TITLE
Additional update policy "OnDemand"

### DIFF
--- a/src/ArduinoIoTCloud.cpp
+++ b/src/ArduinoIoTCloud.cpp
@@ -25,6 +25,11 @@
  * PUBLIC MEMBER FUNCTIONS
  ******************************************************************************/
 
+void ArduinoIoTCloudClass::push()
+{
+  _property_container.requestUpdateForAllProperties();
+}
+
 void ArduinoIoTCloudClass::addCallback(ArduinoIoTCloudEvent const event, OnCloudEventCallback callback)
 {
   _cloud_event_callback[static_cast<size_t>(event)] = callback;

--- a/src/ArduinoIoTCloud.h
+++ b/src/ArduinoIoTCloud.h
@@ -87,6 +87,8 @@ class ArduinoIoTCloudClass
     virtual int  connected     () = 0;
     virtual void printDebugInfo() = 0;
 
+            void push();
+
     inline void     setThingId (String const thing_id)  { _thing_id = thing_id; };
     inline String & getThingId ()                       { return _thing_id; };
     inline void     setDeviceId(String const device_id) { _device_id = device_id; };

--- a/src/property/Property.h
+++ b/src/property/Property.h
@@ -117,7 +117,7 @@ enum class Type {
 };
 
 enum class UpdatePolicy {
-  OnChange, TimeInterval
+  OnChange, TimeInterval, OnDemand
 };
 
 typedef void(*UpdateCallbackFunc)(void);
@@ -138,6 +138,7 @@ class Property {
     Property & onSync(SyncCallbackFunc func);
     Property & publishOnChange(float const min_delta_property, unsigned long const min_time_between_updates_millis = 0);
     Property & publishEvery(unsigned long const seconds);
+    Property & publishOnDemand();
 
     inline String name() const {
       return _name;
@@ -153,6 +154,7 @@ class Property {
     }
 
     bool shouldBeUpdated();
+    void requestUpdate();
     void execCallbackOnChange();
     void execCallbackOnSync();
     void setLastCloudChangeTimestamp(unsigned long cloudChangeTime);
@@ -211,6 +213,8 @@ class Property {
     int                _attributeIdentifier;
     /* Indicates if the property shall be encoded using the identifier instead of the name */
     bool               _lightPayload;
+    /* Indicates whether a property update has been requested in case of the OnDemand update policy. */
+    bool               _update_requested;
 };
 
 /******************************************************************************

--- a/src/property/PropertyContainer.cpp
+++ b/src/property/PropertyContainer.cpp
@@ -112,6 +112,16 @@ int PropertyContainer::appendChangedProperties(CborEncoder * arrayEncoder, bool 
   return appendedProperties;
 }
 
+void PropertyContainer::requestUpdateForAllProperties()
+{
+  std::for_each(_property_list.begin(),
+                _property_list.end(),
+                [](Property * p)
+                {
+                  p->requestUpdate();
+                });
+}
+
 void PropertyContainer::updateTimestampOnLocallyChangedProperties()
 {
   /* This function updates the timestamps on the primitive properties 

--- a/src/property/PropertyContainer.h
+++ b/src/property/PropertyContainer.h
@@ -52,6 +52,7 @@ public:
 
   int appendChangedProperties(CborEncoder * arrayEncoder, bool lightPayload);
   void updateTimestampOnLocallyChangedProperties();
+  void requestUpdateForAllProperties();
 
 
 


### PR DESCRIPTION
This new update policy allows to trigger the transmission of all properties when a certain function (`push`) is called. In order to configure a property for this update policy it must be initalized using the following syntax in `thing_properties.h`:
```C++
int seconds;
/* ... */
void initProperties()
{
  ArduinoCloud.addProperty(seconds, Permission::Read).publishOnDemand();
```
In order to trigger the update the `ArduinoCloud.pushAll()` needs to be called. All properties are transmitted on the next call of `ArduinoCloud.update()`.
```C++
void loop()
{
  /* ... */
  ArduinoCloud.update();
  /* ... */
  ArduinoCloud.pushAll();
}
```
Successfully tested on PROD with
* `MKR WiFi 1010` :heavy_check_mark: 
* `MKR 1000` :heavy_check_mark: 
* `ESP8266` :heavy_check_mark: 
