### PR TITLE
Fix: Correct required nina-fw version for SSL stack offloading

### DIFF
--- a/src/ArduinoIoTCloudTCP.cpp
+++ b/src/ArduinoIoTCloudTCP.cpp
@@ -263,8 +263,8 @@ int ArduinoIoTCloudTCP::begin(bool const enable_watchdog, String brokerAddress, 
 #endif /* OTA_STORAGE_SNU */
 
 #ifdef BOARD_HAS_OFFLOADED_ECCX08
-  if (String(WiFi.firmwareVersion()) < String("1.4.3")) {
-    DEBUG_ERROR("ArduinoIoTCloudTCP::%s In order to connect to Arduino IoT Cloud, NINA firmware needs to be >= 1.4.3, current %s", __FUNCTION__, WiFi.firmwareVersion());
+  if (String(WiFi.firmwareVersion()) < String("1.4.4")) {
+    DEBUG_ERROR("ArduinoIoTCloudTCP::%s In order to connect to Arduino IoT Cloud, NINA firmware needs to be >= 1.4.4, current %s", __FUNCTION__, WiFi.firmwareVersion());
     return 0;
   }
 #endif /* BOARD_HAS_OFFLOADED_ECCX08 */


### PR DESCRIPTION
Since we'll be only using nina-fw:v1.4.4 and forward for SSL offloading the outdated warning concerning v1.4.3 needs to be replaced with 1.4.4.