### PR TITLE
Debug macros replace direct calls to Arduino_DebugUtils

### DIFF
--- a/src/AIoTC_Config.h
+++ b/src/AIoTC_Config.h
@@ -26,6 +26,26 @@
   #define OTA_STORAGE_SFU         (0)
 #endif
 
+#ifndef DBG_ERROR
+  #define DBG_ERROR(fmt, ...) Debug.print(DBG_ERROR, fmt, ## __VA_ARGS__)
+#endif
+
+#ifndef DBG_WARNING
+  #define DBG_WARNING(fmt, ...) Debug.print(DBG_WARNING, fmt, ## __VA_ARGS__)
+#endif
+
+#ifndef DBG_INFO
+  #define DBG_INFO(fmt, ...) Debug.print(DBG_INFO, fmt, ## __VA_ARGS__)
+#endif
+
+#ifndef DBG_DEBUG
+  #define DBG_DEBUG(fmt, ...) Debug.print(DBG_DEBUG, fmt, ## __VA_ARGS__)
+#endif
+
+#ifndef DBG_VERBOSE
+  #define DBG_VERBOSE(fmt, ...) Debug.print(DBG_VERBOSE, fmt, ## __VA_ARGS__)
+#endif
+
 /******************************************************************************
  * AUTOMATICALLY CONFIGURED DEFINES
  ******************************************************************************/

--- a/src/AIoTC_Config.h
+++ b/src/AIoTC_Config.h
@@ -15,8 +15,8 @@
    a commercial license, send an email to license@arduino.cc.
 */
 
-#ifndef ARDUINO_IOT_CLOUD_CONFIG_H_
-#define ARDUINO_IOT_CLOUD_CONFIG_H_
+#ifndef ARDUINO_AIOTC_CONFIG_H_
+#define ARDUINO_AIOTC_CONFIG_H_
 
 /******************************************************************************
  * USER CONFIGURED DEFINES
@@ -64,4 +64,4 @@
   #define HAS_TCP
 #endif
 
-#endif /* ARDUINO_IOT_CLOUD_CONFIG_H_ */
+#endif /* ARDUINO_AIOTC_CONFIG_H_ */

--- a/src/AIoTC_Config.h
+++ b/src/AIoTC_Config.h
@@ -19,12 +19,16 @@
 #define ARDUINO_AIOTC_CONFIG_H_
 
 /******************************************************************************
- * USER CONFIGURED DEFINES
+ * USER CONFIGURABLE DEFINES
  ******************************************************************************/
 
 #ifndef OTA_STORAGE_SFU
   #define OTA_STORAGE_SFU         (0)
 #endif
+
+/******************************************************************************
+ * AUTOMATICALLY CONFIGURED DEFINES
+ ******************************************************************************/
 
 #if defined(ARDUINO_SAMD_MKRWIFI1010) || defined(ARDUINO_SAMD_NANO_33_IOT)
   #define OTA_STORAGE_SNU         (1)
@@ -37,10 +41,6 @@
 #else
   #define OTA_STORAGE_SSU         (0)
 #endif
-
-/******************************************************************************
- * AUTOMATIC CONFIGURED DEFINES
- ******************************************************************************/
 
 #if OTA_STORAGE_SFU || OTA_STORAGE_SSU || OTA_STORAGE_SNU
   #define OTA_ENABLED             (1)

