### PR TITLE
All registration of callbacks for various "on connection attempt" failures

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -26,6 +26,9 @@ setDeviceId	KEYWORD2
 getDeviceId	KEYWORD2
 getConnection	KEYWORD2
 addCallback	KEYWORD2
+onPhyConnectionFailure	KEYWORD2
+onMQTTConnectionFailure	KEYWORD2
+onMQTTSubscriptionFailure	KEYWORD2
 addProperty	KEYWORD2
 
 # ArduinoIoTCloudLPWAN.h

--- a/src/ArduinoIoTCloud.h
+++ b/src/ArduinoIoTCloud.h
@@ -66,7 +66,7 @@ enum class ArduinoIoTConnectionStatus
 
 enum class ArduinoIoTCloudEvent : size_t
 {
-  SYNC = 0, CONNECT = 1, DISCONNECT = 2
+  SYNC = 0, CONNECT = 1, DISCONNECT = 2, MOTT_CONNECT_FAILURE = 3, MOTT_SUBSCRIBE_FAILURE = 4
 };
 
 typedef void (*OnCloudEventCallback)(void);
@@ -99,6 +99,11 @@ class ArduinoIoTCloudClass
     inline unsigned long getInternalTime() { return _time_service.getTime(); }
 
     void addCallback(ArduinoIoTCloudEvent const event, OnCloudEventCallback callback);
+
+    inline void onPhyConnectionFailure   (OnCloudEventCallback func) { if (_connection) _connection->addCallback(NetworkConnectionEvent::CONNECTION_FAILED, func); }
+    inline void onMQTTConnectionFailure  (OnCloudEventCallback func) { addCallback(ArduinoIoTCloudEvent::MOTT_CONNECT_FAILURE, func); }
+    inline void onMQTTSubscriptionFailure(OnCloudEventCallback func) { addCallback(ArduinoIoTCloudEvent::MOTT_SUBSCRIBE_FAILURE, func); }
+
 
 #define addProperty( v, ...) addPropertyReal(v, #v, __VA_ARGS__)
 
@@ -148,7 +153,7 @@ class ArduinoIoTCloudClass
 
     String _thing_id = "";
     String _device_id = "";
-    OnCloudEventCallback _cloud_event_callback[3] = {nullptr};
+    OnCloudEventCallback _cloud_event_callback[5] = {nullptr};
 };
 
 #ifdef HAS_TCP

--- a/src/ArduinoIoTCloudTCP.cpp
+++ b/src/ArduinoIoTCloudTCP.cpp
@@ -354,6 +354,8 @@ ArduinoIoTCloudTCP::State ArduinoIoTCloudTCP::handle_ConnectMqttBroker()
   if (_mqttClient.connect(_brokerAddress.c_str(), _brokerPort))
     return State::SubscribeMqttTopics;
 
+  execCloudEventCallback(ArduinoIoTCloudEvent::MOTT_CONNECT_FAILURE);
+
   DEBUG_ERROR("ArduinoIoTCloudTCP::%s could not connect to %s:%d", __FUNCTION__, _brokerAddress.c_str(), _brokerPort);
   return State::ConnectPhy;
 }
@@ -374,6 +376,7 @@ ArduinoIoTCloudTCP::State ArduinoIoTCloudTCP::handle_SubscribeMqttTopics()
 #if !defined(__AVR__)
     DEBUG_ERROR("Check your thing configuration, and press the reset button on your board.");
 #endif
+    execCloudEventCallback(ArduinoIoTCloudEvent::MOTT_SUBSCRIBE_FAILURE);
     return State::SubscribeMqttTopics;
   }
 
@@ -385,6 +388,7 @@ ArduinoIoTCloudTCP::State ArduinoIoTCloudTCP::handle_SubscribeMqttTopics()
 #if !defined(__AVR__)
       DEBUG_ERROR("Check your thing configuration, and press the reset button on your board.");
 #endif
+      execCloudEventCallback(ArduinoIoTCloudEvent::MOTT_SUBSCRIBE_FAILURE);
       return State::SubscribeMqttTopics;
     }
   }


### PR DESCRIPTION
Requires https://github.com/arduino-libraries/Arduino_ConnectionHandler/pull/57.

```C++
#include "arduino_secrets.h"
#include "thingProperties.h"

void onPhyFail()
{
  Serial.println("[Connection Error] Could not connect to WiFi - check SSID and PASS");
}
void onMqttConnectFail()
{
  Serial.println("[Connection Error] Provision your device or verify MQTT server settings");
}
void onMqttSubscribeFail()
{
  Serial.println("[Connection Error] Assign a device to your thing and verify thing id!");
}
 
void setup()
{
  Serial.begin(9600);
  while (!Serial) { }

  initProperties();

  setDebugMessageLevel(DBG_VERBOSE);

  ArduinoCloud.begin(ArduinoIoTPreferredConnection);

  ArduinoCloud.onPhyConnectionFailure(onPhyFail);
  ArduinoCloud.onMQTTConnectionFailure(onMqttConnectFail);
  ArduinoCloud.onMQTTSubscriptionFailure(onMqttSubscribeFail);
}

void loop()
{
  ArduinoCloud.update();
}
```