### PR TITLE
Use sketch compilation CI actions from their new dedicated repositories

### DIFF
--- a/.github/workflows/compile-examples.yml
+++ b/.github/workflows/compile-examples.yml
@@ -170,12 +170,14 @@ jobs:
           sketch-paths: "${{ env.UNIVERSAL_SKETCH_PATHS }} ${{ matrix.sketch-paths }}"
           size-report-sketch: 'ArduinoIoTCloud_Travis_CI'
           enable-size-deltas-report: 'true'
+          sketches-report-path: ${{ env.SKETCHES_REPORTS_PATH }}
 
       - name: Write data to size trends report spreadsheet
         # Update report on every push to the master branch
         if: github.event_name == 'push' && github.ref == 'refs/heads/master'
         uses: arduino/report-size-trends@main
         with:
+          sketches-report-path: ${{ env.SKETCHES_REPORTS_PATH }}
           google-key-file: ${{ secrets.GOOGLE_KEY_FILE }}
           spreadsheet-id: 1I6NZkpZpf8KugBkE92adB1Z3_b7ZepOpCdYTOigJpN4
 

--- a/.github/workflows/compile-examples.yml
+++ b/.github/workflows/compile-examples.yml
@@ -28,6 +28,7 @@ jobs:
       UNIVERSAL_SKETCH_PATHS: '"examples/ArduinoIoTCloud-Advanced" "examples/ArduinoIoTCloud-Basic" "examples/utility/ArduinoIoTCloud_Travis_CI"'
       ARDUINOCORE_MBED_STAGING_PATH: extras/ArduinoCore-mbed
       ARDUINOCORE_API_STAGING_PATH: extras/ArduinoCore-API
+      SKETCHES_REPORTS_PATH: sketches-reports
 
     strategy:
       fail-fast: false
@@ -159,7 +160,7 @@ jobs:
           mv "${{ env.ARDUINOCORE_API_STAGING_PATH }}/api" "${{ env.ARDUINOCORE_MBED_STAGING_PATH }}/cores/arduino"
 
       - name: Compile examples
-        uses: arduino/actions/libraries/compile-examples@master
+        uses: arduino/compile-sketches@main
         with:
           platforms: ${{ matrix.platforms }}
           fqbn: ${{ matrix.board.fqbn }}
@@ -173,7 +174,7 @@ jobs:
       - name: Write data to size trends report spreadsheet
         # Update report on every push to the master branch
         if: github.event_name == 'push' && github.ref == 'refs/heads/master'
-        uses: arduino/actions/libraries/report-size-trends@master
+        uses: arduino/report-size-trends@main
         with:
           google-key-file: ${{ secrets.GOOGLE_KEY_FILE }}
           spreadsheet-id: 1I6NZkpZpf8KugBkE92adB1Z3_b7ZepOpCdYTOigJpN4
@@ -182,5 +183,5 @@ jobs:
         if: github.event_name == 'pull_request'
         uses: actions/upload-artifact@v1
         with:
-          name: 'size-deltas-reports'
-          path: 'size-deltas-reports'
+          name: ${{ env.SKETCHES_REPORTS_PATH }}
+          path: ${{ env.SKETCHES_REPORTS_PATH }}

--- a/.github/workflows/compile-examples.yml
+++ b/.github/workflows/compile-examples.yml
@@ -25,7 +25,10 @@ jobs:
         - name: Arduino_DebugUtils
         - name: ArduinoMqttClient
       # sketch paths to compile (recursive) for all boards
-      UNIVERSAL_SKETCH_PATHS: '"examples/ArduinoIoTCloud-Advanced" "examples/ArduinoIoTCloud-Basic" "examples/utility/ArduinoIoTCloud_Travis_CI"'
+      UNIVERSAL_SKETCH_PATHS: |
+        - examples/ArduinoIoTCloud-Advanced
+        - examples/ArduinoIoTCloud-Basic
+        - examples/utility/ArduinoIoTCloud_Travis_CI
       ARDUINOCORE_MBED_STAGING_PATH: extras/ArduinoCore-mbed
       ARDUINOCORE_API_STAGING_PATH: extras/ArduinoCore-API
       SKETCHES_REPORTS_PATH: sketches-reports
@@ -58,7 +61,8 @@ jobs:
               - name: ArduinoECCX08
               - name: RTCZero
               - name: WiFi101
-            sketch-paths: '"examples/utility/Provisioning"'
+            sketch-paths: |
+              - examples/utility/Provisioning
           # MKR WiFi 1010, Nano 33 IoT
           - board:
               type: "nina"