--- a/src/ArduinoIoTCloud.cpp
+++ b/src/ArduinoIoTCloud.cpp
@@ -199,11 +199,11 @@ void ArduinoIoTCloudClass::printConnectionStatus(ArduinoIoTConnectionStatus stat
 {
   switch (status)
   {
-    case ArduinoIoTConnectionStatus::IDLE:         Debug.print(DBG_INFO,  "Arduino IoT Cloud Connection status: IDLE");         break;
-    case ArduinoIoTConnectionStatus::ERROR:        Debug.print(DBG_ERROR, "Arduino IoT Cloud Connection status: ERROR");        break;
-    case ArduinoIoTConnectionStatus::CONNECTING:   Debug.print(DBG_INFO,  "Arduino IoT Cloud Connection status: CONNECTING");   break;
-    case ArduinoIoTConnectionStatus::RECONNECTING: Debug.print(DBG_INFO,  "Arduino IoT Cloud Connection status: RECONNECTING"); break;
-    case ArduinoIoTConnectionStatus::CONNECTED:    Debug.print(DBG_INFO,  "Arduino IoT Cloud Connection status: CONNECTED");    break;
-    case ArduinoIoTConnectionStatus::DISCONNECTED: Debug.print(DBG_ERROR, "Arduino IoT Cloud Connection status: DISCONNECTED"); break;
+    case ArduinoIoTConnectionStatus::IDLE:         DBG_INFO   ("Arduino IoT Cloud Connection status: IDLE");         break;
+    case ArduinoIoTConnectionStatus::ERROR:        DBG_ERROR("Arduino IoT Cloud Connection status: ERROR");        break;
+    case ArduinoIoTConnectionStatus::CONNECTING:   DBG_INFO   ("Arduino IoT Cloud Connection status: CONNECTING");   break;
+    case ArduinoIoTConnectionStatus::RECONNECTING: DBG_INFO   ("Arduino IoT Cloud Connection status: RECONNECTING"); break;
+    case ArduinoIoTConnectionStatus::CONNECTED:    DBG_INFO   ("Arduino IoT Cloud Connection status: CONNECTED");    break;
+    case ArduinoIoTConnectionStatus::DISCONNECTED: DBG_ERROR("Arduino IoT Cloud Connection status: DISCONNECTED"); break;
   }
 }

--- a/src/ArduinoIoTCloud.h
+++ b/src/ArduinoIoTCloud.h
@@ -22,7 +22,7 @@
  * INCLUDE
  ******************************************************************************/
 
-#include <ArduinoIoTCloud_Config.h>
+#include <AIoTC_Config.h>
 
 #include <Arduino_ConnectionHandler.h>
 #include <Arduino_DebugUtils.h>

--- a/src/ArduinoIoTCloudLPWAN.cpp
+++ b/src/ArduinoIoTCloudLPWAN.cpp
@@ -19,7 +19,7 @@
  * INCLUDE
  ******************************************************************************/
 
-#include <ArduinoIoTCloud_Config.h>
+#include <AIoTC_Config.h>
 
 #ifdef HAS_LORA
 

--- a/src/ArduinoIoTCloudLPWAN.cpp
+++ b/src/ArduinoIoTCloudLPWAN.cpp
@@ -101,8 +101,8 @@ void ArduinoIoTCloudLPWAN::update()
 
 void ArduinoIoTCloudLPWAN::printDebugInfo()
 {
-  Debug.print(DBG_INFO, "***** Arduino IoT Cloud LPWAN - configuration info *****");
-  Debug.print(DBG_INFO, "Thing ID: %s", getThingId().c_str());
+  DBG_INFO("***** Arduino IoT Cloud LPWAN - configuration info *****");
+  DBG_INFO("Thing ID: %s", getThingId().c_str());
 }
 
 /******************************************************************************

--- a/src/ArduinoIoTCloudTCP.cpp
+++ b/src/ArduinoIoTCloudTCP.cpp
@@ -19,7 +19,7 @@
  * INCLUDE
  ******************************************************************************/
 
-#include <ArduinoIoTCloud_Config.h>
+#include <AIoTC_Config.h>
 
 #ifdef HAS_TCP
 #include <ArduinoIoTCloudTCP.h>

--- a/src/ArduinoIoTCloudTCP.cpp
+++ b/src/ArduinoIoTCloudTCP.cpp
@@ -119,9 +119,9 @@ int ArduinoIoTCloudTCP::begin(String brokerAddress, uint16_t brokerPort)
   _brokerPort = brokerPort;
 
   #ifdef BOARD_HAS_ECCX08
-  if (!ECCX08.begin())                                                                                                                                                         { Debug.print(DBG_ERROR, "Cryptography processor failure. Make sure you have a compatible board."); return 0; }
-  if (!CryptoUtil::readDeviceId(ECCX08, getDeviceId(), ECCX08Slot::DeviceId))                                                                                                  { Debug.print(DBG_ERROR, "Cryptography processor read failure."); return 0; }
-  if (!CryptoUtil::reconstructCertificate(_eccx08_cert, getDeviceId(), ECCX08Slot::Key, ECCX08Slot::CompressedCertificate, ECCX08Slot::SerialNumberAndAuthorityKeyIdentifier)) { Debug.print(DBG_ERROR, "Cryptography certificate reconstruction failure."); return 0; }
+  if (!ECCX08.begin())                                                                                                                                                         { DBG_ERROR("Cryptography processor failure. Make sure you have a compatible board."); return 0; }
+  if (!CryptoUtil::readDeviceId(ECCX08, getDeviceId(), ECCX08Slot::DeviceId))                                                                                                  { DBG_ERROR("Cryptography processor read failure."); return 0; }
+  if (!CryptoUtil::reconstructCertificate(_eccx08_cert, getDeviceId(), ECCX08Slot::Key, ECCX08Slot::CompressedCertificate, ECCX08Slot::SerialNumberAndAuthorityKeyIdentifier)) { DBG_ERROR("Cryptography certificate reconstruction failure."); return 0; }
   _sslClient.setClient(_connection->getClient());
   _sslClient.setEccSlot(static_cast<int>(ECCX08Slot::Key), _eccx08_cert.bytes(), _eccx08_cert.length());
   #elif defined(BOARD_ESP)
@@ -219,10 +219,10 @@ int ArduinoIoTCloudTCP::connected()
 
 void ArduinoIoTCloudTCP::printDebugInfo()
 {
-  Debug.print(DBG_INFO, "***** Arduino IoT Cloud - configuration info *****");
-  Debug.print(DBG_INFO, "Device ID: %s", getDeviceId().c_str());
-  Debug.print(DBG_INFO, "Thing ID: %s", getThingId().c_str());
-  Debug.print(DBG_INFO, "MQTT Broker: %s:%d", _brokerAddress.c_str(), _brokerPort);
+  DBG_INFO("***** Arduino IoT Cloud - configuration info *****");
+  DBG_INFO("Device ID: %s", getDeviceId().c_str());
+  DBG_INFO("Thing ID: %s", getThingId().c_str());
+  DBG_INFO("MQTT Broker: %s:%d", _brokerAddress.c_str(), _brokerPort);
 }
 
 #if OTA_ENABLED
@@ -342,7 +342,7 @@ ArduinoIoTConnectionStatus ArduinoIoTCloudTCP::checkCloudConnection()
     case ArduinoIoTConnectionStatus::DISCONNECTED: next_iot_status = ArduinoIoTConnectionStatus::RECONNECTING; break;
     case ArduinoIoTConnectionStatus::CONNECTING:
     {
-      Debug.print(DBG_INFO, "Arduino IoT Cloud connecting ...");
+      DBG_INFO("Arduino IoT Cloud connecting ...");
       int const ret = connect();
       if (ret == CONNECT_SUCCESS)
       {
@@ -352,14 +352,14 @@ ArduinoIoTConnectionStatus ArduinoIoTCloudTCP::checkCloudConnection()
       }
       else if (ret == CONNECT_FAILURE_SUBSCRIBE)
       {
-        Debug.print(DBG_ERROR, "ERROR - Please verify your THING ID");
+        DBG_ERROR("ERROR - Please verify your THING ID");
       }
     }
     break;
 
     case ArduinoIoTConnectionStatus::RECONNECTING:
     {
-      Debug.print(DBG_INFO, "Arduino IoT Cloud reconnecting ...");
+      DBG_INFO("Arduino IoT Cloud reconnecting ...");
       if (reconnect() == CONNECT_SUCCESS)
       {
         next_iot_status = ArduinoIoTConnectionStatus::CONNECTED;

--- a/src/ArduinoIoTCloudTCP.h
+++ b/src/ArduinoIoTCloudTCP.h
@@ -22,7 +22,7 @@
  * INCLUDE
  ******************************************************************************/
 
-#include <ArduinoIoTCloud_Config.h>
+#include <AIoTC_Config.h>
 
 #include <ArduinoIoTCloud.h>
 

--- a/src/CloudSerial.cpp
+++ b/src/CloudSerial.cpp
@@ -19,7 +19,7 @@
  * INCLUDE
  ******************************************************************************/
 
-#include <ArduinoIoTCloud_Config.h>
+#include <AIoTC_Config.h>
 
 #ifndef HAS_LORA
 

--- a/src/tls/BearSSLClient.cpp
+++ b/src/tls/BearSSLClient.cpp
@@ -22,7 +22,7 @@
  * SOFTWARE.
  */
 
-#include <ArduinoIoTCloud_Config.h>
+#include <AIoTC_Config.h>
 #ifdef BOARD_HAS_ECCX08
 
 #include <ArduinoECCX08.h>

--- a/src/tls/BearSSLClient.h
+++ b/src/tls/BearSSLClient.h
@@ -25,7 +25,7 @@
 #ifndef _BEAR_SSL_CLIENT_H_
 #define _BEAR_SSL_CLIENT_H_
 
-#include <ArduinoIoTCloud_Config.h>
+#include <AIoTC_Config.h>
 #ifdef BOARD_HAS_ECCX08
 
 #ifndef BEAR_SSL_CLIENT_OBUF_SIZE

--- a/src/tls/BearSSLTrustAnchors.h
+++ b/src/tls/BearSSLTrustAnchors.h
@@ -23,7 +23,7 @@
  * INCLUDE
  ******************************************************************************/
 
-#include <ArduinoIoTCloud_Config.h>
+#include <AIoTC_Config.h>
 #ifdef BOARD_HAS_ECCX08
 
 #include "bearssl/bearssl_ssl.h"

--- a/src/tls/bearssl/aes_big_cbcdec.c
+++ b/src/tls/bearssl/aes_big_cbcdec.c
@@ -22,7 +22,7 @@
  * SOFTWARE.
  */
 
-#include <ArduinoIoTCloud_Config.h>
+#include <AIoTC_Config.h>
 #ifdef BOARD_HAS_ECCX08
 
 #include "inner.h"

--- a/src/tls/bearssl/aes_big_cbcenc.c
+++ b/src/tls/bearssl/aes_big_cbcenc.c
@@ -22,7 +22,7 @@
  * SOFTWARE.
  */
 
-#include <ArduinoIoTCloud_Config.h>
+#include <AIoTC_Config.h>
 #ifdef BOARD_HAS_ECCX08
 
 #include "inner.h"

--- a/src/tls/bearssl/aes_big_ctr.c
+++ b/src/tls/bearssl/aes_big_ctr.c
@@ -22,7 +22,7 @@
  * SOFTWARE.
  */
 
-#include <ArduinoIoTCloud_Config.h>
+#include <AIoTC_Config.h>
 #ifdef BOARD_HAS_ECCX08
 
 #include "inner.h"

--- a/src/tls/bearssl/aes_big_ctrcbc.c
+++ b/src/tls/bearssl/aes_big_ctrcbc.c
@@ -22,7 +22,7 @@
  * SOFTWARE.
  */
 
-#include <ArduinoIoTCloud_Config.h>
+#include <AIoTC_Config.h>
 #ifdef BOARD_HAS_ECCX08
 
 #include "inner.h"

--- a/src/tls/bearssl/aes_big_dec.c
+++ b/src/tls/bearssl/aes_big_dec.c
@@ -22,7 +22,7 @@
  * SOFTWARE.
  */
 
-#include <ArduinoIoTCloud_Config.h>
+#include <AIoTC_Config.h>
 #ifdef BOARD_HAS_ECCX08
 
 #include "inner.h"

--- a/src/tls/bearssl/aes_big_enc.c
+++ b/src/tls/bearssl/aes_big_enc.c
@@ -22,7 +22,7 @@
  * SOFTWARE.
  */
 
-#include <ArduinoIoTCloud_Config.h>
+#include <AIoTC_Config.h>
 #ifdef BOARD_HAS_ECCX08
 
 #include "inner.h"

--- a/src/tls/bearssl/aes_common.c
+++ b/src/tls/bearssl/aes_common.c
@@ -22,7 +22,7 @@
  * SOFTWARE.
  */
 
-#include <ArduinoIoTCloud_Config.h>
+#include <AIoTC_Config.h>
 #ifdef BOARD_HAS_ECCX08
 
 #include "inner.h"

--- a/src/tls/bearssl/aes_ct.c
+++ b/src/tls/bearssl/aes_ct.c
@@ -22,7 +22,7 @@
  * SOFTWARE.
  */
 
-#include <ArduinoIoTCloud_Config.h>
+#include <AIoTC_Config.h>
 #ifdef BOARD_HAS_ECCX08
 
 #include "inner.h"

--- a/src/tls/bearssl/aes_ct64.c
+++ b/src/tls/bearssl/aes_ct64.c
@@ -22,7 +22,7 @@
  * SOFTWARE.
  */
 
-#include <ArduinoIoTCloud_Config.h>
+#include <AIoTC_Config.h>
 #ifdef BOARD_HAS_ECCX08
 
 #include "inner.h"

--- a/src/tls/bearssl/aes_ct64_cbcdec.c
+++ b/src/tls/bearssl/aes_ct64_cbcdec.c
@@ -22,7 +22,7 @@
  * SOFTWARE.
  */
 
-#include <ArduinoIoTCloud_Config.h>
+#include <AIoTC_Config.h>
 #ifdef BOARD_HAS_ECCX08
 
 #include "inner.h"

--- a/src/tls/bearssl/aes_ct64_cbcenc.c
+++ b/src/tls/bearssl/aes_ct64_cbcenc.c
@@ -22,7 +22,7 @@
  * SOFTWARE.
  */
 
-#include <ArduinoIoTCloud_Config.h>
+#include <AIoTC_Config.h>
 #ifdef BOARD_HAS_ECCX08
 
 #include "inner.h"

--- a/src/tls/bearssl/aes_ct64_ctr.c
+++ b/src/tls/bearssl/aes_ct64_ctr.c
@@ -22,7 +22,7 @@
  * SOFTWARE.
  */
 
-#include <ArduinoIoTCloud_Config.h>
+#include <AIoTC_Config.h>
 #ifdef BOARD_HAS_ECCX08
 
 #include "inner.h"

--- a/src/tls/bearssl/aes_ct64_ctrcbc.c
+++ b/src/tls/bearssl/aes_ct64_ctrcbc.c
@@ -22,7 +22,7 @@
  * SOFTWARE.
  */
 
-#include <ArduinoIoTCloud_Config.h>
+#include <AIoTC_Config.h>
 #ifdef BOARD_HAS_ECCX08
 
 #include "inner.h"

--- a/src/tls/bearssl/aes_ct64_dec.c
+++ b/src/tls/bearssl/aes_ct64_dec.c
@@ -22,7 +22,7 @@
  * SOFTWARE.
  */
 
-#include <ArduinoIoTCloud_Config.h>
+#include <AIoTC_Config.h>
 #ifdef BOARD_HAS_ECCX08
 
 #include "inner.h"

--- a/src/tls/bearssl/aes_ct64_enc.c
+++ b/src/tls/bearssl/aes_ct64_enc.c
@@ -22,7 +22,7 @@
  * SOFTWARE.
  */
 
-#include <ArduinoIoTCloud_Config.h>
+#include <AIoTC_Config.h>
 #ifdef BOARD_HAS_ECCX08
 
 #include "inner.h"

--- a/src/tls/bearssl/aes_ct_cbcdec.c
+++ b/src/tls/bearssl/aes_ct_cbcdec.c
@@ -22,7 +22,7 @@
  * SOFTWARE.
  */
 
-#include <ArduinoIoTCloud_Config.h>
+#include <AIoTC_Config.h>
 #ifdef BOARD_HAS_ECCX08
 
 #include "inner.h"

--- a/src/tls/bearssl/aes_ct_cbcenc.c
+++ b/src/tls/bearssl/aes_ct_cbcenc.c
@@ -22,7 +22,7 @@
  * SOFTWARE.
  */
 
-#include <ArduinoIoTCloud_Config.h>
+#include <AIoTC_Config.h>
 #ifdef BOARD_HAS_ECCX08
 
 #include "inner.h"

--- a/src/tls/bearssl/aes_ct_ctr.c
+++ b/src/tls/bearssl/aes_ct_ctr.c
@@ -22,7 +22,7 @@
  * SOFTWARE.
  */
 
-#include <ArduinoIoTCloud_Config.h>
+#include <AIoTC_Config.h>
 #ifdef BOARD_HAS_ECCX08
 
 #include "inner.h"

--- a/src/tls/bearssl/aes_ct_ctrcbc.c
+++ b/src/tls/bearssl/aes_ct_ctrcbc.c
@@ -22,7 +22,7 @@
  * SOFTWARE.
  */
 
-#include <ArduinoIoTCloud_Config.h>
+#include <AIoTC_Config.h>
 #ifdef BOARD_HAS_ECCX08
 
 #include "inner.h"

--- a/src/tls/bearssl/aes_ct_dec.c
+++ b/src/tls/bearssl/aes_ct_dec.c
@@ -22,7 +22,7 @@
  * SOFTWARE.
  */
 
-#include <ArduinoIoTCloud_Config.h>
+#include <AIoTC_Config.h>
 #ifdef BOARD_HAS_ECCX08
 
 #include "inner.h"

--- a/src/tls/bearssl/aes_ct_enc.c
+++ b/src/tls/bearssl/aes_ct_enc.c
@@ -22,7 +22,7 @@
  * SOFTWARE.
  */
 
-#include <ArduinoIoTCloud_Config.h>
+#include <AIoTC_Config.h>
 #ifdef BOARD_HAS_ECCX08
 
 #include "inner.h"

--- a/src/tls/bearssl/aes_pwr8.c
+++ b/src/tls/bearssl/aes_pwr8.c
@@ -22,7 +22,7 @@
  * SOFTWARE.
  */
 
-#include <ArduinoIoTCloud_Config.h>
+#include <AIoTC_Config.h>
 #ifdef BOARD_HAS_ECCX08
 
 #define BR_POWER_ASM_MACROS   1

--- a/src/tls/bearssl/aes_pwr8_cbcdec.c
+++ b/src/tls/bearssl/aes_pwr8_cbcdec.c
@@ -22,7 +22,7 @@
  * SOFTWARE.
  */
 
-#include <ArduinoIoTCloud_Config.h>
+#include <AIoTC_Config.h>
 #ifdef BOARD_HAS_ECCX08
 
 #define BR_POWER_ASM_MACROS   1

--- a/src/tls/bearssl/aes_pwr8_cbcenc.c
+++ b/src/tls/bearssl/aes_pwr8_cbcenc.c
@@ -22,7 +22,7 @@
  * SOFTWARE.
  */
 
-#include <ArduinoIoTCloud_Config.h>
+#include <AIoTC_Config.h>
 #ifdef BOARD_HAS_ECCX08
 
 #define BR_POWER_ASM_MACROS   1

--- a/src/tls/bearssl/aes_pwr8_ctr.c
+++ b/src/tls/bearssl/aes_pwr8_ctr.c
@@ -22,7 +22,7 @@
  * SOFTWARE.
  */
 
-#include <ArduinoIoTCloud_Config.h>
+#include <AIoTC_Config.h>
 #ifdef BOARD_HAS_ECCX08
 
 #define BR_POWER_ASM_MACROS   1

--- a/src/tls/bearssl/aes_pwr8_ctrcbc.c
+++ b/src/tls/bearssl/aes_pwr8_ctrcbc.c
@@ -22,7 +22,7 @@
  * SOFTWARE.
  */
 
-#include <ArduinoIoTCloud_Config.h>
+#include <AIoTC_Config.h>
 #ifdef BOARD_HAS_ECCX08
 
 #define BR_POWER_ASM_MACROS   1

--- a/src/tls/bearssl/aes_small_cbcdec.c
+++ b/src/tls/bearssl/aes_small_cbcdec.c
@@ -22,7 +22,7 @@
  * SOFTWARE.
  */
 
-#include <ArduinoIoTCloud_Config.h>
+#include <AIoTC_Config.h>
 #ifdef BOARD_HAS_ECCX08
 
 #include "inner.h"

--- a/src/tls/bearssl/aes_small_cbcenc.c
+++ b/src/tls/bearssl/aes_small_cbcenc.c
@@ -22,7 +22,7 @@
  * SOFTWARE.
  */
 
-#include <ArduinoIoTCloud_Config.h>
+#include <AIoTC_Config.h>
 #ifdef BOARD_HAS_ECCX08
 
 #include "inner.h"

--- a/src/tls/bearssl/aes_small_ctr.c
+++ b/src/tls/bearssl/aes_small_ctr.c
@@ -22,7 +22,7 @@
  * SOFTWARE.
  */
 
-#include <ArduinoIoTCloud_Config.h>
+#include <AIoTC_Config.h>
 #ifdef BOARD_HAS_ECCX08
 
 #include "inner.h"

--- a/src/tls/bearssl/aes_small_ctrcbc.c
+++ b/src/tls/bearssl/aes_small_ctrcbc.c
@@ -22,7 +22,7 @@
  * SOFTWARE.
  */
 
-#include <ArduinoIoTCloud_Config.h>
+#include <AIoTC_Config.h>
 #ifdef BOARD_HAS_ECCX08
 
 #include "inner.h"

--- a/src/tls/bearssl/aes_small_dec.c
+++ b/src/tls/bearssl/aes_small_dec.c
@@ -22,7 +22,7 @@
  * SOFTWARE.
  */
 
-#include <ArduinoIoTCloud_Config.h>
+#include <AIoTC_Config.h>
 #ifdef BOARD_HAS_ECCX08
 
 #include "inner.h"

--- a/src/tls/bearssl/aes_small_enc.c
+++ b/src/tls/bearssl/aes_small_enc.c
@@ -22,7 +22,7 @@
  * SOFTWARE.
  */
 
-#include <ArduinoIoTCloud_Config.h>
+#include <AIoTC_Config.h>
 #ifdef BOARD_HAS_ECCX08
 
 #include "inner.h"

--- a/src/tls/bearssl/aes_x86ni.c
+++ b/src/tls/bearssl/aes_x86ni.c
@@ -22,7 +22,7 @@
  * SOFTWARE.
  */
 
-#include <ArduinoIoTCloud_Config.h>
+#include <AIoTC_Config.h>
 #ifdef BOARD_HAS_ECCX08
 
 #include "inner.h"

--- a/src/tls/bearssl/aes_x86ni_cbcdec.c
+++ b/src/tls/bearssl/aes_x86ni_cbcdec.c
@@ -22,7 +22,7 @@
  * SOFTWARE.
  */
 
-#include <ArduinoIoTCloud_Config.h>
+#include <AIoTC_Config.h>
 #ifdef BOARD_HAS_ECCX08
 
 #define BR_ENABLE_INTRINSICS   1

--- a/src/tls/bearssl/aes_x86ni_cbcenc.c
+++ b/src/tls/bearssl/aes_x86ni_cbcenc.c
@@ -22,7 +22,7 @@
  * SOFTWARE.
  */
 
-#include <ArduinoIoTCloud_Config.h>
+#include <AIoTC_Config.h>
 #ifdef BOARD_HAS_ECCX08
 
 #include "inner.h"

--- a/src/tls/bearssl/aes_x86ni_ctr.c
+++ b/src/tls/bearssl/aes_x86ni_ctr.c
@@ -22,7 +22,7 @@
  * SOFTWARE.
  */
 
-#include <ArduinoIoTCloud_Config.h>
+#include <AIoTC_Config.h>
 #ifdef BOARD_HAS_ECCX08
 
 #define BR_ENABLE_INTRINSICS   1

--- a/src/tls/bearssl/aesctr_drbg.c
+++ b/src/tls/bearssl/aesctr_drbg.c
@@ -22,7 +22,7 @@
  * SOFTWARE.
  */
 
-#include <ArduinoIoTCloud_Config.h>
+#include <AIoTC_Config.h>
 #ifdef BOARD_HAS_ECCX08
 
 #include "inner.h"

--- a/src/tls/bearssl/asn1enc.c
+++ b/src/tls/bearssl/asn1enc.c
@@ -22,7 +22,7 @@
  * SOFTWARE.
  */
 
-#include <ArduinoIoTCloud_Config.h>
+#include <AIoTC_Config.h>
 #ifdef BOARD_HAS_ECCX08
 
 #include "inner.h"

--- a/src/tls/bearssl/ccm.c
+++ b/src/tls/bearssl/ccm.c
@@ -22,7 +22,7 @@
  * SOFTWARE.
  */
 
-#include <ArduinoIoTCloud_Config.h>
+#include <AIoTC_Config.h>
 #ifdef BOARD_HAS_ECCX08
 
 #include "inner.h"

--- a/src/tls/bearssl/ccopy.c
+++ b/src/tls/bearssl/ccopy.c
@@ -22,7 +22,7 @@
  * SOFTWARE.
  */
 
-#include <ArduinoIoTCloud_Config.h>
+#include <AIoTC_Config.h>
 #ifdef BOARD_HAS_ECCX08
 
 #include "inner.h"

--- a/src/tls/bearssl/chacha20_ct.c
+++ b/src/tls/bearssl/chacha20_ct.c
@@ -22,7 +22,7 @@
  * SOFTWARE.
  */
 
-#include <ArduinoIoTCloud_Config.h>
+#include <AIoTC_Config.h>
 #ifdef BOARD_HAS_ECCX08
 
 #include "inner.h"

--- a/src/tls/bearssl/chacha20_sse2.c
+++ b/src/tls/bearssl/chacha20_sse2.c
@@ -22,7 +22,7 @@
  * SOFTWARE.
  */
 
-#include <ArduinoIoTCloud_Config.h>
+#include <AIoTC_Config.h>
 #ifdef BOARD_HAS_ECCX08
 
 #define BR_ENABLE_INTRINSICS   1

--- a/src/tls/bearssl/dec16be.c
+++ b/src/tls/bearssl/dec16be.c
@@ -22,7 +22,7 @@
  * SOFTWARE.
  */
 
-#include <ArduinoIoTCloud_Config.h>
+#include <AIoTC_Config.h>
 #ifdef BOARD_HAS_ECCX08
 
 #include "inner.h"

--- a/src/tls/bearssl/dec16le.c
+++ b/src/tls/bearssl/dec16le.c
@@ -22,7 +22,7 @@
  * SOFTWARE.
  */
 
-#include <ArduinoIoTCloud_Config.h>
+#include <AIoTC_Config.h>
 #ifdef BOARD_HAS_ECCX08
 
 #include "inner.h"

--- a/src/tls/bearssl/dec32be.c
+++ b/src/tls/bearssl/dec32be.c
@@ -22,7 +22,7 @@
  * SOFTWARE.
  */
 
-#include <ArduinoIoTCloud_Config.h>
+#include <AIoTC_Config.h>
 #ifdef BOARD_HAS_ECCX08
 
 #include "inner.h"

--- a/src/tls/bearssl/dec32le.c
+++ b/src/tls/bearssl/dec32le.c
@@ -22,7 +22,7 @@
  * SOFTWARE.
  */
 
-#include <ArduinoIoTCloud_Config.h>
+#include <AIoTC_Config.h>
 #ifdef BOARD_HAS_ECCX08
 
 #include "inner.h"

--- a/src/tls/bearssl/dec64be.c
+++ b/src/tls/bearssl/dec64be.c
@@ -22,7 +22,7 @@
  * SOFTWARE.
  */
 
-#include <ArduinoIoTCloud_Config.h>
+#include <AIoTC_Config.h>
 #ifdef BOARD_HAS_ECCX08
 
 #include "inner.h"

--- a/src/tls/bearssl/dec64le.c
+++ b/src/tls/bearssl/dec64le.c
@@ -22,7 +22,7 @@
  * SOFTWARE.
  */
 
-#include <ArduinoIoTCloud_Config.h>
+#include <AIoTC_Config.h>
 #ifdef BOARD_HAS_ECCX08
 
 #include "inner.h"

--- a/src/tls/bearssl/des_ct.c
+++ b/src/tls/bearssl/des_ct.c
@@ -22,7 +22,7 @@
  * SOFTWARE.
  */
 
-#include <ArduinoIoTCloud_Config.h>
+#include <AIoTC_Config.h>
 #ifdef BOARD_HAS_ECCX08
 
 #include "inner.h"

--- a/src/tls/bearssl/des_ct_cbcdec.c
+++ b/src/tls/bearssl/des_ct_cbcdec.c
@@ -22,7 +22,7 @@
  * SOFTWARE.
  */
 
-#include <ArduinoIoTCloud_Config.h>
+#include <AIoTC_Config.h>
 #ifdef BOARD_HAS_ECCX08
 
 #include "inner.h"

--- a/src/tls/bearssl/des_ct_cbcenc.c
+++ b/src/tls/bearssl/des_ct_cbcenc.c
@@ -22,7 +22,7 @@
  * SOFTWARE.
  */
 
-#include <ArduinoIoTCloud_Config.h>
+#include <AIoTC_Config.h>
 #ifdef BOARD_HAS_ECCX08
 
 #include "inner.h"

--- a/src/tls/bearssl/des_support.c
+++ b/src/tls/bearssl/des_support.c
@@ -22,7 +22,7 @@
  * SOFTWARE.
  */
 
-#include <ArduinoIoTCloud_Config.h>
+#include <AIoTC_Config.h>
 #ifdef BOARD_HAS_ECCX08
 
 #include "inner.h"

--- a/src/tls/bearssl/des_tab.c
+++ b/src/tls/bearssl/des_tab.c
@@ -22,7 +22,7 @@
  * SOFTWARE.
  */
 
-#include <ArduinoIoTCloud_Config.h>
+#include <AIoTC_Config.h>
 #ifdef BOARD_HAS_ECCX08
 
 #include "inner.h"

--- a/src/tls/bearssl/des_tab_cbcdec.c
+++ b/src/tls/bearssl/des_tab_cbcdec.c
@@ -22,7 +22,7 @@
  * SOFTWARE.
  */
 
-#include <ArduinoIoTCloud_Config.h>
+#include <AIoTC_Config.h>
 #ifdef BOARD_HAS_ECCX08
 
 #include "inner.h"

--- a/src/tls/bearssl/des_tab_cbcenc.c
+++ b/src/tls/bearssl/des_tab_cbcenc.c
@@ -22,7 +22,7 @@
  * SOFTWARE.
  */
 
-#include <ArduinoIoTCloud_Config.h>
+#include <AIoTC_Config.h>
 #ifdef BOARD_HAS_ECCX08
 
 #include "inner.h"

--- a/src/tls/bearssl/dig_oid.c
+++ b/src/tls/bearssl/dig_oid.c
@@ -22,7 +22,7 @@
  * SOFTWARE.
  */
 
-#include <ArduinoIoTCloud_Config.h>
+#include <AIoTC_Config.h>
 #ifdef BOARD_HAS_ECCX08
 
 #include "inner.h"

--- a/src/tls/bearssl/dig_size.c
+++ b/src/tls/bearssl/dig_size.c
@@ -22,7 +22,7 @@
  * SOFTWARE.
  */
 
-#include <ArduinoIoTCloud_Config.h>
+#include <AIoTC_Config.h>
 #ifdef BOARD_HAS_ECCX08
 
 #include "inner.h"

--- a/src/tls/bearssl/eax.c
+++ b/src/tls/bearssl/eax.c
@@ -22,7 +22,7 @@
  * SOFTWARE.
  */
 
-#include <ArduinoIoTCloud_Config.h>
+#include <AIoTC_Config.h>
 #ifdef BOARD_HAS_ECCX08
 
 #include "inner.h"

--- a/src/tls/bearssl/ec_all_m15.c
+++ b/src/tls/bearssl/ec_all_m15.c
@@ -22,7 +22,7 @@
  * SOFTWARE.
  */
 
-#include <ArduinoIoTCloud_Config.h>
+#include <AIoTC_Config.h>
 #ifdef BOARD_HAS_ECCX08
 
 #include "inner.h"

--- a/src/tls/bearssl/ec_all_m31.c
+++ b/src/tls/bearssl/ec_all_m31.c
@@ -22,7 +22,7 @@
  * SOFTWARE.
  */
 
-#include <ArduinoIoTCloud_Config.h>
+#include <AIoTC_Config.h>
 #ifdef BOARD_HAS_ECCX08
 
 #include "inner.h"

--- a/src/tls/bearssl/ec_c25519_i15.c
+++ b/src/tls/bearssl/ec_c25519_i15.c
@@ -22,7 +22,7 @@
  * SOFTWARE.
  */
 
-#include <ArduinoIoTCloud_Config.h>
+#include <AIoTC_Config.h>
 #ifdef BOARD_HAS_ECCX08
 
 #include "inner.h"

--- a/src/tls/bearssl/ec_c25519_i31.c
+++ b/src/tls/bearssl/ec_c25519_i31.c
@@ -22,7 +22,7 @@
  * SOFTWARE.
  */
 
-#include <ArduinoIoTCloud_Config.h>
+#include <AIoTC_Config.h>
 #ifdef BOARD_HAS_ECCX08
 
 #include "inner.h"

--- a/src/tls/bearssl/ec_c25519_m15.c
+++ b/src/tls/bearssl/ec_c25519_m15.c
@@ -22,7 +22,7 @@
  * SOFTWARE.
  */
 
-#include <ArduinoIoTCloud_Config.h>
+#include <AIoTC_Config.h>
 #ifdef BOARD_HAS_ECCX08
 
 #include "inner.h"

--- a/src/tls/bearssl/ec_c25519_m31.c
+++ b/src/tls/bearssl/ec_c25519_m31.c
@@ -22,7 +22,7 @@
  * SOFTWARE.
  */
 
-#include <ArduinoIoTCloud_Config.h>
+#include <AIoTC_Config.h>
 #ifdef BOARD_HAS_ECCX08
 
 #include "inner.h"

--- a/src/tls/bearssl/ec_curve25519.c
+++ b/src/tls/bearssl/ec_curve25519.c
@@ -22,7 +22,7 @@
  * SOFTWARE.
  */
 
-#include <ArduinoIoTCloud_Config.h>
+#include <AIoTC_Config.h>
 #ifdef BOARD_HAS_ECCX08
 
 #include "inner.h"

--- a/src/tls/bearssl/ec_default.c
+++ b/src/tls/bearssl/ec_default.c
@@ -22,7 +22,7 @@
  * SOFTWARE.
  */
 
-#include <ArduinoIoTCloud_Config.h>
+#include <AIoTC_Config.h>
 #ifdef BOARD_HAS_ECCX08
 
 #include "inner.h"

--- a/src/tls/bearssl/ec_keygen.c
+++ b/src/tls/bearssl/ec_keygen.c
@@ -22,7 +22,7 @@
  * SOFTWARE.
  */
 
-#include <ArduinoIoTCloud_Config.h>
+#include <AIoTC_Config.h>
 #ifdef BOARD_HAS_ECCX08
 
 #include "inner.h"

--- a/src/tls/bearssl/ec_p256_m15.c
+++ b/src/tls/bearssl/ec_p256_m15.c
@@ -22,7 +22,7 @@
  * SOFTWARE.
  */
 
-#include <ArduinoIoTCloud_Config.h>
+#include <AIoTC_Config.h>
 #ifdef BOARD_HAS_ECCX08
 
 #include "inner.h"

--- a/src/tls/bearssl/ec_p256_m31.c
+++ b/src/tls/bearssl/ec_p256_m31.c
@@ -22,7 +22,7 @@
  * SOFTWARE.
  */
 
-#include <ArduinoIoTCloud_Config.h>
+#include <AIoTC_Config.h>
 #ifdef BOARD_HAS_ECCX08
 
 #include "inner.h"

--- a/src/tls/bearssl/ec_prime_i15.c
+++ b/src/tls/bearssl/ec_prime_i15.c
@@ -22,7 +22,7 @@
  * SOFTWARE.
  */
 
-#include <ArduinoIoTCloud_Config.h>
+#include <AIoTC_Config.h>
 #ifdef BOARD_HAS_ECCX08
 
 #include "inner.h"

--- a/src/tls/bearssl/ec_prime_i31.c
+++ b/src/tls/bearssl/ec_prime_i31.c
@@ -22,7 +22,7 @@
  * SOFTWARE.
  */
 
-#include <ArduinoIoTCloud_Config.h>
+#include <AIoTC_Config.h>
 #ifdef BOARD_HAS_ECCX08
 
 #include "inner.h"

--- a/src/tls/bearssl/ec_pubkey.c
+++ b/src/tls/bearssl/ec_pubkey.c
@@ -22,7 +22,7 @@
  * SOFTWARE.
  */
 
-#include <ArduinoIoTCloud_Config.h>
+#include <AIoTC_Config.h>
 #ifdef BOARD_HAS_ECCX08
 
 #include "inner.h"

--- a/src/tls/bearssl/ec_secp256r1.c
+++ b/src/tls/bearssl/ec_secp256r1.c
@@ -22,7 +22,7 @@
  * SOFTWARE.
  */
 
-#include <ArduinoIoTCloud_Config.h>
+#include <AIoTC_Config.h>
 #ifdef BOARD_HAS_ECCX08
 
 #include "inner.h"

--- a/src/tls/bearssl/ec_secp384r1.c
+++ b/src/tls/bearssl/ec_secp384r1.c
@@ -22,7 +22,7 @@
  * SOFTWARE.
  */
 
-#include <ArduinoIoTCloud_Config.h>
+#include <AIoTC_Config.h>
 #ifdef BOARD_HAS_ECCX08
 
 #include "inner.h"

--- a/src/tls/bearssl/ec_secp521r1.c
+++ b/src/tls/bearssl/ec_secp521r1.c
@@ -22,7 +22,7 @@
  * SOFTWARE.
  */
 
-#include <ArduinoIoTCloud_Config.h>
+#include <AIoTC_Config.h>
 #ifdef BOARD_HAS_ECCX08
 
 #include "inner.h"

--- a/src/tls/bearssl/ecdsa_atr.c
+++ b/src/tls/bearssl/ecdsa_atr.c
@@ -22,7 +22,7 @@
  * SOFTWARE.
  */
 
-#include <ArduinoIoTCloud_Config.h>
+#include <AIoTC_Config.h>
 #ifdef BOARD_HAS_ECCX08
 
 #include "inner.h"

--- a/src/tls/bearssl/ecdsa_default_sign_asn1.c
+++ b/src/tls/bearssl/ecdsa_default_sign_asn1.c
@@ -22,7 +22,7 @@
  * SOFTWARE.
  */
 
-#include <ArduinoIoTCloud_Config.h>
+#include <AIoTC_Config.h>
 #ifdef BOARD_HAS_ECCX08
 
 #include "inner.h"

--- a/src/tls/bearssl/ecdsa_default_sign_raw.c
+++ b/src/tls/bearssl/ecdsa_default_sign_raw.c
@@ -22,7 +22,7 @@
  * SOFTWARE.
  */
 
-#include <ArduinoIoTCloud_Config.h>
+#include <AIoTC_Config.h>
 #ifdef BOARD_HAS_ECCX08
 
 #include "inner.h"

--- a/src/tls/bearssl/ecdsa_default_vrfy_asn1.c
+++ b/src/tls/bearssl/ecdsa_default_vrfy_asn1.c
@@ -22,7 +22,7 @@
  * SOFTWARE.
  */
 
-#include <ArduinoIoTCloud_Config.h>
+#include <AIoTC_Config.h>
 #ifdef BOARD_HAS_ECCX08
 
 #include "inner.h"

--- a/src/tls/bearssl/ecdsa_default_vrfy_raw.c
+++ b/src/tls/bearssl/ecdsa_default_vrfy_raw.c
@@ -22,7 +22,7 @@
  * SOFTWARE.
  */
 
-#include <ArduinoIoTCloud_Config.h>
+#include <AIoTC_Config.h>
 #ifdef BOARD_HAS_ECCX08
 
 #include "inner.h"

--- a/src/tls/bearssl/ecdsa_i15_bits.c
+++ b/src/tls/bearssl/ecdsa_i15_bits.c
@@ -22,7 +22,7 @@
  * SOFTWARE.
  */
 
-#include <ArduinoIoTCloud_Config.h>
+#include <AIoTC_Config.h>
 #ifdef BOARD_HAS_ECCX08
 
 #include "inner.h"

--- a/src/tls/bearssl/ecdsa_i15_sign_asn1.c
+++ b/src/tls/bearssl/ecdsa_i15_sign_asn1.c
@@ -22,7 +22,7 @@
  * SOFTWARE.
  */
 
-#include <ArduinoIoTCloud_Config.h>
+#include <AIoTC_Config.h>
 #ifdef BOARD_HAS_ECCX08
 
 #include "inner.h"

--- a/src/tls/bearssl/ecdsa_i15_sign_raw.c
+++ b/src/tls/bearssl/ecdsa_i15_sign_raw.c
@@ -22,7 +22,7 @@
  * SOFTWARE.
  */
 
-#include <ArduinoIoTCloud_Config.h>
+#include <AIoTC_Config.h>
 #ifdef BOARD_HAS_ECCX08
 
 #include "inner.h"

--- a/src/tls/bearssl/ecdsa_i15_vrfy_asn1.c
+++ b/src/tls/bearssl/ecdsa_i15_vrfy_asn1.c
@@ -22,7 +22,7 @@
  * SOFTWARE.
  */
 
-#include <ArduinoIoTCloud_Config.h>
+#include <AIoTC_Config.h>
 #ifdef BOARD_HAS_ECCX08
 
 #include "inner.h"

--- a/src/tls/bearssl/ecdsa_i15_vrfy_raw.c
+++ b/src/tls/bearssl/ecdsa_i15_vrfy_raw.c
@@ -22,7 +22,7 @@
  * SOFTWARE.
  */
 
-#include <ArduinoIoTCloud_Config.h>
+#include <AIoTC_Config.h>
 #ifdef BOARD_HAS_ECCX08
 
 #include "inner.h"

--- a/src/tls/bearssl/ecdsa_i31_bits.c
+++ b/src/tls/bearssl/ecdsa_i31_bits.c
@@ -22,7 +22,7 @@
  * SOFTWARE.
  */
 
-#include <ArduinoIoTCloud_Config.h>
+#include <AIoTC_Config.h>
 #ifdef BOARD_HAS_ECCX08
 
 #include "inner.h"

--- a/src/tls/bearssl/ecdsa_i31_sign_asn1.c
+++ b/src/tls/bearssl/ecdsa_i31_sign_asn1.c
@@ -22,7 +22,7 @@
  * SOFTWARE.
  */
 
-#include <ArduinoIoTCloud_Config.h>
+#include <AIoTC_Config.h>
 #ifdef BOARD_HAS_ECCX08
 
 #include "inner.h"

--- a/src/tls/bearssl/ecdsa_i31_sign_raw.c
+++ b/src/tls/bearssl/ecdsa_i31_sign_raw.c
@@ -22,7 +22,7 @@
  * SOFTWARE.
  */
 
-#include <ArduinoIoTCloud_Config.h>
+#include <AIoTC_Config.h>
 #ifdef BOARD_HAS_ECCX08
 
 #include "inner.h"

--- a/src/tls/bearssl/ecdsa_i31_vrfy_asn1.c
+++ b/src/tls/bearssl/ecdsa_i31_vrfy_asn1.c
@@ -22,7 +22,7 @@
  * SOFTWARE.
  */
 
-#include <ArduinoIoTCloud_Config.h>
+#include <AIoTC_Config.h>
 #ifdef BOARD_HAS_ECCX08
 
 #include "inner.h"

--- a/src/tls/bearssl/ecdsa_i31_vrfy_raw.c
+++ b/src/tls/bearssl/ecdsa_i31_vrfy_raw.c
@@ -22,7 +22,7 @@
  * SOFTWARE.
  */
 
-#include <ArduinoIoTCloud_Config.h>
+#include <AIoTC_Config.h>
 #ifdef BOARD_HAS_ECCX08
 
 #include "inner.h"

--- a/src/tls/bearssl/ecdsa_rta.c
+++ b/src/tls/bearssl/ecdsa_rta.c
@@ -22,7 +22,7 @@
  * SOFTWARE.
  */
 
-#include <ArduinoIoTCloud_Config.h>
+#include <AIoTC_Config.h>
 #ifdef BOARD_HAS_ECCX08
 
 #include "inner.h"

--- a/src/tls/bearssl/enc16be.c
+++ b/src/tls/bearssl/enc16be.c
@@ -22,7 +22,7 @@
  * SOFTWARE.
  */
 
-#include <ArduinoIoTCloud_Config.h>
+#include <AIoTC_Config.h>
 #ifdef BOARD_HAS_ECCX08
 
 #include "inner.h"

--- a/src/tls/bearssl/enc16le.c
+++ b/src/tls/bearssl/enc16le.c
@@ -22,7 +22,7 @@
  * SOFTWARE.
  */
 
-#include <ArduinoIoTCloud_Config.h>
+#include <AIoTC_Config.h>
 #ifdef BOARD_HAS_ECCX08
 
 #include "inner.h"

--- a/src/tls/bearssl/enc32be.c
+++ b/src/tls/bearssl/enc32be.c
@@ -22,7 +22,7 @@
  * SOFTWARE.
  */
 
-#include <ArduinoIoTCloud_Config.h>
+#include <AIoTC_Config.h>
 #ifdef BOARD_HAS_ECCX08
 
 #include "inner.h"

--- a/src/tls/bearssl/enc32le.c
+++ b/src/tls/bearssl/enc32le.c
@@ -22,7 +22,7 @@
  * SOFTWARE.
  */
 
-#include <ArduinoIoTCloud_Config.h>
+#include <AIoTC_Config.h>
 #ifdef BOARD_HAS_ECCX08
 
 #include "inner.h"

--- a/src/tls/bearssl/enc64be.c
+++ b/src/tls/bearssl/enc64be.c
@@ -22,7 +22,7 @@
  * SOFTWARE.
  */
 
-#include <ArduinoIoTCloud_Config.h>
+#include <AIoTC_Config.h>
 #ifdef BOARD_HAS_ECCX08
 
 #include "inner.h"

--- a/src/tls/bearssl/enc64le.c
+++ b/src/tls/bearssl/enc64le.c
@@ -22,7 +22,7 @@
  * SOFTWARE.
  */
 
-#include <ArduinoIoTCloud_Config.h>
+#include <AIoTC_Config.h>
 #ifdef BOARD_HAS_ECCX08
 
 #include "inner.h"

--- a/src/tls/bearssl/encode_ec_pk8der.c
+++ b/src/tls/bearssl/encode_ec_pk8der.c
@@ -22,7 +22,7 @@
  * SOFTWARE.
  */
 
-#include <ArduinoIoTCloud_Config.h>
+#include <AIoTC_Config.h>
 #ifdef BOARD_HAS_ECCX08
 
 #include "inner.h"

--- a/src/tls/bearssl/encode_ec_rawder.c
+++ b/src/tls/bearssl/encode_ec_rawder.c
@@ -22,7 +22,7 @@
  * SOFTWARE.
  */
 
-#include <ArduinoIoTCloud_Config.h>
+#include <AIoTC_Config.h>
 #ifdef BOARD_HAS_ECCX08
 
 #include "inner.h"

--- a/src/tls/bearssl/encode_rsa_pk8der.c
+++ b/src/tls/bearssl/encode_rsa_pk8der.c
@@ -22,7 +22,7 @@
  * SOFTWARE.
  */
 
-#include <ArduinoIoTCloud_Config.h>
+#include <AIoTC_Config.h>
 #ifdef BOARD_HAS_ECCX08
 
 #include "inner.h"

--- a/src/tls/bearssl/encode_rsa_rawder.c
+++ b/src/tls/bearssl/encode_rsa_rawder.c
@@ -22,7 +22,7 @@
  * SOFTWARE.
  */
 
-#include <ArduinoIoTCloud_Config.h>
+#include <AIoTC_Config.h>
 #ifdef BOARD_HAS_ECCX08
 
 #include "inner.h"

--- a/src/tls/bearssl/gcm.c
+++ b/src/tls/bearssl/gcm.c
@@ -22,7 +22,7 @@
  * SOFTWARE.
  */
 
-#include <ArduinoIoTCloud_Config.h>
+#include <AIoTC_Config.h>
 #ifdef BOARD_HAS_ECCX08
 
 #include "inner.h"

--- a/src/tls/bearssl/ghash_ctmul.c
+++ b/src/tls/bearssl/ghash_ctmul.c
@@ -22,7 +22,7 @@
  * SOFTWARE.
  */
 
-#include <ArduinoIoTCloud_Config.h>
+#include <AIoTC_Config.h>
 #ifdef BOARD_HAS_ECCX08
 
 #include "inner.h"

--- a/src/tls/bearssl/ghash_ctmul32.c
+++ b/src/tls/bearssl/ghash_ctmul32.c
@@ -22,7 +22,7 @@
  * SOFTWARE.
  */
 
-#include <ArduinoIoTCloud_Config.h>
+#include <AIoTC_Config.h>
 #ifdef BOARD_HAS_ECCX08
 
 #include "inner.h"

--- a/src/tls/bearssl/ghash_ctmul64.c
+++ b/src/tls/bearssl/ghash_ctmul64.c
@@ -22,7 +22,7 @@
  * SOFTWARE.
  */
 
-#include <ArduinoIoTCloud_Config.h>
+#include <AIoTC_Config.h>
 #ifdef BOARD_HAS_ECCX08
 
 #include "inner.h"

--- a/src/tls/bearssl/ghash_pclmul.c
+++ b/src/tls/bearssl/ghash_pclmul.c
@@ -22,7 +22,7 @@
  * SOFTWARE.
  */
 
-#include <ArduinoIoTCloud_Config.h>
+#include <AIoTC_Config.h>
 #ifdef BOARD_HAS_ECCX08
 
 #define BR_ENABLE_INTRINSICS   1

--- a/src/tls/bearssl/ghash_pwr8.c
+++ b/src/tls/bearssl/ghash_pwr8.c
@@ -22,7 +22,7 @@
  * SOFTWARE.
  */
 
-#include <ArduinoIoTCloud_Config.h>
+#include <AIoTC_Config.h>
 #ifdef BOARD_HAS_ECCX08
 
 #define BR_POWER_ASM_MACROS   1

--- a/src/tls/bearssl/hkdf.c
+++ b/src/tls/bearssl/hkdf.c
@@ -22,7 +22,7 @@
  * SOFTWARE.
  */
 
-#include <ArduinoIoTCloud_Config.h>
+#include <AIoTC_Config.h>
 #ifdef BOARD_HAS_ECCX08
 
 #include "inner.h"

--- a/src/tls/bearssl/hmac.c
+++ b/src/tls/bearssl/hmac.c
@@ -22,7 +22,7 @@
  * SOFTWARE.
  */
 
-#include <ArduinoIoTCloud_Config.h>
+#include <AIoTC_Config.h>
 #ifdef BOARD_HAS_ECCX08
 
 #include "inner.h"

--- a/src/tls/bearssl/hmac_ct.c
+++ b/src/tls/bearssl/hmac_ct.c
@@ -22,7 +22,7 @@
  * SOFTWARE.
  */
 
-#include <ArduinoIoTCloud_Config.h>
+#include <AIoTC_Config.h>
 #ifdef BOARD_HAS_ECCX08
 
 #include "inner.h"

--- a/src/tls/bearssl/hmac_drbg.c
+++ b/src/tls/bearssl/hmac_drbg.c
@@ -22,7 +22,7 @@
  * SOFTWARE.
  */
 
-#include <ArduinoIoTCloud_Config.h>
+#include <AIoTC_Config.h>
 #ifdef BOARD_HAS_ECCX08
 
 #include "inner.h"

--- a/src/tls/bearssl/i15_add.c
+++ b/src/tls/bearssl/i15_add.c
@@ -22,7 +22,7 @@
  * SOFTWARE.
  */
 
-#include <ArduinoIoTCloud_Config.h>
+#include <AIoTC_Config.h>
 #ifdef BOARD_HAS_ECCX08
 
 #include "inner.h"

--- a/src/tls/bearssl/i15_bitlen.c
+++ b/src/tls/bearssl/i15_bitlen.c
@@ -22,7 +22,7 @@
  * SOFTWARE.
  */
 
-#include <ArduinoIoTCloud_Config.h>
+#include <AIoTC_Config.h>
 #ifdef BOARD_HAS_ECCX08
 
 #include "inner.h"

--- a/src/tls/bearssl/i15_decmod.c
+++ b/src/tls/bearssl/i15_decmod.c
@@ -22,7 +22,7 @@
  * SOFTWARE.
  */
 
-#include <ArduinoIoTCloud_Config.h>
+#include <AIoTC_Config.h>
 #ifdef BOARD_HAS_ECCX08
 
 #include "inner.h"

--- a/src/tls/bearssl/i15_decode.c
+++ b/src/tls/bearssl/i15_decode.c
@@ -22,7 +22,7 @@
  * SOFTWARE.
  */
 
-#include <ArduinoIoTCloud_Config.h>
+#include <AIoTC_Config.h>
 #ifdef BOARD_HAS_ECCX08
 
 #include "inner.h"

--- a/src/tls/bearssl/i15_decred.c
+++ b/src/tls/bearssl/i15_decred.c
@@ -22,7 +22,7 @@
  * SOFTWARE.
  */
 
-#include <ArduinoIoTCloud_Config.h>
+#include <AIoTC_Config.h>
 #ifdef BOARD_HAS_ECCX08
 
 #include "inner.h"

--- a/src/tls/bearssl/i15_encode.c
+++ b/src/tls/bearssl/i15_encode.c
@@ -22,7 +22,7 @@
  * SOFTWARE.
  */
 
-#include <ArduinoIoTCloud_Config.h>
+#include <AIoTC_Config.h>
 #ifdef BOARD_HAS_ECCX08
 
 #include "inner.h"

--- a/src/tls/bearssl/i15_fmont.c
+++ b/src/tls/bearssl/i15_fmont.c
@@ -22,7 +22,7 @@
  * SOFTWARE.
  */
 
-#include <ArduinoIoTCloud_Config.h>
+#include <AIoTC_Config.h>
 #ifdef BOARD_HAS_ECCX08
 
 #include "inner.h"

--- a/src/tls/bearssl/i15_iszero.c
+++ b/src/tls/bearssl/i15_iszero.c
@@ -22,7 +22,7 @@
  * SOFTWARE.
  */
 
-#include <ArduinoIoTCloud_Config.h>
+#include <AIoTC_Config.h>
 #ifdef BOARD_HAS_ECCX08
 
 #include "inner.h"

--- a/src/tls/bearssl/i15_moddiv.c
+++ b/src/tls/bearssl/i15_moddiv.c
@@ -22,7 +22,7 @@
  * SOFTWARE.
  */
 
-#include <ArduinoIoTCloud_Config.h>
+#include <AIoTC_Config.h>
 #ifdef BOARD_HAS_ECCX08
 
 #include "inner.h"

--- a/src/tls/bearssl/i15_modpow.c
+++ b/src/tls/bearssl/i15_modpow.c
@@ -22,7 +22,7 @@
  * SOFTWARE.
  */
 
-#include <ArduinoIoTCloud_Config.h>
+#include <AIoTC_Config.h>
 #ifdef BOARD_HAS_ECCX08
 
 #include "inner.h"

--- a/src/tls/bearssl/i15_modpow2.c
+++ b/src/tls/bearssl/i15_modpow2.c
@@ -22,7 +22,7 @@
  * SOFTWARE.
  */
 
-#include <ArduinoIoTCloud_Config.h>
+#include <AIoTC_Config.h>
 #ifdef BOARD_HAS_ECCX08
 
 #include "inner.h"

--- a/src/tls/bearssl/i15_montmul.c
+++ b/src/tls/bearssl/i15_montmul.c
@@ -22,7 +22,7 @@
  * SOFTWARE.
  */
 
-#include <ArduinoIoTCloud_Config.h>
+#include <AIoTC_Config.h>
 #ifdef BOARD_HAS_ECCX08
 
 #include "inner.h"

--- a/src/tls/bearssl/i15_mulacc.c
+++ b/src/tls/bearssl/i15_mulacc.c
@@ -22,7 +22,7 @@
  * SOFTWARE.
  */
 
-#include <ArduinoIoTCloud_Config.h>
+#include <AIoTC_Config.h>
 #ifdef BOARD_HAS_ECCX08
 
 #include "inner.h"

--- a/src/tls/bearssl/i15_muladd.c
+++ b/src/tls/bearssl/i15_muladd.c
@@ -22,7 +22,7 @@
  * SOFTWARE.
  */
 
-#include <ArduinoIoTCloud_Config.h>
+#include <AIoTC_Config.h>
 #ifdef BOARD_HAS_ECCX08
 
 #include "inner.h"

--- a/src/tls/bearssl/i15_ninv15.c
+++ b/src/tls/bearssl/i15_ninv15.c
@@ -22,7 +22,7 @@
  * SOFTWARE.
  */
 
-#include <ArduinoIoTCloud_Config.h>
+#include <AIoTC_Config.h>
 #ifdef BOARD_HAS_ECCX08
 
 #include "inner.h"

--- a/src/tls/bearssl/i15_reduce.c
+++ b/src/tls/bearssl/i15_reduce.c
@@ -22,7 +22,7 @@
  * SOFTWARE.
  */
 
-#include <ArduinoIoTCloud_Config.h>
+#include <AIoTC_Config.h>
 #ifdef BOARD_HAS_ECCX08
 
 #include "inner.h"

--- a/src/tls/bearssl/i15_rshift.c
+++ b/src/tls/bearssl/i15_rshift.c
@@ -22,7 +22,7 @@
  * SOFTWARE.
  */
 
-#include <ArduinoIoTCloud_Config.h>
+#include <AIoTC_Config.h>
 #ifdef BOARD_HAS_ECCX08
 
 #include "inner.h"

--- a/src/tls/bearssl/i15_sub.c
+++ b/src/tls/bearssl/i15_sub.c
@@ -22,7 +22,7 @@
  * SOFTWARE.
  */
 
-#include <ArduinoIoTCloud_Config.h>
+#include <AIoTC_Config.h>
 #ifdef BOARD_HAS_ECCX08
 
 #include "inner.h"

--- a/src/tls/bearssl/i15_tmont.c
+++ b/src/tls/bearssl/i15_tmont.c
@@ -22,7 +22,7 @@
  * SOFTWARE.
  */
 
-#include <ArduinoIoTCloud_Config.h>
+#include <AIoTC_Config.h>
 #ifdef BOARD_HAS_ECCX08
 
 #include "inner.h"

--- a/src/tls/bearssl/i31_add.c
+++ b/src/tls/bearssl/i31_add.c
@@ -22,7 +22,7 @@
  * SOFTWARE.
  */
 
-#include <ArduinoIoTCloud_Config.h>
+#include <AIoTC_Config.h>
 #ifdef BOARD_HAS_ECCX08
 
 #include "inner.h"

--- a/src/tls/bearssl/i31_bitlen.c
+++ b/src/tls/bearssl/i31_bitlen.c
@@ -22,7 +22,7 @@
  * SOFTWARE.
  */
 
-#include <ArduinoIoTCloud_Config.h>
+#include <AIoTC_Config.h>
 #ifdef BOARD_HAS_ECCX08
 
 #include "inner.h"

--- a/src/tls/bearssl/i31_decmod.c
+++ b/src/tls/bearssl/i31_decmod.c
@@ -22,7 +22,7 @@
  * SOFTWARE.
  */
 
-#include <ArduinoIoTCloud_Config.h>
+#include <AIoTC_Config.h>
 #ifdef BOARD_HAS_ECCX08
 
 #include "inner.h"

--- a/src/tls/bearssl/i31_decode.c
+++ b/src/tls/bearssl/i31_decode.c
@@ -22,7 +22,7 @@
  * SOFTWARE.
  */
 
-#include <ArduinoIoTCloud_Config.h>
+#include <AIoTC_Config.h>
 #ifdef BOARD_HAS_ECCX08
 
 #include "inner.h"

--- a/src/tls/bearssl/i31_decred.c
+++ b/src/tls/bearssl/i31_decred.c
@@ -22,7 +22,7 @@
  * SOFTWARE.
  */
 
-#include <ArduinoIoTCloud_Config.h>
+#include <AIoTC_Config.h>
 #ifdef BOARD_HAS_ECCX08
 
 #include "inner.h"

--- a/src/tls/bearssl/i31_encode.c
+++ b/src/tls/bearssl/i31_encode.c
@@ -22,7 +22,7 @@
  * SOFTWARE.
  */
 
-#include <ArduinoIoTCloud_Config.h>
+#include <AIoTC_Config.h>
 #ifdef BOARD_HAS_ECCX08
 
 #include "inner.h"

--- a/src/tls/bearssl/i31_fmont.c
+++ b/src/tls/bearssl/i31_fmont.c
@@ -22,7 +22,7 @@
  * SOFTWARE.
  */
 
-#include <ArduinoIoTCloud_Config.h>
+#include <AIoTC_Config.h>
 #ifdef BOARD_HAS_ECCX08
 
 #include "inner.h"

--- a/src/tls/bearssl/i31_iszero.c
+++ b/src/tls/bearssl/i31_iszero.c
@@ -22,7 +22,7 @@
  * SOFTWARE.
  */
 
-#include <ArduinoIoTCloud_Config.h>
+#include <AIoTC_Config.h>
 #ifdef BOARD_HAS_ECCX08
 
 #include "inner.h"

--- a/src/tls/bearssl/i31_moddiv.c
+++ b/src/tls/bearssl/i31_moddiv.c
@@ -22,7 +22,7 @@
  * SOFTWARE.
  */
 
-#include <ArduinoIoTCloud_Config.h>
+#include <AIoTC_Config.h>
 #ifdef BOARD_HAS_ECCX08
 
 #include "inner.h"

--- a/src/tls/bearssl/i31_modpow.c
+++ b/src/tls/bearssl/i31_modpow.c
@@ -22,7 +22,7 @@
  * SOFTWARE.
  */
 
-#include <ArduinoIoTCloud_Config.h>
+#include <AIoTC_Config.h>
 #ifdef BOARD_HAS_ECCX08
 
 #include "inner.h"

--- a/src/tls/bearssl/i31_modpow2.c
+++ b/src/tls/bearssl/i31_modpow2.c
@@ -22,7 +22,7 @@
  * SOFTWARE.
  */
 
-#include <ArduinoIoTCloud_Config.h>
+#include <AIoTC_Config.h>
 #ifdef BOARD_HAS_ECCX08
 
 #include "inner.h"

--- a/src/tls/bearssl/i31_montmul.c
+++ b/src/tls/bearssl/i31_montmul.c
@@ -22,7 +22,7 @@
  * SOFTWARE.
  */
 
-#include <ArduinoIoTCloud_Config.h>
+#include <AIoTC_Config.h>
 #ifdef BOARD_HAS_ECCX08
 
 #include "inner.h"

--- a/src/tls/bearssl/i31_mulacc.c
+++ b/src/tls/bearssl/i31_mulacc.c
@@ -22,7 +22,7 @@
  * SOFTWARE.
  */
 
-#include <ArduinoIoTCloud_Config.h>
+#include <AIoTC_Config.h>
 #ifdef BOARD_HAS_ECCX08
 
 #include "inner.h"

--- a/src/tls/bearssl/i31_muladd.c
+++ b/src/tls/bearssl/i31_muladd.c
@@ -22,7 +22,7 @@
  * SOFTWARE.
  */
 
-#include <ArduinoIoTCloud_Config.h>
+#include <AIoTC_Config.h>
 #ifdef BOARD_HAS_ECCX08
 
 #include "inner.h"

--- a/src/tls/bearssl/i31_ninv31.c
+++ b/src/tls/bearssl/i31_ninv31.c
@@ -22,7 +22,7 @@
  * SOFTWARE.
  */
 
-#include <ArduinoIoTCloud_Config.h>
+#include <AIoTC_Config.h>
 #ifdef BOARD_HAS_ECCX08
 
 #include "inner.h"

--- a/src/tls/bearssl/i31_reduce.c
+++ b/src/tls/bearssl/i31_reduce.c
@@ -22,7 +22,7 @@
  * SOFTWARE.
  */
 
-#include <ArduinoIoTCloud_Config.h>
+#include <AIoTC_Config.h>
 #ifdef BOARD_HAS_ECCX08
 
 #include "inner.h"

--- a/src/tls/bearssl/i31_rshift.c
+++ b/src/tls/bearssl/i31_rshift.c
@@ -22,7 +22,7 @@
  * SOFTWARE.
  */
 
-#include <ArduinoIoTCloud_Config.h>
+#include <AIoTC_Config.h>
 #ifdef BOARD_HAS_ECCX08
 
 #include "inner.h"

--- a/src/tls/bearssl/i31_sub.c
+++ b/src/tls/bearssl/i31_sub.c
@@ -22,7 +22,7 @@
  * SOFTWARE.
  */
 
-#include <ArduinoIoTCloud_Config.h>
+#include <AIoTC_Config.h>
 #ifdef BOARD_HAS_ECCX08
 
 #include "inner.h"

--- a/src/tls/bearssl/i31_tmont.c
+++ b/src/tls/bearssl/i31_tmont.c
@@ -22,7 +22,7 @@
  * SOFTWARE.
  */
 
-#include <ArduinoIoTCloud_Config.h>
+#include <AIoTC_Config.h>
 #ifdef BOARD_HAS_ECCX08
 
 #include "inner.h"

--- a/src/tls/bearssl/i32_add.c
+++ b/src/tls/bearssl/i32_add.c
@@ -22,7 +22,7 @@
  * SOFTWARE.
  */
 
-#include <ArduinoIoTCloud_Config.h>
+#include <AIoTC_Config.h>
 #ifdef BOARD_HAS_ECCX08
 
 #include "inner.h"

--- a/src/tls/bearssl/i32_bitlen.c
+++ b/src/tls/bearssl/i32_bitlen.c
@@ -22,7 +22,7 @@
  * SOFTWARE.
  */
 
-#include <ArduinoIoTCloud_Config.h>
+#include <AIoTC_Config.h>
 #ifdef BOARD_HAS_ECCX08
 
 #include "inner.h"

--- a/src/tls/bearssl/i32_decmod.c
+++ b/src/tls/bearssl/i32_decmod.c
@@ -22,7 +22,7 @@
  * SOFTWARE.
  */
 
-#include <ArduinoIoTCloud_Config.h>
+#include <AIoTC_Config.h>
 #ifdef BOARD_HAS_ECCX08
 
 #include "inner.h"

--- a/src/tls/bearssl/i32_decode.c
+++ b/src/tls/bearssl/i32_decode.c
@@ -22,7 +22,7 @@
  * SOFTWARE.
  */
 
-#include <ArduinoIoTCloud_Config.h>
+#include <AIoTC_Config.h>
 #ifdef BOARD_HAS_ECCX08
 
 #include "inner.h"

--- a/src/tls/bearssl/i32_decred.c
+++ b/src/tls/bearssl/i32_decred.c
@@ -22,7 +22,7 @@
  * SOFTWARE.
  */
 
-#include <ArduinoIoTCloud_Config.h>
+#include <AIoTC_Config.h>
 #ifdef BOARD_HAS_ECCX08
 
 #include "inner.h"

--- a/src/tls/bearssl/i32_div32.c
+++ b/src/tls/bearssl/i32_div32.c
@@ -22,7 +22,7 @@
  * SOFTWARE.
  */
 
-#include <ArduinoIoTCloud_Config.h>
+#include <AIoTC_Config.h>
 #ifdef BOARD_HAS_ECCX08
 
 #include "inner.h"

--- a/src/tls/bearssl/i32_encode.c
+++ b/src/tls/bearssl/i32_encode.c
@@ -22,7 +22,7 @@
  * SOFTWARE.
  */
 
-#include <ArduinoIoTCloud_Config.h>
+#include <AIoTC_Config.h>
 #ifdef BOARD_HAS_ECCX08
 
 #include "inner.h"

--- a/src/tls/bearssl/i32_fmont.c
+++ b/src/tls/bearssl/i32_fmont.c
@@ -22,7 +22,7 @@
  * SOFTWARE.
  */
 
-#include <ArduinoIoTCloud_Config.h>
+#include <AIoTC_Config.h>
 #ifdef BOARD_HAS_ECCX08
 
 #include "inner.h"

--- a/src/tls/bearssl/i32_iszero.c
+++ b/src/tls/bearssl/i32_iszero.c
@@ -22,7 +22,7 @@
  * SOFTWARE.
  */
 
-#include <ArduinoIoTCloud_Config.h>
+#include <AIoTC_Config.h>
 #ifdef BOARD_HAS_ECCX08
 
 #include "inner.h"

--- a/src/tls/bearssl/i32_modpow.c
+++ b/src/tls/bearssl/i32_modpow.c
@@ -22,7 +22,7 @@
  * SOFTWARE.
  */
 
-#include <ArduinoIoTCloud_Config.h>
+#include <AIoTC_Config.h>
 #ifdef BOARD_HAS_ECCX08
 
 #include "inner.h"

--- a/src/tls/bearssl/i32_montmul.c
+++ b/src/tls/bearssl/i32_montmul.c
@@ -22,7 +22,7 @@
  * SOFTWARE.
  */
 
-#include <ArduinoIoTCloud_Config.h>
+#include <AIoTC_Config.h>
 #ifdef BOARD_HAS_ECCX08
 
 #include "inner.h"

--- a/src/tls/bearssl/i32_mulacc.c
+++ b/src/tls/bearssl/i32_mulacc.c
@@ -22,7 +22,7 @@
  * SOFTWARE.
  */
 
-#include <ArduinoIoTCloud_Config.h>
+#include <AIoTC_Config.h>
 #ifdef BOARD_HAS_ECCX08
 
 #include "inner.h"

--- a/src/tls/bearssl/i32_muladd.c
+++ b/src/tls/bearssl/i32_muladd.c
@@ -22,7 +22,7 @@
  * SOFTWARE.
  */
 
-#include <ArduinoIoTCloud_Config.h>
+#include <AIoTC_Config.h>
 #ifdef BOARD_HAS_ECCX08
 
 #include "inner.h"

--- a/src/tls/bearssl/i32_ninv32.c
+++ b/src/tls/bearssl/i32_ninv32.c
@@ -22,7 +22,7 @@
  * SOFTWARE.
  */
 
-#include <ArduinoIoTCloud_Config.h>
+#include <AIoTC_Config.h>
 #ifdef BOARD_HAS_ECCX08
 
 #include "inner.h"

--- a/src/tls/bearssl/i32_reduce.c
+++ b/src/tls/bearssl/i32_reduce.c
@@ -22,7 +22,7 @@
  * SOFTWARE.
  */
 
-#include <ArduinoIoTCloud_Config.h>
+#include <AIoTC_Config.h>
 #ifdef BOARD_HAS_ECCX08
 
 #include "inner.h"

--- a/src/tls/bearssl/i32_sub.c
+++ b/src/tls/bearssl/i32_sub.c
@@ -22,7 +22,7 @@
  * SOFTWARE.
  */
 
-#include <ArduinoIoTCloud_Config.h>
+#include <AIoTC_Config.h>
 #ifdef BOARD_HAS_ECCX08
 
 #include "inner.h"

--- a/src/tls/bearssl/i32_tmont.c
+++ b/src/tls/bearssl/i32_tmont.c
@@ -22,7 +22,7 @@
  * SOFTWARE.
  */
 
-#include <ArduinoIoTCloud_Config.h>
+#include <AIoTC_Config.h>
 #ifdef BOARD_HAS_ECCX08
 
 #include "inner.h"

--- a/src/tls/bearssl/i62_modpow2.c
+++ b/src/tls/bearssl/i62_modpow2.c
@@ -22,7 +22,7 @@
  * SOFTWARE.
  */
 
-#include <ArduinoIoTCloud_Config.h>
+#include <AIoTC_Config.h>
 #ifdef BOARD_HAS_ECCX08
 
 #include "inner.h"

--- a/src/tls/bearssl/md5.c
+++ b/src/tls/bearssl/md5.c
@@ -22,7 +22,7 @@
  * SOFTWARE.
  */
 
-#include <ArduinoIoTCloud_Config.h>
+#include <AIoTC_Config.h>
 #ifdef BOARD_HAS_ECCX08
 
 #include "inner.h"

--- a/src/tls/bearssl/md5sha1.c
+++ b/src/tls/bearssl/md5sha1.c
@@ -22,7 +22,7 @@
  * SOFTWARE.
  */
 
-#include <ArduinoIoTCloud_Config.h>
+#include <AIoTC_Config.h>
 #ifdef BOARD_HAS_ECCX08
 
 #include "inner.h"

--- a/src/tls/bearssl/mgf1.c
+++ b/src/tls/bearssl/mgf1.c
@@ -22,7 +22,7 @@
  * SOFTWARE.
  */
 
-#include <ArduinoIoTCloud_Config.h>
+#include <AIoTC_Config.h>
 #ifdef BOARD_HAS_ECCX08
 
 #include "inner.h"

--- a/src/tls/bearssl/multihash.c
+++ b/src/tls/bearssl/multihash.c
@@ -22,7 +22,7 @@
  * SOFTWARE.
  */
 
-#include <ArduinoIoTCloud_Config.h>
+#include <AIoTC_Config.h>
 #ifdef BOARD_HAS_ECCX08
 
 #include "inner.h"

--- a/src/tls/bearssl/pemdec.c
+++ b/src/tls/bearssl/pemdec.c
@@ -1,6 +1,6 @@
 /* Automatically generated code; do not modify directly. */
 
-#include <ArduinoIoTCloud_Config.h>
+#include <AIoTC_Config.h>
 #ifdef BOARD_HAS_ECCX08
 
 #include <stddef.h>

--- a/src/tls/bearssl/pemenc.c
+++ b/src/tls/bearssl/pemenc.c
@@ -22,7 +22,7 @@
  * SOFTWARE.
  */
 
-#include <ArduinoIoTCloud_Config.h>
+#include <AIoTC_Config.h>
 #ifdef BOARD_HAS_ECCX08
 
 #include "inner.h"

--- a/src/tls/bearssl/poly1305_ctmul.c
+++ b/src/tls/bearssl/poly1305_ctmul.c
@@ -22,7 +22,7 @@
  * SOFTWARE.
  */
 
-#include <ArduinoIoTCloud_Config.h>
+#include <AIoTC_Config.h>
 #ifdef BOARD_HAS_ECCX08
 
 #include "inner.h"

--- a/src/tls/bearssl/poly1305_ctmul32.c
+++ b/src/tls/bearssl/poly1305_ctmul32.c
@@ -22,7 +22,7 @@
  * SOFTWARE.
  */
 
-#include <ArduinoIoTCloud_Config.h>
+#include <AIoTC_Config.h>
 #ifdef BOARD_HAS_ECCX08
 
 #include "inner.h"

--- a/src/tls/bearssl/poly1305_ctmulq.c
+++ b/src/tls/bearssl/poly1305_ctmulq.c
@@ -22,7 +22,7 @@
  * SOFTWARE.
  */
 
-#include <ArduinoIoTCloud_Config.h>
+#include <AIoTC_Config.h>
 #ifdef BOARD_HAS_ECCX08
 
 #include "inner.h"

--- a/src/tls/bearssl/poly1305_i15.c
+++ b/src/tls/bearssl/poly1305_i15.c
@@ -22,7 +22,7 @@
  * SOFTWARE.
  */
 
-#include <ArduinoIoTCloud_Config.h>
+#include <AIoTC_Config.h>
 #ifdef BOARD_HAS_ECCX08
 
 #include "inner.h"

--- a/src/tls/bearssl/prf.c
+++ b/src/tls/bearssl/prf.c
@@ -22,7 +22,7 @@
  * SOFTWARE.
  */
 
-#include <ArduinoIoTCloud_Config.h>
+#include <AIoTC_Config.h>
 #ifdef BOARD_HAS_ECCX08
 
 #include "inner.h"

--- a/src/tls/bearssl/prf_md5sha1.c
+++ b/src/tls/bearssl/prf_md5sha1.c
@@ -22,7 +22,7 @@
  * SOFTWARE.
  */
 
-#include <ArduinoIoTCloud_Config.h>
+#include <AIoTC_Config.h>
 #ifdef BOARD_HAS_ECCX08
 
 #include "inner.h"

--- a/src/tls/bearssl/prf_sha256.c
+++ b/src/tls/bearssl/prf_sha256.c
@@ -22,7 +22,7 @@
  * SOFTWARE.
  */
 
-#include <ArduinoIoTCloud_Config.h>
+#include <AIoTC_Config.h>
 #ifdef BOARD_HAS_ECCX08
 
 #include "inner.h"

--- a/src/tls/bearssl/prf_sha384.c
+++ b/src/tls/bearssl/prf_sha384.c
@@ -22,7 +22,7 @@
  * SOFTWARE.
  */
 
-#include <ArduinoIoTCloud_Config.h>
+#include <AIoTC_Config.h>
 #ifdef BOARD_HAS_ECCX08
 
 #include "inner.h"

--- a/src/tls/bearssl/rsa_default_keygen.c
+++ b/src/tls/bearssl/rsa_default_keygen.c
@@ -22,7 +22,7 @@
  * SOFTWARE.
  */
 
-#include <ArduinoIoTCloud_Config.h>
+#include <AIoTC_Config.h>
 #ifdef BOARD_HAS_ECCX08
 
 #include "inner.h"

--- a/src/tls/bearssl/rsa_default_modulus.c
+++ b/src/tls/bearssl/rsa_default_modulus.c
@@ -22,7 +22,7 @@
  * SOFTWARE.
  */
 
-#include <ArduinoIoTCloud_Config.h>
+#include <AIoTC_Config.h>
 #ifdef BOARD_HAS_ECCX08
 
 #include "inner.h"

--- a/src/tls/bearssl/rsa_default_oaep_decrypt.c
+++ b/src/tls/bearssl/rsa_default_oaep_decrypt.c
@@ -22,7 +22,7 @@
  * SOFTWARE.
  */
 
-#include <ArduinoIoTCloud_Config.h>
+#include <AIoTC_Config.h>
 #ifdef BOARD_HAS_ECCX08
 
 #include "inner.h"

--- a/src/tls/bearssl/rsa_default_oaep_encrypt.c
+++ b/src/tls/bearssl/rsa_default_oaep_encrypt.c
@@ -22,7 +22,7 @@
  * SOFTWARE.
  */
 
-#include <ArduinoIoTCloud_Config.h>
+#include <AIoTC_Config.h>
 #ifdef BOARD_HAS_ECCX08
 
 #include "inner.h"

--- a/src/tls/bearssl/rsa_default_pkcs1_sign.c
+++ b/src/tls/bearssl/rsa_default_pkcs1_sign.c
@@ -22,7 +22,7 @@
  * SOFTWARE.
  */
 
-#include <ArduinoIoTCloud_Config.h>
+#include <AIoTC_Config.h>
 #ifdef BOARD_HAS_ECCX08
 
 #include "inner.h"

--- a/src/tls/bearssl/rsa_default_pkcs1_vrfy.c
+++ b/src/tls/bearssl/rsa_default_pkcs1_vrfy.c
@@ -22,7 +22,7 @@
  * SOFTWARE.
  */
 
-#include <ArduinoIoTCloud_Config.h>
+#include <AIoTC_Config.h>
 #ifdef BOARD_HAS_ECCX08
 
 #include "inner.h"

--- a/src/tls/bearssl/rsa_default_priv.c
+++ b/src/tls/bearssl/rsa_default_priv.c
@@ -22,7 +22,7 @@
  * SOFTWARE.
  */
 
-#include <ArduinoIoTCloud_Config.h>
+#include <AIoTC_Config.h>
 #ifdef BOARD_HAS_ECCX08
 
 #include "inner.h"

--- a/src/tls/bearssl/rsa_default_privexp.c
+++ b/src/tls/bearssl/rsa_default_privexp.c
@@ -22,7 +22,7 @@
  * SOFTWARE.
  */
 
-#include <ArduinoIoTCloud_Config.h>
+#include <AIoTC_Config.h>
 #ifdef BOARD_HAS_ECCX08
 
 #include "inner.h"

--- a/src/tls/bearssl/rsa_default_pub.c
+++ b/src/tls/bearssl/rsa_default_pub.c
@@ -22,7 +22,7 @@
  * SOFTWARE.
  */
 
-#include <ArduinoIoTCloud_Config.h>
+#include <AIoTC_Config.h>
 #ifdef BOARD_HAS_ECCX08
 
 #include "inner.h"

--- a/src/tls/bearssl/rsa_default_pubexp.c
+++ b/src/tls/bearssl/rsa_default_pubexp.c
@@ -22,7 +22,7 @@
  * SOFTWARE.
  */
 
-#include <ArduinoIoTCloud_Config.h>
+#include <AIoTC_Config.h>
 #ifdef BOARD_HAS_ECCX08
 
 #include "inner.h"

--- a/src/tls/bearssl/rsa_i15_keygen.c
+++ b/src/tls/bearssl/rsa_i15_keygen.c
@@ -22,7 +22,7 @@
  * SOFTWARE.
  */
 
-#include <ArduinoIoTCloud_Config.h>
+#include <AIoTC_Config.h>
 #ifdef BOARD_HAS_ECCX08
 
 #include "inner.h"

--- a/src/tls/bearssl/rsa_i15_modulus.c
+++ b/src/tls/bearssl/rsa_i15_modulus.c
@@ -22,7 +22,7 @@
  * SOFTWARE.
  */
 
-#include <ArduinoIoTCloud_Config.h>
+#include <AIoTC_Config.h>
 #ifdef BOARD_HAS_ECCX08
 
 #include "inner.h"

--- a/src/tls/bearssl/rsa_i15_oaep_decrypt.c
+++ b/src/tls/bearssl/rsa_i15_oaep_decrypt.c
@@ -22,7 +22,7 @@
  * SOFTWARE.
  */
 
-#include <ArduinoIoTCloud_Config.h>
+#include <AIoTC_Config.h>
 #ifdef BOARD_HAS_ECCX08
 
 #include "inner.h"

--- a/src/tls/bearssl/rsa_i15_oaep_encrypt.c
+++ b/src/tls/bearssl/rsa_i15_oaep_encrypt.c
@@ -22,7 +22,7 @@
  * SOFTWARE.
  */
 
-#include <ArduinoIoTCloud_Config.h>
+#include <AIoTC_Config.h>
 #ifdef BOARD_HAS_ECCX08
 
 #include "inner.h"

--- a/src/tls/bearssl/rsa_i15_pkcs1_sign.c
+++ b/src/tls/bearssl/rsa_i15_pkcs1_sign.c
@@ -22,7 +22,7 @@
  * SOFTWARE.
  */
 
-#include <ArduinoIoTCloud_Config.h>
+#include <AIoTC_Config.h>
 #ifdef BOARD_HAS_ECCX08
 
 #include "inner.h"

--- a/src/tls/bearssl/rsa_i15_pkcs1_vrfy.c
+++ b/src/tls/bearssl/rsa_i15_pkcs1_vrfy.c
@@ -22,7 +22,7 @@
  * SOFTWARE.
  */
 
-#include <ArduinoIoTCloud_Config.h>
+#include <AIoTC_Config.h>
 #ifdef BOARD_HAS_ECCX08
 
 #include "inner.h"

--- a/src/tls/bearssl/rsa_i15_priv.c
+++ b/src/tls/bearssl/rsa_i15_priv.c
@@ -22,7 +22,7 @@
  * SOFTWARE.
  */
 
-#include <ArduinoIoTCloud_Config.h>
+#include <AIoTC_Config.h>
 #ifdef BOARD_HAS_ECCX08
 
 #include "inner.h"

--- a/src/tls/bearssl/rsa_i15_privexp.c
+++ b/src/tls/bearssl/rsa_i15_privexp.c
@@ -22,7 +22,7 @@
  * SOFTWARE.
  */
 
-#include <ArduinoIoTCloud_Config.h>
+#include <AIoTC_Config.h>
 #ifdef BOARD_HAS_ECCX08
 
 #include "inner.h"

--- a/src/tls/bearssl/rsa_i15_pub.c
+++ b/src/tls/bearssl/rsa_i15_pub.c
@@ -22,7 +22,7 @@
  * SOFTWARE.
  */
 
-#include <ArduinoIoTCloud_Config.h>
+#include <AIoTC_Config.h>
 #ifdef BOARD_HAS_ECCX08
 
 #include "inner.h"

--- a/src/tls/bearssl/rsa_i15_pubexp.c
+++ b/src/tls/bearssl/rsa_i15_pubexp.c
@@ -22,7 +22,7 @@
  * SOFTWARE.
  */
 
-#include <ArduinoIoTCloud_Config.h>
+#include <AIoTC_Config.h>
 #ifdef BOARD_HAS_ECCX08
 
 #include "inner.h"

--- a/src/tls/bearssl/rsa_i31_keygen.c
+++ b/src/tls/bearssl/rsa_i31_keygen.c
@@ -22,7 +22,7 @@
  * SOFTWARE.
  */
 
-#include <ArduinoIoTCloud_Config.h>
+#include <AIoTC_Config.h>
 #ifdef BOARD_HAS_ECCX08
 
 #include "inner.h"

--- a/src/tls/bearssl/rsa_i31_keygen_inner.c
+++ b/src/tls/bearssl/rsa_i31_keygen_inner.c
@@ -22,7 +22,7 @@
  * SOFTWARE.
  */
 
-#include <ArduinoIoTCloud_Config.h>
+#include <AIoTC_Config.h>
 #ifdef BOARD_HAS_ECCX08
 
 #include "inner.h"

--- a/src/tls/bearssl/rsa_i31_modulus.c
+++ b/src/tls/bearssl/rsa_i31_modulus.c
@@ -22,7 +22,7 @@
  * SOFTWARE.
  */
 
-#include <ArduinoIoTCloud_Config.h>
+#include <AIoTC_Config.h>
 #ifdef BOARD_HAS_ECCX08
 
 #include "inner.h"

--- a/src/tls/bearssl/rsa_i31_oaep_decrypt.c
+++ b/src/tls/bearssl/rsa_i31_oaep_decrypt.c
@@ -22,7 +22,7 @@
  * SOFTWARE.
  */
 
-#include <ArduinoIoTCloud_Config.h>
+#include <AIoTC_Config.h>
 #ifdef BOARD_HAS_ECCX08
 
 #include "inner.h"

--- a/src/tls/bearssl/rsa_i31_oaep_encrypt.c
+++ b/src/tls/bearssl/rsa_i31_oaep_encrypt.c
@@ -22,7 +22,7 @@
  * SOFTWARE.
  */
 
-#include <ArduinoIoTCloud_Config.h>
+#include <AIoTC_Config.h>
 #ifdef BOARD_HAS_ECCX08
 
 #include "inner.h"

--- a/src/tls/bearssl/rsa_i31_pkcs1_sign.c
+++ b/src/tls/bearssl/rsa_i31_pkcs1_sign.c
@@ -22,7 +22,7 @@
  * SOFTWARE.
  */
 
-#include <ArduinoIoTCloud_Config.h>
+#include <AIoTC_Config.h>
 #ifdef BOARD_HAS_ECCX08
 
 #include "inner.h"

--- a/src/tls/bearssl/rsa_i31_pkcs1_vrfy.c
+++ b/src/tls/bearssl/rsa_i31_pkcs1_vrfy.c
@@ -22,7 +22,7 @@
  * SOFTWARE.
  */
 
-#include <ArduinoIoTCloud_Config.h>
+#include <AIoTC_Config.h>
 #ifdef BOARD_HAS_ECCX08
 
 #include "inner.h"

--- a/src/tls/bearssl/rsa_i31_priv.c
+++ b/src/tls/bearssl/rsa_i31_priv.c
@@ -22,7 +22,7 @@
  * SOFTWARE.
  */
 
-#include <ArduinoIoTCloud_Config.h>
+#include <AIoTC_Config.h>
 #ifdef BOARD_HAS_ECCX08
 
 #include "inner.h"

--- a/src/tls/bearssl/rsa_i31_privexp.c
+++ b/src/tls/bearssl/rsa_i31_privexp.c
@@ -22,7 +22,7 @@
  * SOFTWARE.
  */
 
-#include <ArduinoIoTCloud_Config.h>
+#include <AIoTC_Config.h>
 #ifdef BOARD_HAS_ECCX08
 
 #include "inner.h"

--- a/src/tls/bearssl/rsa_i31_pub.c
+++ b/src/tls/bearssl/rsa_i31_pub.c
@@ -22,7 +22,7 @@
  * SOFTWARE.
  */
 
-#include <ArduinoIoTCloud_Config.h>
+#include <AIoTC_Config.h>
 #ifdef BOARD_HAS_ECCX08
 
 #include "inner.h"

--- a/src/tls/bearssl/rsa_i31_pubexp.c
+++ b/src/tls/bearssl/rsa_i31_pubexp.c
@@ -22,7 +22,7 @@
  * SOFTWARE.
  */
 
-#include <ArduinoIoTCloud_Config.h>
+#include <AIoTC_Config.h>
 #ifdef BOARD_HAS_ECCX08
 
 #include "inner.h"

--- a/src/tls/bearssl/rsa_i32_oaep_decrypt.c
+++ b/src/tls/bearssl/rsa_i32_oaep_decrypt.c
@@ -22,7 +22,7 @@
  * SOFTWARE.
  */
 
-#include <ArduinoIoTCloud_Config.h>
+#include <AIoTC_Config.h>
 #ifdef BOARD_HAS_ECCX08
 
 #include "inner.h"

--- a/src/tls/bearssl/rsa_i32_oaep_encrypt.c
+++ b/src/tls/bearssl/rsa_i32_oaep_encrypt.c
@@ -22,7 +22,7 @@
  * SOFTWARE.
  */
 
-#include <ArduinoIoTCloud_Config.h>
+#include <AIoTC_Config.h>
 #ifdef BOARD_HAS_ECCX08
 
 #include "inner.h"

--- a/src/tls/bearssl/rsa_i32_pkcs1_sign.c
+++ b/src/tls/bearssl/rsa_i32_pkcs1_sign.c
@@ -22,7 +22,7 @@
  * SOFTWARE.
  */
 
-#include <ArduinoIoTCloud_Config.h>
+#include <AIoTC_Config.h>
 #ifdef BOARD_HAS_ECCX08
 
 #include "inner.h"

--- a/src/tls/bearssl/rsa_i32_pkcs1_vrfy.c
+++ b/src/tls/bearssl/rsa_i32_pkcs1_vrfy.c
@@ -22,7 +22,7 @@
  * SOFTWARE.
  */
 
-#include <ArduinoIoTCloud_Config.h>
+#include <AIoTC_Config.h>
 #ifdef BOARD_HAS_ECCX08
 
 #include "inner.h"

--- a/src/tls/bearssl/rsa_i32_priv.c
+++ b/src/tls/bearssl/rsa_i32_priv.c
@@ -22,7 +22,7 @@
  * SOFTWARE.
  */
 
-#include <ArduinoIoTCloud_Config.h>
+#include <AIoTC_Config.h>
 #ifdef BOARD_HAS_ECCX08
 
 #include "inner.h"

--- a/src/tls/bearssl/rsa_i32_pub.c
+++ b/src/tls/bearssl/rsa_i32_pub.c
@@ -22,7 +22,7 @@
  * SOFTWARE.
  */
 
-#include <ArduinoIoTCloud_Config.h>
+#include <AIoTC_Config.h>
 #ifdef BOARD_HAS_ECCX08
 
 #include "inner.h"

--- a/src/tls/bearssl/rsa_i62_keygen.c
+++ b/src/tls/bearssl/rsa_i62_keygen.c
@@ -22,7 +22,7 @@
  * SOFTWARE.
  */
 
-#include <ArduinoIoTCloud_Config.h>
+#include <AIoTC_Config.h>
 #ifdef BOARD_HAS_ECCX08
 
 #include "inner.h"

--- a/src/tls/bearssl/rsa_i62_oaep_decrypt.c
+++ b/src/tls/bearssl/rsa_i62_oaep_decrypt.c
@@ -22,7 +22,7 @@
  * SOFTWARE.
  */
 
-#include <ArduinoIoTCloud_Config.h>
+#include <AIoTC_Config.h>
 #ifdef BOARD_HAS_ECCX08
 
 #include "inner.h"

--- a/src/tls/bearssl/rsa_i62_oaep_encrypt.c
+++ b/src/tls/bearssl/rsa_i62_oaep_encrypt.c
@@ -22,7 +22,7 @@
  * SOFTWARE.
  */
 
-#include <ArduinoIoTCloud_Config.h>
+#include <AIoTC_Config.h>
 #ifdef BOARD_HAS_ECCX08
 
 #include "inner.h"

--- a/src/tls/bearssl/rsa_i62_pkcs1_sign.c
+++ b/src/tls/bearssl/rsa_i62_pkcs1_sign.c
@@ -22,7 +22,7 @@
  * SOFTWARE.
  */
 
-#include <ArduinoIoTCloud_Config.h>
+#include <AIoTC_Config.h>
 #ifdef BOARD_HAS_ECCX08
 
 #include "inner.h"

--- a/src/tls/bearssl/rsa_i62_pkcs1_vrfy.c
+++ b/src/tls/bearssl/rsa_i62_pkcs1_vrfy.c
@@ -22,7 +22,7 @@
  * SOFTWARE.
  */
 
-#include <ArduinoIoTCloud_Config.h>
+#include <AIoTC_Config.h>
 #ifdef BOARD_HAS_ECCX08
 
 #include "inner.h"

--- a/src/tls/bearssl/rsa_i62_priv.c
+++ b/src/tls/bearssl/rsa_i62_priv.c
@@ -22,7 +22,7 @@
  * SOFTWARE.
  */
 
-#include <ArduinoIoTCloud_Config.h>
+#include <AIoTC_Config.h>
 #ifdef BOARD_HAS_ECCX08
 
 #include "inner.h"

--- a/src/tls/bearssl/rsa_i62_pub.c
+++ b/src/tls/bearssl/rsa_i62_pub.c
@@ -22,7 +22,7 @@
  * SOFTWARE.
  */
 
-#include <ArduinoIoTCloud_Config.h>
+#include <AIoTC_Config.h>
 #ifdef BOARD_HAS_ECCX08
 
 #include "inner.h"

--- a/src/tls/bearssl/rsa_oaep_pad.c
+++ b/src/tls/bearssl/rsa_oaep_pad.c
@@ -22,7 +22,7 @@
  * SOFTWARE.
  */
 
-#include <ArduinoIoTCloud_Config.h>
+#include <AIoTC_Config.h>
 #ifdef BOARD_HAS_ECCX08
 
 #include "inner.h"

--- a/src/tls/bearssl/rsa_oaep_unpad.c
+++ b/src/tls/bearssl/rsa_oaep_unpad.c
@@ -22,7 +22,7 @@
  * SOFTWARE.
  */
 
-#include <ArduinoIoTCloud_Config.h>
+#include <AIoTC_Config.h>
 #ifdef BOARD_HAS_ECCX08
 
 #include "inner.h"

--- a/src/tls/bearssl/rsa_pkcs1_sig_pad.c
+++ b/src/tls/bearssl/rsa_pkcs1_sig_pad.c
@@ -22,7 +22,7 @@
  * SOFTWARE.
  */
 
-#include <ArduinoIoTCloud_Config.h>
+#include <AIoTC_Config.h>
 #ifdef BOARD_HAS_ECCX08
 
 #include "inner.h"

--- a/src/tls/bearssl/rsa_pkcs1_sig_unpad.c
+++ b/src/tls/bearssl/rsa_pkcs1_sig_unpad.c
@@ -22,7 +22,7 @@
  * SOFTWARE.
  */
 
-#include <ArduinoIoTCloud_Config.h>
+#include <AIoTC_Config.h>
 #ifdef BOARD_HAS_ECCX08
 
 #include "inner.h"

--- a/src/tls/bearssl/rsa_ssl_decrypt.c
+++ b/src/tls/bearssl/rsa_ssl_decrypt.c
@@ -22,7 +22,7 @@
  * SOFTWARE.
  */
 
-#include <ArduinoIoTCloud_Config.h>
+#include <AIoTC_Config.h>
 #ifdef BOARD_HAS_ECCX08
 
 #include "inner.h"

--- a/src/tls/bearssl/settings.c
+++ b/src/tls/bearssl/settings.c
@@ -22,7 +22,7 @@
  * SOFTWARE.
  */
 
-#include <ArduinoIoTCloud_Config.h>
+#include <AIoTC_Config.h>
 #ifdef BOARD_HAS_ECCX08
 
 #include "inner.h"

--- a/src/tls/bearssl/sha1.c
+++ b/src/tls/bearssl/sha1.c
@@ -22,7 +22,7 @@
  * SOFTWARE.
  */
 
-#include <ArduinoIoTCloud_Config.h>
+#include <AIoTC_Config.h>
 #ifdef BOARD_HAS_ECCX08
 
 #include "inner.h"

--- a/src/tls/bearssl/sha2big.c
+++ b/src/tls/bearssl/sha2big.c
@@ -22,7 +22,7 @@
  * SOFTWARE.
  */
 
-#include <ArduinoIoTCloud_Config.h>
+#include <AIoTC_Config.h>
 #ifdef BOARD_HAS_ECCX08
 
 #include "inner.h"

--- a/src/tls/bearssl/sha2small.c
+++ b/src/tls/bearssl/sha2small.c
@@ -22,7 +22,7 @@
  * SOFTWARE.
  */
 
-#include <ArduinoIoTCloud_Config.h>
+#include <AIoTC_Config.h>
 #ifdef BOARD_HAS_ECCX08
 
 #include "inner.h"

--- a/src/tls/bearssl/skey_decoder.c
+++ b/src/tls/bearssl/skey_decoder.c
@@ -1,6 +1,6 @@
 /* Automatically generated code; do not modify directly. */
 
-#include <ArduinoIoTCloud_Config.h>
+#include <AIoTC_Config.h>
 #ifdef BOARD_HAS_ECCX08
 
 #include <stddef.h>

--- a/src/tls/bearssl/ssl_ccert_single_ec.c
+++ b/src/tls/bearssl/ssl_ccert_single_ec.c
@@ -22,7 +22,7 @@
  * SOFTWARE.
  */
 
-#include <ArduinoIoTCloud_Config.h>
+#include <AIoTC_Config.h>
 #ifdef BOARD_HAS_ECCX08
 
 #include "inner.h"

--- a/src/tls/bearssl/ssl_ccert_single_rsa.c
+++ b/src/tls/bearssl/ssl_ccert_single_rsa.c
@@ -22,7 +22,7 @@
  * SOFTWARE.
  */
 
-#include <ArduinoIoTCloud_Config.h>
+#include <AIoTC_Config.h>
 #ifdef BOARD_HAS_ECCX08
 
 #include "inner.h"

--- a/src/tls/bearssl/ssl_client.c
+++ b/src/tls/bearssl/ssl_client.c
@@ -22,7 +22,7 @@
  * SOFTWARE.
  */
 
-#include <ArduinoIoTCloud_Config.h>
+#include <AIoTC_Config.h>
 #ifdef BOARD_HAS_ECCX08
 
 #include "inner.h"

--- a/src/tls/bearssl/ssl_client_default_rsapub.c
+++ b/src/tls/bearssl/ssl_client_default_rsapub.c
@@ -22,7 +22,7 @@
  * SOFTWARE.
  */
 
-#include <ArduinoIoTCloud_Config.h>
+#include <AIoTC_Config.h>
 #ifdef BOARD_HAS_ECCX08
 
 #include "inner.h"

--- a/src/tls/bearssl/ssl_client_full.c
+++ b/src/tls/bearssl/ssl_client_full.c
@@ -22,7 +22,7 @@
  * SOFTWARE.
  */
 
-#include <ArduinoIoTCloud_Config.h>
+#include <AIoTC_Config.h>
 #ifdef BOARD_HAS_ECCX08
 
 #include "inner.h"

--- a/src/tls/bearssl/ssl_engine.c
+++ b/src/tls/bearssl/ssl_engine.c
@@ -22,7 +22,7 @@
  * SOFTWARE.
  */
 
-#include <ArduinoIoTCloud_Config.h>
+#include <AIoTC_Config.h>
 #ifdef BOARD_HAS_ECCX08
 
 #include "inner.h"

--- a/src/tls/bearssl/ssl_engine_default_aescbc.c
+++ b/src/tls/bearssl/ssl_engine_default_aescbc.c
@@ -22,7 +22,7 @@
  * SOFTWARE.
  */
 
-#include <ArduinoIoTCloud_Config.h>
+#include <AIoTC_Config.h>
 #ifdef BOARD_HAS_ECCX08
 
 #include "inner.h"

--- a/src/tls/bearssl/ssl_engine_default_aesccm.c
+++ b/src/tls/bearssl/ssl_engine_default_aesccm.c
@@ -22,7 +22,7 @@
  * SOFTWARE.
  */
 
-#include <ArduinoIoTCloud_Config.h>
+#include <AIoTC_Config.h>
 #ifdef BOARD_HAS_ECCX08
 
 #include "inner.h"

--- a/src/tls/bearssl/ssl_engine_default_aesgcm.c
+++ b/src/tls/bearssl/ssl_engine_default_aesgcm.c
@@ -22,7 +22,7 @@
  * SOFTWARE.
  */
 
-#include <ArduinoIoTCloud_Config.h>
+#include <AIoTC_Config.h>
 #ifdef BOARD_HAS_ECCX08
 
 #include "inner.h"

--- a/src/tls/bearssl/ssl_engine_default_chapol.c
+++ b/src/tls/bearssl/ssl_engine_default_chapol.c
@@ -22,7 +22,7 @@
  * SOFTWARE.
  */
 
-#include <ArduinoIoTCloud_Config.h>
+#include <AIoTC_Config.h>
 #ifdef BOARD_HAS_ECCX08
 
 #include "inner.h"

--- a/src/tls/bearssl/ssl_engine_default_descbc.c
+++ b/src/tls/bearssl/ssl_engine_default_descbc.c
@@ -22,7 +22,7 @@
  * SOFTWARE.
  */
 
-#include <ArduinoIoTCloud_Config.h>
+#include <AIoTC_Config.h>
 #ifdef BOARD_HAS_ECCX08
 
 #include "inner.h"

--- a/src/tls/bearssl/ssl_engine_default_ec.c
+++ b/src/tls/bearssl/ssl_engine_default_ec.c
@@ -22,7 +22,7 @@
  * SOFTWARE.
  */
 
-#include <ArduinoIoTCloud_Config.h>
+#include <AIoTC_Config.h>
 #ifdef BOARD_HAS_ECCX08
 
 #include "inner.h"

--- a/src/tls/bearssl/ssl_engine_default_ecdsa.c
+++ b/src/tls/bearssl/ssl_engine_default_ecdsa.c
@@ -22,7 +22,7 @@
  * SOFTWARE.
  */
 
-#include <ArduinoIoTCloud_Config.h>
+#include <AIoTC_Config.h>
 #ifdef BOARD_HAS_ECCX08
 
 #include "inner.h"

--- a/src/tls/bearssl/ssl_engine_default_rsavrfy.c
+++ b/src/tls/bearssl/ssl_engine_default_rsavrfy.c
@@ -22,7 +22,7 @@
  * SOFTWARE.
  */
 
-#include <ArduinoIoTCloud_Config.h>
+#include <AIoTC_Config.h>
 #ifdef BOARD_HAS_ECCX08
 
 #include "inner.h"

--- a/src/tls/bearssl/ssl_hashes.c
+++ b/src/tls/bearssl/ssl_hashes.c
@@ -22,7 +22,7 @@
  * SOFTWARE.
  */
 
-#include <ArduinoIoTCloud_Config.h>
+#include <AIoTC_Config.h>
 #ifdef BOARD_HAS_ECCX08
 
 #include "inner.h"

--- a/src/tls/bearssl/ssl_hs_client.c
+++ b/src/tls/bearssl/ssl_hs_client.c
@@ -1,6 +1,6 @@
 /* Automatically generated code; do not modify directly. */
 
-#include <ArduinoIoTCloud_Config.h>
+#include <AIoTC_Config.h>
 #ifdef BOARD_HAS_ECCX08
 
 #include <stddef.h>

--- a/src/tls/bearssl/ssl_hs_server.c
+++ b/src/tls/bearssl/ssl_hs_server.c
@@ -1,6 +1,6 @@
 /* Automatically generated code; do not modify directly. */
 
-#include <ArduinoIoTCloud_Config.h>
+#include <AIoTC_Config.h>
 #ifdef BOARD_HAS_ECCX08
 
 #include <stddef.h>

--- a/src/tls/bearssl/ssl_io.c
+++ b/src/tls/bearssl/ssl_io.c
@@ -22,7 +22,7 @@
  * SOFTWARE.
  */
 
-#include <ArduinoIoTCloud_Config.h>
+#include <AIoTC_Config.h>
 #ifdef BOARD_HAS_ECCX08
 
 #include "inner.h"

--- a/src/tls/bearssl/ssl_keyexport.c
+++ b/src/tls/bearssl/ssl_keyexport.c
@@ -22,7 +22,7 @@
  * SOFTWARE.
  */
 
-#include <ArduinoIoTCloud_Config.h>
+#include <AIoTC_Config.h>
 #ifdef BOARD_HAS_ECCX08
 
 #include "inner.h"

--- a/src/tls/bearssl/ssl_lru.c
+++ b/src/tls/bearssl/ssl_lru.c
@@ -22,7 +22,7 @@
  * SOFTWARE.
  */
 
-#include <ArduinoIoTCloud_Config.h>
+#include <AIoTC_Config.h>
 #ifdef BOARD_HAS_ECCX08
 
 #include "inner.h"

--- a/src/tls/bearssl/ssl_rec_cbc.c
+++ b/src/tls/bearssl/ssl_rec_cbc.c
@@ -22,7 +22,7 @@
  * SOFTWARE.
  */
 
-#include <ArduinoIoTCloud_Config.h>
+#include <AIoTC_Config.h>
 #ifdef BOARD_HAS_ECCX08
 
 #include "inner.h"

--- a/src/tls/bearssl/ssl_rec_ccm.c
+++ b/src/tls/bearssl/ssl_rec_ccm.c
@@ -22,7 +22,7 @@
  * SOFTWARE.
  */
 
-#include <ArduinoIoTCloud_Config.h>
+#include <AIoTC_Config.h>
 #ifdef BOARD_HAS_ECCX08
 
 #include "inner.h"

--- a/src/tls/bearssl/ssl_rec_chapol.c
+++ b/src/tls/bearssl/ssl_rec_chapol.c
@@ -22,7 +22,7 @@
  * SOFTWARE.
  */
 
-#include <ArduinoIoTCloud_Config.h>
+#include <AIoTC_Config.h>
 #ifdef BOARD_HAS_ECCX08
 
 #include "inner.h"

--- a/src/tls/bearssl/ssl_rec_gcm.c
+++ b/src/tls/bearssl/ssl_rec_gcm.c
@@ -22,7 +22,7 @@
  * SOFTWARE.
  */
 
-#include <ArduinoIoTCloud_Config.h>
+#include <AIoTC_Config.h>
 #ifdef BOARD_HAS_ECCX08
 
 #include "inner.h"

--- a/src/tls/bearssl/ssl_scert_single_ec.c
+++ b/src/tls/bearssl/ssl_scert_single_ec.c
@@ -22,7 +22,7 @@
  * SOFTWARE.
  */
 
-#include <ArduinoIoTCloud_Config.h>
+#include <AIoTC_Config.h>
 #ifdef BOARD_HAS_ECCX08
 
 #include "inner.h"

--- a/src/tls/bearssl/ssl_scert_single_rsa.c
+++ b/src/tls/bearssl/ssl_scert_single_rsa.c
@@ -22,7 +22,7 @@
  * SOFTWARE.
  */
 
-#include <ArduinoIoTCloud_Config.h>
+#include <AIoTC_Config.h>
 #ifdef BOARD_HAS_ECCX08
 
 #include "inner.h"

--- a/src/tls/bearssl/ssl_server.c
+++ b/src/tls/bearssl/ssl_server.c
@@ -22,7 +22,7 @@
  * SOFTWARE.
  */
 
-#include <ArduinoIoTCloud_Config.h>
+#include <AIoTC_Config.h>
 #ifdef BOARD_HAS_ECCX08
 
 #include "inner.h"

--- a/src/tls/bearssl/ssl_server_full_ec.c
+++ b/src/tls/bearssl/ssl_server_full_ec.c
@@ -22,7 +22,7 @@
  * SOFTWARE.
  */
 
-#include <ArduinoIoTCloud_Config.h>
+#include <AIoTC_Config.h>
 #ifdef BOARD_HAS_ECCX08
 
 #include "inner.h"

--- a/src/tls/bearssl/ssl_server_full_rsa.c
+++ b/src/tls/bearssl/ssl_server_full_rsa.c
@@ -22,7 +22,7 @@
  * SOFTWARE.
  */
 
-#include <ArduinoIoTCloud_Config.h>
+#include <AIoTC_Config.h>
 #ifdef BOARD_HAS_ECCX08
 
 #include "inner.h"

--- a/src/tls/bearssl/ssl_server_mine2c.c
+++ b/src/tls/bearssl/ssl_server_mine2c.c
@@ -22,7 +22,7 @@
  * SOFTWARE.
  */
 
-#include <ArduinoIoTCloud_Config.h>
+#include <AIoTC_Config.h>
 #ifdef BOARD_HAS_ECCX08
 
 #include "inner.h"

--- a/src/tls/bearssl/ssl_server_mine2g.c
+++ b/src/tls/bearssl/ssl_server_mine2g.c
@@ -22,7 +22,7 @@
  * SOFTWARE.
  */
 
-#include <ArduinoIoTCloud_Config.h>
+#include <AIoTC_Config.h>
 #ifdef BOARD_HAS_ECCX08
 
 #include "inner.h"

--- a/src/tls/bearssl/ssl_server_minf2c.c
+++ b/src/tls/bearssl/ssl_server_minf2c.c
@@ -22,7 +22,7 @@
  * SOFTWARE.
  */
 
-#include <ArduinoIoTCloud_Config.h>
+#include <AIoTC_Config.h>
 #ifdef BOARD_HAS_ECCX08
 
 #include "inner.h"

--- a/src/tls/bearssl/ssl_server_minf2g.c
+++ b/src/tls/bearssl/ssl_server_minf2g.c
@@ -22,7 +22,7 @@
  * SOFTWARE.
  */
 
-#include <ArduinoIoTCloud_Config.h>
+#include <AIoTC_Config.h>
 #ifdef BOARD_HAS_ECCX08
 
 #include "inner.h"

--- a/src/tls/bearssl/ssl_server_minr2g.c
+++ b/src/tls/bearssl/ssl_server_minr2g.c
@@ -22,7 +22,7 @@
  * SOFTWARE.
  */
 
-#include <ArduinoIoTCloud_Config.h>
+#include <AIoTC_Config.h>
 #ifdef BOARD_HAS_ECCX08
 
 #include "inner.h"

--- a/src/tls/bearssl/ssl_server_minu2g.c
+++ b/src/tls/bearssl/ssl_server_minu2g.c
@@ -22,7 +22,7 @@
  * SOFTWARE.
  */
 
-#include <ArduinoIoTCloud_Config.h>
+#include <AIoTC_Config.h>
 #ifdef BOARD_HAS_ECCX08
 
 #include "inner.h"

--- a/src/tls/bearssl/ssl_server_minv2g.c
+++ b/src/tls/bearssl/ssl_server_minv2g.c
@@ -22,7 +22,7 @@
  * SOFTWARE.
  */
 
-#include <ArduinoIoTCloud_Config.h>
+#include <AIoTC_Config.h>
 #ifdef BOARD_HAS_ECCX08
 
 #include "inner.h"

--- a/src/tls/bearssl/sysrng.c
+++ b/src/tls/bearssl/sysrng.c
@@ -22,7 +22,7 @@
  * SOFTWARE.
  */
 
-#include <ArduinoIoTCloud_Config.h>
+#include <AIoTC_Config.h>
 #ifdef BOARD_HAS_ECCX08
 
 #define BR_ENABLE_INTRINSICS   1

--- a/src/tls/bearssl/x509_decoder.c
+++ b/src/tls/bearssl/x509_decoder.c
@@ -1,6 +1,6 @@
 /* Automatically generated code; do not modify directly. */
 
-#include <ArduinoIoTCloud_Config.h>
+#include <AIoTC_Config.h>
 #ifdef BOARD_HAS_ECCX08
 
 #include <stddef.h>

--- a/src/tls/bearssl/x509_knownkey.c
+++ b/src/tls/bearssl/x509_knownkey.c
@@ -22,7 +22,7 @@
  * SOFTWARE.
  */
 
-#include <ArduinoIoTCloud_Config.h>
+#include <AIoTC_Config.h>
 #ifdef BOARD_HAS_ECCX08
 
 #include "inner.h"

--- a/src/tls/bearssl/x509_minimal.c
+++ b/src/tls/bearssl/x509_minimal.c
@@ -1,6 +1,6 @@
 /* Automatically generated code; do not modify directly. */
 
-#include <ArduinoIoTCloud_Config.h>
+#include <AIoTC_Config.h>
 #ifdef BOARD_HAS_ECCX08
 
 #include <stddef.h>

--- a/src/tls/bearssl/x509_minimal_full.c
+++ b/src/tls/bearssl/x509_minimal_full.c
@@ -22,7 +22,7 @@
  * SOFTWARE.
  */
 
-#include <ArduinoIoTCloud_Config.h>
+#include <AIoTC_Config.h>
 #ifdef BOARD_HAS_ECCX08
 
 #include "inner.h"

--- a/src/tls/profile/aiotc_profile.c
+++ b/src/tls/profile/aiotc_profile.c
@@ -22,7 +22,7 @@
  * SOFTWARE.
  */
 
-#include <ArduinoIoTCloud_Config.h>
+#include <AIoTC_Config.h>
 #ifdef BOARD_HAS_ECCX08
 
 #include "../bearssl/inner.h"

--- a/src/tls/utility/CryptoUtil.h
+++ b/src/tls/utility/CryptoUtil.h
@@ -22,7 +22,7 @@
  * INCLUDE
  ******************************************************************************/
 
-#include <ArduinoIoTCloud_Config.h>
+#include <AIoTC_Config.h>
 
 #ifdef BOARD_HAS_ECCX08
 

--- a/src/tls/utility/ECCX08Cert.cpp
+++ b/src/tls/utility/ECCX08Cert.cpp
@@ -19,7 +19,7 @@
  * INCLUDE
  ******************************************************************************/
 
-#include <ArduinoIoTCloud_Config.h>
+#include <AIoTC_Config.h>
 
 #ifdef BOARD_HAS_ECCX08
 

--- a/src/tls/utility/ECCX08Cert.h
+++ b/src/tls/utility/ECCX08Cert.h
@@ -22,7 +22,7 @@
  * INCLUDE
  ******************************************************************************/
 
-#include <ArduinoIoTCloud_Config.h>
+#include <AIoTC_Config.h>
 
 #ifdef BOARD_HAS_ECCX08
 

--- a/src/tls/utility/eccX08_asn1.h
+++ b/src/tls/utility/eccX08_asn1.h
@@ -25,7 +25,7 @@
 #ifndef _ECCX08_ASN1_H_
 #define _ECCX08_ASN1_H_
 
-#include <ArduinoIoTCloud_Config.h>
+#include <AIoTC_Config.h>
 #ifdef BOARD_HAS_ECCX08
 
 #include "../bearssl/bearssl.h"

--- a/src/tls/utility/eccX08_sign_asn1.cpp
+++ b/src/tls/utility/eccX08_sign_asn1.cpp
@@ -23,7 +23,7 @@
  * SOFTWARE.
  */
 
-#include <ArduinoIoTCloud_Config.h>
+#include <AIoTC_Config.h>
 #ifdef BOARD_HAS_ECCX08
 
 #include "eccX08_asn1.h"

--- a/src/tls/utility/eccX08_vrfy_asn1.cpp
+++ b/src/tls/utility/eccX08_vrfy_asn1.cpp
@@ -23,7 +23,7 @@
  * SOFTWARE.
  */
 
-#include <ArduinoIoTCloud_Config.h>
+#include <AIoTC_Config.h>
 #ifdef BOARD_HAS_ECCX08
 
 #include "eccX08_asn1.h"

--- a/src/utility/ota/OTALogic.cpp
+++ b/src/utility/ota/OTALogic.cpp
@@ -20,7 +20,7 @@
  ******************************************************************************/
 
 #ifndef HOST
-  #include <ArduinoIoTCloud_Config.h>
+  #include <AIoTC_Config.h>
 #else
   #define OTA_ENABLED (1)
 #endif

--- a/src/utility/ota/OTALogic.h
+++ b/src/utility/ota/OTALogic.h
@@ -23,7 +23,7 @@
  ******************************************************************************/
 
 #ifndef HOST
-  #include <ArduinoIoTCloud_Config.h>
+  #include <AIoTC_Config.h>
 #else
   #define OTA_ENABLED (1)
 #endif

--- a/src/utility/ota/OTAStorage_SFU.cpp
+++ b/src/utility/ota/OTAStorage_SFU.cpp
@@ -44,12 +44,12 @@ bool OTAStorage_SFU::init()
 {
   flash.begin();
   if(SPIFFS_OK != filesystem.mount()) {
-    Debug.print(DBG_ERROR, "OTAStorage_SFU::init - mount() failed with error code %d", filesystem.err());
+    DBG_ERROR("OTAStorage_SFU::init - mount() failed with error code %d", filesystem.err());
     return false;
   }
 
   if(SPIFFS_OK != filesystem.check()) {
-    Debug.print(DBG_ERROR, "OTAStorage_SFU::init - check() failed with error code %d", filesystem.err());
+    DBG_ERROR("OTAStorage_SFU::init - check() failed with error code %d", filesystem.err());
     return false;
   }
 
@@ -61,7 +61,7 @@ bool OTAStorage_SFU::open(char const * file_name)
   filesystem.clearerr();
   _file = new File(filesystem.open(file_name, CREATE | WRITE_ONLY| TRUNCATE));
   if(SPIFFS_OK != filesystem.err()) {
-    Debug.print(DBG_ERROR, "OTAStorage_SFU::open - open() failed with error code %d", filesystem.err());
+    DBG_ERROR("OTAStorage_SFU::open - open() failed with error code %d", filesystem.err());
     delete _file;
     return false;
   }

--- a/src/utility/ota/OTAStorage_SFU.cpp
+++ b/src/utility/ota/OTAStorage_SFU.cpp
@@ -19,8 +19,10 @@
  * INCLUDE
  ******************************************************************************/
 
-#include "OTAStorage_SFU.h"
+#include <AIoTC_Config.h>
 #if OTA_STORAGE_SFU
+
+#include "OTAStorage_SFU.h"
 
 #include <Arduino_DebugUtils.h>
 

--- a/src/utility/ota/OTAStorage_SFU.h
+++ b/src/utility/ota/OTAStorage_SFU.h
@@ -22,7 +22,7 @@
  * INCLUDE
  ******************************************************************************/
 
-#include <ArduinoIoTCloud_Config.h>
+#include <AIoTC_Config.h>
 #if OTA_STORAGE_SFU
 
 #include "OTAStorage.h"

--- a/src/utility/ota/OTAStorage_SNU.cpp
+++ b/src/utility/ota/OTAStorage_SNU.cpp
@@ -19,7 +19,7 @@
  * INCLUDE
  ******************************************************************************/
 
-#include <ArduinoIoTCloud_Config.h>
+#include <AIoTC_Config.h>
 #if OTA_STORAGE_SNU
 
 #include "OTAStorage_SNU.h"

--- a/src/utility/ota/OTAStorage_SNU.h
+++ b/src/utility/ota/OTAStorage_SNU.h
@@ -22,7 +22,7 @@
  * INCLUDE
  ******************************************************************************/
 
-#include <ArduinoIoTCloud_Config.h>
+#include <AIoTC_Config.h>
 #if OTA_STORAGE_SNU
 
 #include <SNU.h>

--- a/src/utility/ota/OTAStorage_SSU.cpp
+++ b/src/utility/ota/OTAStorage_SSU.cpp
@@ -19,7 +19,7 @@
    INCLUDE
  ******************************************************************************/
 
-#include <ArduinoIoTCloud_Config.h>
+#include <AIoTC_Config.h>
 #if OTA_STORAGE_SSU
 
 #include "OTAStorage_SSU.h"

--- a/src/utility/ota/OTAStorage_SSU.h
+++ b/src/utility/ota/OTAStorage_SSU.h
@@ -22,7 +22,7 @@
  * INCLUDE
  ******************************************************************************/
 
-#include <ArduinoIoTCloud_Config.h>
+#include <AIoTC_Config.h>
 #if OTA_STORAGE_SSU
 
 #include <SSU.h>

--- a/src/utility/ota/crc.cpp
+++ b/src/utility/ota/crc.cpp
@@ -15,7 +15,7 @@
  */
 
 #ifndef HOST
-  #include <ArduinoIoTCloud_Config.h>
+  #include <AIoTC_Config.h>
 #else
   #define OTA_ENABLED (1)
 #endif

--- a/src/utility/ota/crc.h
+++ b/src/utility/ota/crc.h
@@ -41,7 +41,7 @@
 #define CRC_H
 
 #ifndef HOST
-  #include <ArduinoIoTCloud_Config.h>
+  #include <AIoTC_Config.h>
 #else
   #define OTA_ENABLED (1)
 #endif

--- a/src/utility/time/NTPUtils.cpp
+++ b/src/utility/time/NTPUtils.cpp
@@ -19,7 +19,7 @@
  * INCLUDE
  **************************************************************************************/
 
-#include "../../ArduinoIoTCloud_Config.h"
+#include "../../AIoTC_Config.h"
 #ifndef HAS_LORA
 
 #include "NTPUtils.h"

--- a/src/utility/time/NTPUtils.h
+++ b/src/utility/time/NTPUtils.h
@@ -18,7 +18,7 @@
 #ifndef __NTP_UTILS__
 #define __NTP_UTILS__
 
-#include "../../ArduinoIoTCloud_Config.h"
+#include "../../AIoTC_Config.h"
 #ifndef HAS_LORA
 
 /*

--- a/src/utility/time/TimeService.cpp
+++ b/src/utility/time/TimeService.cpp
@@ -19,7 +19,7 @@
  * INCLUDE
  **************************************************************************************/
 
-#include "../../ArduinoIoTCloud_Config.h"
+#include "../../AIoTC_Config.h"
 #ifndef HAS_LORA
 
 #include "TimeService.h"

--- a/src/utility/time/TimeService.h
+++ b/src/utility/time/TimeService.h
@@ -22,7 +22,7 @@
  * INCLUDE
  **************************************************************************************/
 
-#include "../../ArduinoIoTCloud_Config.h"
+#include "../../AIoTC_Config.h"
 #ifndef HAS_LORA
 
 #include <Arduino_ConnectionHandler.h>


### PR DESCRIPTION
This allows to configure the level of debug output within the header file and saves space by turning off all those debug messages which are not currently required.

Disable a particular debug output is as easy as replacing
```C++
#ifndef DBG_ERROR
  #define DBG_ERROR(fmt, ...) Debug.print(DBG_ERROR, fmt, ## __VA_ARGS__)
#endif
```
with
```C++
#ifndef DBG_ERROR
  #define DBG_ERROR(fmt, ...) //Debug.print(DBG_ERROR, fmt, ## __VA_ARGS__)
#endif
```
@manchoz I think you'll love that one :wink: 