### PR TITLE
Use the latest released version of WiFiNINA …

### DIFF
--- a/.github/workflows/compile-examples.yml
+++ b/.github/workflows/compile-examples.yml
@@ -57,8 +57,7 @@ jobs:
               - name: ArduinoECCX08
               - name: RTCZero
               - name: WiFi101
-              # Use the version of WiFiNINA from the tip of its repository's default branch
-              - source-url: https://github.com/arduino-libraries/WiFiNINA.git
+              - name: WiFiNINA
               - name: Arduino_MKRMEM
             sketch-paths: '"examples/utility/Provisioning" "examples/utility/WiFi_Cloud_Blink"'
           # LoRaWAN boards


### PR DESCRIPTION
instead of `WifiNINA:master:HEAD` which is more relevant for the CI check since normal users are usually also only having the latest released library version.