### PR TITLE
Fix: Use sketch compile time if no connection is available for estimating system time.

### DIFF
--- a/src/utility/time/TimeService.cpp
+++ b/src/utility/time/TimeService.cpp
@@ -93,7 +93,8 @@ unsigned long TimeService::getTime()
 
 unsigned long TimeService::getRemoteTime()
 {
-  if(_con_hdl == nullptr) return 0;
+  if(_con_hdl == nullptr)
+    return EPOCH_AT_COMPILE_TIME;
 
   /* At first try to see if a valid time can be obtained
    * using the network time available via the connection
@@ -112,7 +113,12 @@ unsigned long TimeService::getRemoteTime()
     return ntp_time;
   }
 
-  return 0;
+  /* Return the epoch timestamp at compile time as a last
+   * line of defense. Otherwise the certificate expiration
+   * date is wrong and we'll be unable to establish a connection
+   * to the server.
+   */
+  return EPOCH_AT_COMPILE_TIME;
 }
 
 bool TimeService::isTimeValid(unsigned long const time)


### PR DESCRIPTION
Ensure that the returned time is at least the compile time of the sketch, otherwise we might have an error scenario where no connection is available which would lead to a timestamp of 0 which would lead to the certificate being declared 'expired' and the device will be unable to connect to the server