### PR TITLE
Revert "Pin Arduino CLI version used in CI to 0.13.0 (#222)"

### DIFF
--- a/.github/workflows/compile-examples.yml
+++ b/.github/workflows/compile-examples.yml
@@ -180,7 +180,6 @@ jobs:
       - name: Compile examples
         uses: arduino/compile-sketches@main
         with:
-          cli-version: 0.13.0
           platforms: ${{ matrix.platforms }}
           fqbn: ${{ matrix.board.fqbn }}
           libraries: |


### PR DESCRIPTION
This reverts commit 1ffe81137251c052d5978c051d9022d4912bb9c3.

1ffe81137251c052d5978c051d9022d4912bb9c3 was a temporary workaround for a bug in Arduino CLI 0.14.0.
This was fixed (https://github.com/arduino/arduino-cli/pull/1140) with the release of Arduino CLI 0.14.1 so we are now able to go back to using the latest Arduino CLI version in the "Compile Examples" CI workflow.

Fixes https://github.com/arduino-libraries/ArduinoIoTCloud/issues/216