### PR TITLE
[CI] Use latest released version for Arduino_DebugUtils, Arduino_ConnectionHandler, WiFiNINA

### DIFF
--- a/.github/workflows/compile-examples.yml
+++ b/.github/workflows/compile-examples.yml
@@ -21,9 +21,8 @@ jobs:
       UNIVERSAL_LIBRARIES: |
         # Install the ArduinoIoTCloud library from the repository
         - source-path: ./
-        - source-url: https://github.com/arduino-libraries/Arduino_ConnectionHandler.git
-          version: latest
-        - source-url: https://github.com/arduino-libraries/Arduino_DebugUtils.git
+        - name: Arduino_ConnectionHandler
+        - name: Arduino_DebugUtils
         - name: ArduinoMqttClient
       # sketch paths to compile (recursive) for all boards
       UNIVERSAL_SKETCH_PATHS: '"examples/ArduinoIoTCloud-Advanced" "examples/ArduinoIoTCloud-Basic" "examples/utility/ArduinoIoTCloud_Travis_CI"'
@@ -68,7 +67,7 @@ jobs:
             libraries: |
               - name: ArduinoECCX08
               - name: RTCZero
-              - source-url: https://github.com/arduino-libraries/WiFiNINA.git
+              - name: WiFiNINA
               - name: Arduino_JSON
               - name: ArduinoBearSSL
             sketch-paths: '"examples/utility/Provisioning" "examples/utility/SelfProvisioning"'


### PR DESCRIPTION
Wherever possible use the latest released version when loading external libraries for CI (this better reflects the user experience who typically has the latest released version, not the latest commit from master.