### PR TITLE
Add "mbed" to list of supported architectures

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -6,6 +6,6 @@ sentence=This library allows to connect to the Arduino IoT Cloud service.
 paragraph=It provides a ConnectionManager to handle connection/disconnection, property-change updates and events callbacks. The supported boards are MKRGSM, MKR1000 and WiFi101.
 category=Communication
 url=https://github.com/arduino-libraries/ArduinoIoTCloud
-architectures=samd,esp8266
+architectures=mbed,samd,esp8266
 includes=ArduinoIoTCloud.h
 depends=Arduino_ConnectionHandler,Arduino_DebugUtils,ArduinoMqttClient,ArduinoECCX08,RTCZero


### PR DESCRIPTION
Previously, when compiling the library for Portenta H7, a [confusing](https://forum.arduino.cc/index.php?topic=704905) warning was displayed:
```
WARNING: library ArduinoIoTCloud claims to run on samd, esp8266 architecture(s) and may be incompatible with your current board which runs on mbed architecture(s).
```