@@ -71,7 +75,9 @@ jobs:
               - name: WiFiNINA
               - name: Arduino_JSON
               - name: ArduinoBearSSL
-            sketch-paths: '"examples/utility/Provisioning" "examples/utility/SelfProvisioning"'
+            sketch-paths: |
+              - examples/utility/Provisioning
+              - examples/utility/SelfProvisioning
           # LoRaWAN boards
           - board:
               type: "wan"
@@ -91,7 +97,8 @@ jobs:
               - name: ArduinoECCX08
               - name: RTCZero
               - name: MKRGSM
-            sketch-paths: '"examples/utility/Provisioning"'
+            sketch-paths: |
+              - examples/utility/Provisioning
           # NB boards
           - board:
               type: "nb"
@@ -101,7 +108,8 @@ jobs:
               - name: ArduinoECCX08
               - name: RTCZero
               - name: MKRNB
-            sketch-paths: '"examples/utility/Provisioning"'
+            sketch-paths: |
+              - examples/utility/Provisioning
           # Portenta
           - board:
               type: "mbed"
@@ -113,7 +121,8 @@ jobs:
                 name: arduino:mbed
             libraries: |
               - name: ArduinoECCX08
-            sketch-paths: '"examples/utility/Provisioning"'
+            sketch-paths: |
+              - examples/utility/Provisioning
           # ESP8266 boards
           - board:
               type: "esp8266"
@@ -167,9 +176,10 @@ jobs:
           libraries: |
             ${{ env.UNIVERSAL_LIBRARIES }}
             ${{ matrix.libraries }}
-          sketch-paths: "${{ env.UNIVERSAL_SKETCH_PATHS }} ${{ matrix.sketch-paths }}"
-          size-report-sketch: 'ArduinoIoTCloud_Travis_CI'
-          enable-size-deltas-report: 'true'
+          sketch-paths: |
+            ${{ env.UNIVERSAL_SKETCH_PATHS }}
+            ${{ matrix.sketch-paths }}
+          enable-deltas-report: 'true'
           sketches-report-path: ${{ env.SKETCHES_REPORTS_PATH }}
 
       - name: Write data to size trends report spreadsheet

--- a/.github/workflows/report-size-deltas.yml
+++ b/.github/workflows/report-size-deltas.yml
@@ -9,3 +9,6 @@ jobs:
     steps:
       - name: Comment size deltas reports to PRs
         uses: arduino/report-size-deltas@main
+        with:
+          # The name of the workflow artifact created by the "Compile Examples" workflow
+          sketches-reports-source: sketches-reports

--- a/.github/workflows/report-size-deltas.yml
+++ b/.github/workflows/report-size-deltas.yml
@@ -8,4 +8,4 @@ jobs:
 
     steps:
       - name: Comment size deltas reports to PRs
-        uses: arduino/actions/libraries/report-size-deltas@master
+        uses: arduino/report-size-deltas@main


### PR DESCRIPTION
The "smoke test" sketch compilation and reporting actions have been moved to dedicated repositories. The actions hosted at the old `arduino/actions/libraries/*` location will no longer be maintained.

Since the time the actions were migrated to the dedicated repositories, a breaking change was made to the default value of the `sketches-report-path` input, which required a change to the values of the `name` and `path` inputs of the `actions/upload-artifact` action.

Since the time the "Compile Examples" workflow was written, some improvements have been made to the API of the `arduino/compile-sketches` CI action. The previous API is still supported, but is deprecated and warnings are displayed in the workflow run log about this, which could result in confusion for contributors.

---
GitHub only runs scheduled workflows that are in the repository's default branch. This means that the changes made in this PR to the report size deltas workflow will not take effect until the PR is merged. However, the changes to the "Compile Examples" workflow will take effect immediately. The workflow artifact created by the Compile Examples workflow is now named "sketches-reports", but the artifact name the previous report size deltas workflow running in the `master` branch looks for is "size-deltas-reports". This means there will be no size deltas report comment on this PR, but after it is merged the size deltas report comments will resume as usual.

---
This PR fixes the failing report size deltas workflow (e.g., https://github.com/arduino-libraries/ArduinoIoTCloud/actions/runs/366203792), which is caused by a bug that was only [fixed in the new `arduino/report-size-deltas` action repository.](https://github.com/arduino/report-size-deltas/pull/10) (the motivation for this PR)