### PR TITLE
Use temporary file for storing the downloaded OTA image.

### DIFF
--- a/src/utility/ota/OTALogic.h
+++ b/src/utility/ota/OTALogic.h
@@ -45,17 +45,18 @@ static size_t const MQTT_OTA_BUF_SIZE = 256;
 
 enum class OTAState
 {
-  Init, Idle, StartDownload, WaitForHeader, HeaderReceived, WaitForBinary, BinaryReceived, Verify, Reset, Error
+  Init, Idle, StartDownload, WaitForHeader, HeaderReceived, WaitForBinary, BinaryReceived, Verify, Rename, Reset, Error
 };
 
 enum class OTAError : int
 {
-  None                = 0,
-  StorageInitFailed   = 1,
-  StorageOpenFailed   = 2,
-  StorageWriteFailed  = 3,
-  ChecksumMismatch    = 4,
-  ReceivedDataOverrun = 5
+  None                   = 0,
+  StorageInitFailed      = 1,
+  StorageOpenFailed      = 2,
+  StorageWriteFailed     = 3,
+  ChecksumMismatch       = 4,
+  ReceivedDataOverrun    = 5,
+  RenameOfTempFileFailed = 6
 };
 
 /******************************************************************************
@@ -114,6 +115,7 @@ private:
   OTAState handle_WaitForBinary();
   OTAState handle_BinaryReceived();
   OTAState handle_Verify();
+  OTAState handle_Rename();
   OTAState handle_Reset();
 
   void init_mqtt_ota_buffer();

--- a/src/utility/ota/OTAStorage.h
+++ b/src/utility/ota/OTAStorage.h
@@ -45,10 +45,11 @@ public:
 
   virtual Type   type  () = 0;
   virtual bool   init  () = 0;
-  virtual bool   open  () = 0;
+  virtual bool   open  (char const * file_name) = 0;
   virtual size_t write (uint8_t const * const buf, size_t const num_bytes) = 0;
   virtual void   close () = 0;
-  virtual void   remove() = 0;
+  virtual void   remove(char const * file_name) = 0;
+  virtual bool   rename(char const * old_file_name, char const * new_file_name) = 0;
   virtual void   deinit() = 0;
 
 };

--- a/src/utility/ota/OTAStorage_MKRMEM.cpp
+++ b/src/utility/ota/OTAStorage_MKRMEM.cpp
@@ -54,10 +54,10 @@ bool OTAStorage_MKRMEM::init()
   return true;
 }
 
-bool OTAStorage_MKRMEM::open()
+bool OTAStorage_MKRMEM::open(char const * file_name)
 {
   filesystem.clearerr();
-  _file = new File(filesystem.open("UPDATE.BIN", CREATE | WRITE_ONLY| TRUNCATE));
+  _file = new File(filesystem.open(file_name, CREATE | WRITE_ONLY| TRUNCATE));
   if(SPIFFS_OK != filesystem.err()) {
     Debug.print(DBG_ERROR, "OTAStorage_MKRMEM::open - open() failed with error code %d", filesystem.err());
     delete _file;
@@ -77,9 +77,14 @@ void OTAStorage_MKRMEM::close()
   delete _file;
 }
 
-void OTAStorage_MKRMEM::remove()
+void OTAStorage_MKRMEM::remove(char const * file_name)
 {
-  filesystem.remove("UPDATE.BIN");
+  filesystem.remove(file_name);
+}
+
+bool OTAStorage_MKRMEM::rename(char const * old_file_name, char const * new_file_name)
+{
+  return (SPIFFS_OK == filesystem.rename(old_file_name, new_file_name));
 }
 
 void OTAStorage_MKRMEM::deinit()

--- a/src/utility/ota/OTAStorage_MKRMEM.h
+++ b/src/utility/ota/OTAStorage_MKRMEM.h
@@ -43,10 +43,11 @@ public:
 
   virtual Type   type  () override { return Type::MKRMEM; }
   virtual bool   init  () override;
-  virtual bool   open  () override;
+  virtual bool   open  (char const * file_name) override;
   virtual size_t write (uint8_t const * const buf, size_t const num_bytes) override;
   virtual void   close () override;
-  virtual void   remove() override;
+  virtual void   remove(char const * file_name) override;
+  virtual bool   rename(char const * old_file_name, char const * new_file_name) override;
   virtual void   deinit() override;
 
 


### PR DESCRIPTION
This PR adds an additional "rename" step where the file used for storing the downloaded OTA image ("UPDATE.BIN.TMP") is renamed to the one expected by the [SFU](https://github.com/arduino/ArduinoCore-samd/tree/master/libraries/SFU) ("UPDATE.BIN"). This step is **only performed** when a **complete OTA image with valid checksum** has been received. As a result this PR prevents the failure scenario of the device being turned off during reception of the update image.

@manchoz :wave: