### PR TITLE
Reversion: Only use BearSSL offload for Uno WiFi Rev. 2

### DIFF
--- a/src/AIoTC_Config.h
+++ b/src/AIoTC_Config.h
@@ -107,14 +107,14 @@
 #endif
 
 #if defined(ARDUINO_SAMD_MKRGSM1400) || defined(ARDUINO_SAMD_MKR1000) ||   \
+  defined(ARDUINO_SAMD_MKRWIFI1010) || defined(ARDUINO_SAMD_NANO_33_IOT) || \
   defined(ARDUINO_SAMD_MKRNB1500) || defined(ARDUINO_PORTENTA_H7_M7)      ||   \
   defined(ARDUINO_PORTENTA_H7_M4)
   #define BOARD_HAS_ECCX08
   #define HAS_TCP
 #endif
 
-#if defined(ARDUINO_SAMD_MKRWIFI1010) || defined(ARDUINO_SAMD_NANO_33_IOT) || \
-  defined(ARDUINO_AVR_UNO_WIFI_REV2)
+#if defined(ARDUINO_AVR_UNO_WIFI_REV2)
   #define BOARD_HAS_OFFLOADED_ECCX08
   #define HAS_TCP
 #endif


### PR DESCRIPTION
Until we figure out an upgrade path for all current MKR WIFI 1010, NANO 33 IOT users.

CC @facchinm 