### PR TITLE
fix typo in the ArduinoIoTCloud-Callbacks example

### DIFF
--- a/examples/ArduinoIoTCloud-Callbacks/ArduinoIoTCloud-Callbacks.ino
+++ b/examples/ArduinoIoTCloud-Callbacks/ArduinoIoTCloud-Callbacks.ino
@@ -56,7 +56,7 @@ void setup() {
   */
   ArduinoCloud.addCallback(ArduinoIoTCloudEvent::CONNECT, doThisOnConnect);
   ArduinoCloud.addCallback(ArduinoIoTCloudEvent::SYNC, doThisOnSync);
-  ArduinoCloud.addCallback(ArduinoIoTCloudEvent::CONNECT, doThisOnDisconnect);
+  ArduinoCloud.addCallback(ArduinoIoTCloudEvent::DISCONNECT, doThisOnDisconnect);
 
   setDebugMessageLevel(DBG_INFO);
   ArduinoCloud.printDebugInfo();


### PR DESCRIPTION
I found an error in the Callbacks example when I was looking for a solution to a problem I was having with a project. It was the callback for what to do on disconnect. 

It was written:

```
ArduinoCloud.addCallback(ArduinoIoTCloudEvent::CONNECT, doThisOnDisconnect);
```

And I changed it to:

```
ArduinoCloud.addCallback(ArduinoIoTCloudEvent::DISCONNECT, doThisOnDisconnect);
```

Which I think is what it was meant to be.

This is my first time contributing to any Arduino project, so I apologize for breaking any conventions or not following proper protocol. 