### PR TITLE
Change github actions compile examples workflow back to use the latest release version

### DIFF
--- a/.github/workflows/compile-examples.yml
+++ b/.github/workflows/compile-examples.yml
@@ -83,8 +83,7 @@ jobs:
             libraries: |
               - name: ArduinoECCX08
               - name: RTCZero
-              # Use the version of MKRGSM from the tip of its repository's default branch
-              - source-url: https://github.com/arduino-libraries/MKRGSM.git
+              - name: MKRGSM
               - name: Arduino_MKRMEM
             sketch-paths: '"examples/utility/Provisioning" "examples/utility/GSM_Cloud_Blink"'
           # NB boards


### PR DESCRIPTION
instead of MKRGSM:master:HEAD (was only required until the latest features GSMFileUtils had been [released](https://github.com/arduino-libraries/MKRGSM/releases/tag/1.5.0)).