### PR TITLE
Reset OTA error before new OTA download

### DIFF
--- a/src/ArduinoIoTCloudTCP.cpp
+++ b/src/ArduinoIoTCloudTCP.cpp
@@ -307,6 +307,10 @@ ArduinoIoTCloudTCP::State ArduinoIoTCloudTCP::handle_Connected()
      */
     if (_ota_req)
     {
+      /* Clear the error flag. */
+      _ota_error = static_cast<int>(OTAError::None);
+      /* Transmit the cleared error flag to the cloud. */
+      sendPropertiesToCloud();
       /* Clear the request flag. */
       _ota_req = false;
       /* Call member function to handle OTA request. */

--- a/src/ArduinoIoTCloudTCP.h
+++ b/src/ArduinoIoTCloudTCP.h
@@ -140,7 +140,6 @@ class ArduinoIoTCloudTCP: public ArduinoIoTCloudClass
     int write(String const topic, byte const data[], int const length);
 
 #if OTA_ENABLED
-    static void on_OTA_REQ_Update();
     void onOTARequest();
 #endif
 };


### PR DESCRIPTION
This fixes the situation, that if a previous OTA download failed, the used would not get accurate information on a retry since the error would not be cleared in between. CC @eclipse1985 