### PR TITLE
Improve error message when wrong thing id is configured.

### DIFF
--- a/src/ArduinoIoTCloudTCP.cpp
+++ b/src/ArduinoIoTCloudTCP.cpp
@@ -224,6 +224,7 @@ ArduinoIoTCloudTCP::State ArduinoIoTCloudTCP::handle_SubscribeMqttTopics()
   if (!_mqttClient.subscribe(_dataTopicIn))
   {
     DBG_ERROR(F("ArduinoIoTCloudTCP::%s could not subscribe to %s"), __FUNCTION__, _dataTopicIn.c_str());
+    DBG_ERROR(F("Check your thing configuration, and press the reset button on your board."));
     return State::SubscribeMqttTopics;
   }
 
@@ -232,6 +233,7 @@ ArduinoIoTCloudTCP::State ArduinoIoTCloudTCP::handle_SubscribeMqttTopics()
     if (!_mqttClient.subscribe(_shadowTopicIn))
     {
       DBG_ERROR(F("ArduinoIoTCloudTCP::%s could not subscribe to %s"), __FUNCTION__, _shadowTopicIn.c_str());
+      DBG_ERROR(F("Check your thing configuration, and press the reset button on your board."));
       return State::SubscribeMqttTopics;
     }
   }


### PR DESCRIPTION
Instead of
```
ArduinoIoTCloudTCP::handle_SubscribeMqttTopics could not subscribe to /a/t/THING_ID/e/i
```
display
```
ArduinoIoTCloudTCP::handle_SubscribeMqttTopics could not subscribe to /a/t/THING_ID/e/i
Check your thing configuration, and press the reset button on your board.
```