### PR TITLE
Renaming OTAStorage_MKRMEM to OTAStorage_SFU …

### DIFF
--- a/src/ArduinoIoTCloudTCP.cpp
+++ b/src/ArduinoIoTCloudTCP.cpp
@@ -30,7 +30,7 @@
 #endif
 
 #include "utility/ota/OTAStorage_SSU.h"
-#include "utility/ota/OTAStorage_MKRMEM.h"
+#include "utility/ota/OTAStorage_SFU.h"
 
 #include "cbor/CBOREncoder.h"
 
@@ -43,7 +43,7 @@ TimeService time_service;
 #if   OTA_STORAGE_SSU
   static OTAStorage_SSU ota_storage_ssu;
 #elif OTA_STORAGE_MKRMEM
-  static OTAStorage_MKRMEM ota_storage_sfu;
+  static OTAStorage_SFU ota_storage_sfu;
 #endif
 
 /******************************************************************************

--- a/src/utility/ota/OTAStorage_SFU.cpp
+++ b/src/utility/ota/OTAStorage_SFU.cpp
@@ -19,7 +19,7 @@
  * INCLUDE
  ******************************************************************************/
 
-#include "OTAStorage_MKRMEM.h"
+#include "OTAStorage_SFU.h"
 #if OTA_STORAGE_MKRMEM
 
 #include <Arduino_DebugUtils.h>
@@ -28,7 +28,7 @@
  * CTOR/DTOR
  ******************************************************************************/
 
-OTAStorage_MKRMEM::OTAStorage_MKRMEM()
+OTAStorage_SFU::OTAStorage_SFU()
 : _file{nullptr}
 {
 
@@ -38,56 +38,56 @@ OTAStorage_MKRMEM::OTAStorage_MKRMEM()
  * PUBLIC MEMBER FUNCTIONS
  ******************************************************************************/
 
-bool OTAStorage_MKRMEM::init()
+bool OTAStorage_SFU::init()
 {
   flash.begin();
   if(SPIFFS_OK != filesystem.mount()) {
-    Debug.print(DBG_ERROR, "OTAStorage_MKRMEM::init - mount() failed with error code %d", filesystem.err());
+    Debug.print(DBG_ERROR, "OTAStorage_SFU::init - mount() failed with error code %d", filesystem.err());
     return false;
   }
 
   if(SPIFFS_OK != filesystem.check()) {
-    Debug.print(DBG_ERROR, "OTAStorage_MKRMEM::init - check() failed with error code %d", filesystem.err());
+    Debug.print(DBG_ERROR, "OTAStorage_SFU::init - check() failed with error code %d", filesystem.err());
     return false;
   }
 
   return true;
 }
 
-bool OTAStorage_MKRMEM::open(char const * file_name)
+bool OTAStorage_SFU::open(char const * file_name)
 {
   filesystem.clearerr();
   _file = new File(filesystem.open(file_name, CREATE | WRITE_ONLY| TRUNCATE));
   if(SPIFFS_OK != filesystem.err()) {
-    Debug.print(DBG_ERROR, "OTAStorage_MKRMEM::open - open() failed with error code %d", filesystem.err());
+    Debug.print(DBG_ERROR, "OTAStorage_SFU::open - open() failed with error code %d", filesystem.err());
     delete _file;
     return false;
   }
   return true;
 }
 
-size_t OTAStorage_MKRMEM::write(uint8_t const * const buf, size_t const num_bytes)
+size_t OTAStorage_SFU::write(uint8_t const * const buf, size_t const num_bytes)
 {
   return _file->write(const_cast<uint8_t *>(buf), num_bytes);
 }
 
-void OTAStorage_MKRMEM::close()
+void OTAStorage_SFU::close()
 {
   _file->close();
   delete _file;
 }
 
-void OTAStorage_MKRMEM::remove(char const * file_name)
+void OTAStorage_SFU::remove(char const * file_name)
 {
   filesystem.remove(file_name);
 }
 
-bool OTAStorage_MKRMEM::rename(char const * old_file_name, char const * new_file_name)
+bool OTAStorage_SFU::rename(char const * old_file_name, char const * new_file_name)
 {
   return (SPIFFS_OK == filesystem.rename(old_file_name, new_file_name));
 }
 
-void OTAStorage_MKRMEM::deinit()
+void OTAStorage_SFU::deinit()
 {
   filesystem.unmount();
 }

--- a/src/utility/ota/OTAStorage_SFU.h
+++ b/src/utility/ota/OTAStorage_SFU.h
@@ -15,8 +15,8 @@
    a commercial license, send an email to license@arduino.cc.
 */
 
-#ifndef ARDUINO_OTA_STORAGE_MKRKEM_H_
-#define ARDUINO_OTA_STORAGE_MKRKEM_H_
+#ifndef ARDUINO_OTA_STORAGE_SFU_H_
+#define ARDUINO_OTA_STORAGE_SFU_H_
 
 /******************************************************************************
  * INCLUDE
@@ -35,12 +35,12 @@
  * CLASS DECLARATION
  ******************************************************************************/
 
-class OTAStorage_MKRMEM : public OTAStorage
+class OTAStorage_SFU : public OTAStorage
 {
 public:
 
-           OTAStorage_MKRMEM();
-  virtual ~OTAStorage_MKRMEM() { }
+           OTAStorage_SFU();
+  virtual ~OTAStorage_SFU() { }
 
 
   virtual bool   init  () override;
@@ -60,4 +60,4 @@ private:
 
 #endif /* OTA_STORAGE_MKRMEM */
 
-#endif /* ARDUINO_OTA_STORAGE_MKRKEM_H_ */
+#endif /* ARDUINO_OTA_STORAGE_SFU_H_ */


### PR DESCRIPTION
… in order to reflect that the OTA storage medium is used in combination with the SFU second stage bootloader