### PR TITLE
Pin Arduino CLI version used in CI to 0.13.0

### DIFF
--- a/.github/workflows/compile-examples.yml
+++ b/.github/workflows/compile-examples.yml
@@ -179,6 +179,7 @@ jobs:
       - name: Compile examples
         uses: arduino/compile-sketches@main
         with:
+          cli-version: 0.13.0
           platforms: ${{ matrix.platforms }}
           fqbn: ${{ matrix.board.fqbn }}
           libraries: |


### PR DESCRIPTION
When the version is not pinned, the latest release is used (currently 0.14.0). This version has an incompatibility with
the combination of ArduinoIoTCloud and ESP8266 (https://github.com/arduino-libraries/ArduinoIoTCloud/issues/216):
https://github.com/arduino-libraries/ArduinoIoTCloud/runs/1695624922?check_suite_focus=true#step:8:266
```
  /home/runner/.arduino15/packages/esp8266/tools/xtensa-lx106-elf-gcc/2.5.0-4-b40a506/bin/../lib/gcc/xtensa-lx106-elf/4.8.2/../../../../xtensa-lx106-elf/bin/ld: /tmp/arduino-sketch-E7F14C7104ED32E659A1CD76F63C3596/libraries/ESP8266WiFi/objs.a: member /tmp/arduino-sketch-E7F14C7104ED32E659A1CD76F63C3596/libraries/ESP8266WiFi/objs.a(ESP8266WiFi.a) in archive is not an object
```

The easy workaround is to use the previous Arduino CLI version to get
the CI system working again.

Once the real fix for the issue is found, this commit should be reverted so the CI system can benefit from the ongoing
development work on Arduino CLI.