### PR TITLE
Remove commented-out CI code for Uno WiFi Rev. 2.

### DIFF
--- a/.github/workflows/compile-examples.yml
+++ b/.github/workflows/compile-examples.yml
@@ -44,8 +44,6 @@ jobs:
             type: nina
           - fqbn: arduino:samd:nano_33_iot
             type: nina
-          #- fqbn: arduino:megaavr:uno2018
-          #  type: megaavr
           - fqbn: arduino:samd:mkrwan1300
             type: wan
           - fqbn: arduino:samd:mkrgsm1400
@@ -95,21 +93,6 @@ jobs:
             sketch-paths: |
               - examples/utility/Provisioning
               - examples/utility/SelfProvisioning
-          # Uno WiFi Rev2
-          #- board:
-          #    type: megaavr
-          #  platforms: |
-          #    - name: arduino:megaavr
-          #  libraries: |
-          #    - name: ArduinoECCX08
-          #    - name: Arduino_AVRSTL
-          #    - name: WiFiNINA
-          #    - name: Arduino_JSON
-          #    - name: ArduinoBearSSL
-          #  sketch-paths: |
-          #    - examples/utility/Provisioning
-          #    - examples/utility/SelfProvisioning
-          # LoRaWAN boards
           - board:
               type: wan
             platforms: |


### PR DESCRIPTION
I should already have done that with #254 since what do we have a CVS for if not for keeping track of all the changes ;) (Meaning the CI code can easily be restored).