### PR TITLE
Bugfix: Changing value of property before loop prevents connection to cloud server.

### DIFF
--- a/src/ArduinoIoTCloudTCP.cpp
+++ b/src/ArduinoIoTCloudTCP.cpp
@@ -164,11 +164,17 @@ void ArduinoIoTCloudTCP::update()
   _ota_error = static_cast<int>(err);
 #endif /* OTA_ENABLED */
 
-  // Check if a primitive property wrapper is locally changed
-  updateTimestampOnLocallyChangedProperties(_property_container);
-
   if(checkPhyConnection()   != NetworkConnectionState::CONNECTED)     return;
   if(checkCloudConnection() != ArduinoIoTConnectionStatus::CONNECTED) return;
+
+  /* Check if a primitive property wrapper is locally changed.
+   * This function requires an existing time service which in
+   * turn requires an established connection. Not having that
+   * leads to a wrong time set in the time service which inhibits
+   * the connection from being established due to a wrong data
+   * in the reconstructed certificate.
+   */
+  updateTimestampOnLocallyChangedProperties(_property_container);
 
   if(_mqtt_data_request_retransmit && (_mqtt_data_len > 0)) {
     write(_dataTopicOut, _mqtt_data_buf, _mqtt_data_len);


### PR DESCRIPTION
`updateTimestampOnLocallyChangedProperties` was called before a connection had been established which led to the time service having a wrong date configured (1/1/2000) which leads to an expired certificate which inhibits the establishment of a connection to the server since the certificate has expired. This was triggered when properties where changed within `setup`.
```C++
void setup()
{
  /* ... */
  property = 1337;
  /* This caused updateTimestampOnLocallyChangedProperties to configure the time service
   * before a network connection has been established. This causes a wrong certificate date
   * which appears as if the certificate has expired.
   */
}
```
Behaviour with the bug present:
```
Arduino IoT Cloud Connection status: CONNECTING
Arduino IoT Cloud connecting ...
Arduino IoT Cloud connecting ...
Arduino IoT Cloud connecting ...
Arduino IoT Cloud connecting ...
Arduino IoT Cloud connecting ...
```
@manchoz @zmoog 