### PR TITLE
Remove claim of compatibility with megaavr architecture

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -6,6 +6,6 @@ sentence=This library allows to connect to the Arduino IoT Cloud service.
 paragraph=It provides a ConnectionManager to handle connection/disconnection, property-change updates and events callbacks. The supported boards are MKRGSM, MKR1000 and WiFi101.
 category=Communication
 url=https://github.com/arduino-libraries/ArduinoIoTCloud
-architectures=mbed,samd,esp8266,megaavr,mbed_nano,mbed_portenta
+architectures=mbed,samd,esp8266,mbed_nano,mbed_portenta
 includes=ArduinoIoTCloud.h
 depends=Arduino_ConnectionHandler,Arduino_DebugUtils,ArduinoMqttClient,ArduinoECCX08,RTCZero


### PR DESCRIPTION
The library does not support the megaavr architecture, so the metadata was incorrect.

Reference: https://github.com/arduino-libraries/ArduinoIoTCloud/pull/254