### PR TITLE
Add Portenta boards to Compile Examples CI workflow

### DIFF
--- a/.github/workflows/compile-examples.yml
+++ b/.github/workflows/compile-examples.yml
@@ -27,6 +27,8 @@ jobs:
         - name: ArduinoMqttClient
       # sketch paths to compile (recursive) for all boards
       UNIVERSAL_SKETCH_PATHS: '"examples/ArduinoIoTCloud-Advanced" "examples/ArduinoIoTCloud-Basic" "examples/utility/ArduinoIoTCloud_Travis_CI"'
+      ARDUINOCORE_MBED_STAGING_PATH: extras/ArduinoCore-mbed
+      ARDUINOCORE_API_STAGING_PATH: extras/ArduinoCore-API
 
     strategy:
       fail-fast: false
@@ -102,7 +104,11 @@ jobs:
           - board:
               type: "mbed"
             platforms: |
+              # Install Arduino mbed-Enabled Boards via Boards Manager for the toolchain
               - name: arduino-beta:mbed
+              # Overwrite the Arduino mbed-Enabled Boards release version with version from the tip of the master branch (located in local path because of the need to first install ArduinoCore-API)
+              - source-path: extras/ArduinoCore-mbed
+                name: arduino-beta:mbed
             libraries: |
               - name: ArduinoECCX08
             sketch-paths: '"examples/utility/Provisioning"'
@@ -119,6 +125,37 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
+
+      # it's necessary to checkout the platform before installing it so that the ArduinoCore-API dependency can be added
+      - name: Checkout ArduinoCore-mbed
+        # this step only needed when the Arduino mbed-Enabled Boards platform sourced from the repository is being used
+        if: matrix.board.type == 'mbed'
+        uses: actions/checkout@v2
+        with:
+          repository: arduino/ArduinoCore-mbed
+          # the arduino/actions/libraries/compile-examples action will install the platform from this path
+          path: ${{ env.ARDUINOCORE_MBED_STAGING_PATH }}
+
+      - name: Remove ArduinoCore-API symlink from Arduino mbed-Enabled Boards platform
+        # this step only needed when the Arduino mbed-Enabled Boards platform sourced from the repository is being used
+        if: matrix.board.type == 'mbed'
+        run: rm "${{ env.ARDUINOCORE_MBED_STAGING_PATH }}/cores/arduino/api"
+
+      - name: Checkout ArduinoCore-API
+        # this step only needed when the Arduino mbed-Enabled Boards platform sourced from the repository is being used
+        if: matrix.board.type == 'mbed'
+        uses: actions/checkout@v2
+        with:
+          repository: arduino/ArduinoCore-API
+          # as specified at https://github.com/arduino/ArduinoCore-mbed/blob/master/README.md#installation
+          ref: namespace_arduino
+          path: ${{ env.ARDUINOCORE_API_STAGING_PATH }}
+
+      - name: Install ArduinoCore-API
+        # this step only needed when the Arduino mbed-Enabled Boards platform sourced from the repository is being used
+        if: matrix.board.type == 'mbed'
+        run: |
+          mv "${{ env.ARDUINOCORE_API_STAGING_PATH }}/api" "${{ env.ARDUINOCORE_MBED_STAGING_PATH }}/cores/arduino"
 
       - name: Compile examples
         uses: arduino/actions/libraries/compile-examples@master

--- a/.github/workflows/compile-examples.yml
+++ b/.github/workflows/compile-examples.yml
@@ -39,6 +39,8 @@ jobs:
           {"fqbn": "arduino:samd:mkrwan1300", "type": "wan"},
           {"fqbn": "arduino:samd:mkrgsm1400", "type": "gsm"},
           {"fqbn": "arduino:samd:mkrnb1500", "type": "nb"},
+          {"fqbn": "arduino-beta:mbed:envie_m4", "type": "mbed"},
+          {"fqbn": "arduino-beta:mbed:envie_m7", "type": "mbed"},
           {"fqbn": "esp8266:esp8266:huzzah", "type": "esp8266"}
         ]
 
@@ -95,6 +97,14 @@ jobs:
               - name: ArduinoECCX08
               - name: RTCZero
               - name: MKRNB
+            sketch-paths: '"examples/utility/Provisioning"'
+          # Portenta
+          - board:
+              type: "mbed"
+            platforms: |
+              - name: arduino-beta:mbed
+            libraries: |
+              - name: ArduinoECCX08
             sketch-paths: '"examples/utility/Provisioning"'
           # ESP8266 boards
           - board:


### PR DESCRIPTION
Compile library examples for Arduino Portenta H7's M4 and M7 cores during CI run.

The workflow is configured to use the version of the Arduino mbed-Enabled Boards platform from the tip of the default branch of the ArduinoCore-mbed repository. This is necessary because compiling for the Portenta H7 M4 core board fails when using the current release version of the platform (1.2.2). The issue has been fixed (https://github.com/arduino/ArduinoCore-mbed/pull/33), so the [second commit of this PR](https://github.com/arduino-libraries/ArduinoIoTCloud/commit/24edb4b439c3b1624efbbb313b6698314e721aaa) can be reverted after the next release of the Arduino mbed-Enabled Boards platform.

Fixes https://github.com/arduino-libraries/ArduinoIoTCloud/issues/180