### PR TITLE
Disable warnings when compiling test code -Werror and GCC 9.3.0

### DIFF
--- a/extras/test/CMakeLists.txt
+++ b/extras/test/CMakeLists.txt
@@ -84,9 +84,10 @@ set(TEST_TARGET_SRCS
 
 add_compile_definitions(HOST)
 add_compile_options(-Wall -Wextra -Wpedantic -Werror)
+add_compile_options(-Wno-cast-function-type)
 
 set(CMAKE_C_FLAGS   ${CMAKE_C_FLAGS}   "--coverage")
-set(CMAKE_CXX_FLAGS ${CMAKE_CXX_FLAGS} "--coverage")
+set(CMAKE_CXX_FLAGS ${CMAKE_CXX_FLAGS} "--coverage -Wno-deprecated-copy")
 
 ##########################################################################
 


### PR DESCRIPTION
Disabling `-Wcast-function-type` for FakeIt mocking framework and `-Wdeprecated-copy` for cloud data types (both cause warnings which become errors when compiling with `-Werror` and `GCC 9.3.0`.