### PR TITLE
Add ESP32 board to "Compile Examples" CI workflow

### DIFF
--- a/.github/workflows/compile-examples.yml
+++ b/.github/workflows/compile-examples.yml
@@ -46,7 +46,8 @@ jobs:
           {"fqbn": "arduino:samd:mkrnb1500", "type": "nb"},
           {"fqbn": "arduino:mbed:envie_m4", "type": "mbed"},
           {"fqbn": "arduino:mbed:envie_m7", "type": "mbed"},
-          {"fqbn": "esp8266:esp8266:huzzah", "type": "esp8266"}
+          {"fqbn": "esp8266:esp8266:huzzah", "type": "esp8266"},
+          {"fqbn": "esp32:esp32:esp32", "type": "esp32"}
         ]
 
         # make board type-specific customizations to the matrix jobs
@@ -132,6 +133,15 @@ jobs:
                 source-url: https://arduino.esp8266.com/stable/package_esp8266com_index.json
             libraries:
             sketch-paths:
+          # ESP32 boards
+          - board:
+              type: "esp32"
+            platforms: |
+              # Install ESP32 platform via Boards Manager
+              - name: esp32:esp32
+                source-url: https://raw.githubusercontent.com/espressif/arduino-esp32/gh-pages/package_esp32_index.json
+            libraries:
+            sketch-paths:
 
     steps:
       - name: Checkout
@@ -161,6 +171,10 @@ jobs:
         if: matrix.board.type == 'mbed'
         run: |
           mv "${{ env.ARDUINOCORE_API_STAGING_PATH }}/api" "${{ env.ARDUINOCORE_MBED_STAGING_PATH }}/cores/arduino"
+
+      - name: Install ESP32 platform dependencies
+        if: matrix.board.type == 'esp32'
+        run: pip3 install pyserial
 
       - name: Compile examples
         uses: arduino/compile-sketches@main

--- a/examples/ArduinoIoTCloud-Basic/ArduinoIoTCloud-Basic.ino
+++ b/examples/ArduinoIoTCloud-Basic/ArduinoIoTCloud-Basic.ino
@@ -22,6 +22,10 @@
 #include "arduino_secrets.h"
 #include "thingProperties.h"
 
+#if defined(ESP32)
+static int const LED_BUILTIN = 2;
+#endif
+
 void setup() {
   /* Initialize serial and wait up to 5 seconds for port to open */
   Serial.begin(9600);

--- a/src/cbor/lib/tinycbor/src/open_memstream.c
+++ b/src/cbor/lib/tinycbor/src/open_memstream.c
@@ -41,6 +41,7 @@ typedef size_t LenType;
 
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wpedantic"
+#pragma GCC diagnostic ignored "-Wreturn-type"
 
 struct Buffer
 {


### PR DESCRIPTION
ESP32 support has been added to the library (https://github.com/arduino-libraries/ArduinoIoTCloud/pull/211), so the examples compilation smoke test should be done for this architecture as well.

Fixes https://github.com/arduino-libraries/ArduinoIoTCloud/issues/215