### PR TITLE
Adding alias for function onUpdate to address issues uncovered during user testing

### DIFF
--- a/src/property/Property.h
+++ b/src/property/Property.h
@@ -147,6 +147,8 @@ class Property
     Property & publishOnDemand();
     Property & encodeTimestamp();
 
+    inline Property & onExternalChange(UpdateCallbackFunc func) { return onUpdate(func); }
+
     inline String name() const {
       return _name;
     }


### PR DESCRIPTION
Now functions which are triggered on an external change of the property, that is via the cloud dashboard can be registered via both `onUpdate` as well as `onExternalChange`.