### PR TITLE
Watchdog handling cleanup

### DIFF
--- a/src/ArduinoIoTCloudTCP.cpp
+++ b/src/ArduinoIoTCloudTCP.cpp
@@ -285,7 +285,11 @@ int ArduinoIoTCloudTCP::begin(bool const enable_watchdog, String brokerAddress, 
 #if defined (ARDUINO_ARCH_SAMD) || (ARDUINO_ARCH_MBED)
   if (enable_watchdog) {
     watchdog_enable();
+#ifdef WIFI_HAS_FEED_WATCHDOG_FUNC
+      WiFi.setFeedWatchdogFunc(watchdog_reset);
+#endif
   }
+
 #endif
 
   return 1;

--- a/src/ArduinoIoTCloudTCP.cpp
+++ b/src/ArduinoIoTCloudTCP.cpp
@@ -321,7 +321,7 @@ void ArduinoIoTCloudTCP::update()
   _state = next_state;
 
   /* This watchdog feed is actually needed only by the RP2040 CONNECT cause its
-   * maximum watchdog window is 8388ms; despite this we feed it for all 
+   * maximum watchdog window is 8389ms; despite this we feed it for all 
    * supported ARCH to keep code aligned.
    */
 #ifdef ARDUINO_ARCH_SAMD

--- a/src/ArduinoIoTCloudTCP.cpp
+++ b/src/ArduinoIoTCloudTCP.cpp
@@ -282,13 +282,9 @@ int ArduinoIoTCloudTCP::begin(bool const enable_watchdog, String brokerAddress, 
    * call to ArduinoIoTCloudTCP::update() it is wise to
    * set a rather large timeout at first.
    */
-#ifdef ARDUINO_ARCH_SAMD
+#if defined (ARDUINO_ARCH_SAMD) || (ARDUINO_ARCH_MBED)
   if (enable_watchdog) {
-    samd_watchdog_enable();
-  }
-#elif defined(ARDUINO_ARCH_MBED)
-  if (enable_watchdog) {
-    mbed_watchdog_enable();
+    watchdog_enable();
   }
 #endif
 
@@ -300,10 +296,8 @@ void ArduinoIoTCloudTCP::update()
   /* Feed the watchdog. If any of the functions called below
    * get stuck than we can at least reset and recover.
    */
-#ifdef ARDUINO_ARCH_SAMD
-  samd_watchdog_reset();
-#elif defined(ARDUINO_ARCH_MBED)
-  mbed_watchdog_reset();
+#if defined (ARDUINO_ARCH_SAMD) || (ARDUINO_ARCH_MBED)
+  watchdog_reset();
 #endif
 
 
@@ -324,10 +318,8 @@ void ArduinoIoTCloudTCP::update()
    * maximum watchdog window is 8389ms; despite this we feed it for all 
    * supported ARCH to keep code aligned.
    */
-#ifdef ARDUINO_ARCH_SAMD
-  samd_watchdog_reset();
-#elif defined(ARDUINO_ARCH_MBED)
-  mbed_watchdog_reset();
+#if defined (ARDUINO_ARCH_SAMD) || (ARDUINO_ARCH_MBED)
+  watchdog_reset();
 #endif
 
   /* Check for new data from the MQTT client. */

--- a/src/utility/ota/OTA-nano-rp2040.cpp
+++ b/src/utility/ota/OTA-nano-rp2040.cpp
@@ -84,7 +84,7 @@ void URI::parse(const string& url_s)
 
 int rp2040_connect_onOTARequest(char const * ota_url)
 {
-  mbed_watchdog_reset();
+  watchdog_reset();
 
   int err = -1;
   FlashIAPBlockDevice flash(XIP_BASE + 0xF00000, 0x100000);
@@ -94,11 +94,11 @@ int rp2040_connect_onOTARequest(char const * ota_url)
     return static_cast<int>(OTAError::RP2040_ErrorFlashInit);
   }
 
-  mbed_watchdog_reset();
+  watchdog_reset();
 
   flash.erase(XIP_BASE + 0xF00000, 0x100000);
 
-  mbed_watchdog_reset();
+  watchdog_reset();
 
   mbed::FATFileSystem fs("ota");
   if ((err = fs.reformat(&flash)) != 0)
@@ -107,7 +107,7 @@ int rp2040_connect_onOTARequest(char const * ota_url)
      return static_cast<int>(OTAError::RP2040_ErrorReformat);
   }
 
-  mbed_watchdog_reset();
+  watchdog_reset();
 
   FILE * file = fopen("/ota/UPDATE.BIN.LZSS", "wb");
   if (!file)
@@ -117,7 +117,7 @@ int rp2040_connect_onOTARequest(char const * ota_url)
     return static_cast<int>(OTAError::RP2040_ErrorOpenUpdateFile);
   }
 
-  mbed_watchdog_reset();
+  watchdog_reset();
 
   URI url(ota_url);
   Client * client = nullptr;
@@ -135,7 +135,7 @@ int rp2040_connect_onOTARequest(char const * ota_url)
     return static_cast<int>(OTAError::RP2040_UrlParseError);
   }
 
-  mbed_watchdog_reset();
+  watchdog_reset();
 
   if (!client->connect(url.host_.c_str(), port))
   {
@@ -144,14 +144,14 @@ int rp2040_connect_onOTARequest(char const * ota_url)
     return static_cast<int>(OTAError::RP2040_ServerConnectError);
   }
 
-  mbed_watchdog_reset();
+  watchdog_reset();
 
   client->println(String("GET ") + url.path_.c_str() + " HTTP/1.1");
   client->println(String("Host: ") + url.host_.c_str());
   client->println("Connection: close");
   client->println();
 
-  mbed_watchdog_reset();
+  watchdog_reset();
 
   /* Receive HTTP header. */
   String http_header;
@@ -162,7 +162,7 @@ int rp2040_connect_onOTARequest(char const * ota_url)
     is_http_header_timeout = (millis() - start) > AIOT_CONFIG_RP2040_OTA_HTTP_HEADER_RECEIVE_TIMEOUT_ms;
     if (is_http_header_timeout) break;
 
-    mbed_watchdog_reset();
+    watchdog_reset();
 
     if (client->available())
     {
@@ -208,7 +208,7 @@ int rp2040_connect_onOTARequest(char const * ota_url)
     is_http_data_timeout = (millis() - start) > AIOT_CONFIG_RP2040_OTA_HTTP_DATA_RECEIVE_TIMEOUT_ms;
     if (is_http_data_timeout) break;
 
-    mbed_watchdog_reset();
+    watchdog_reset();
 
     if (client->available())
     {

--- a/src/utility/ota/OTA-portenta-h7.cpp
+++ b/src/utility/ota/OTA-portenta-h7.cpp
@@ -34,13 +34,13 @@
 
 int portenta_h7_onOTARequest(char const * ota_url)
 {
-  mbed_watchdog_reset();
+  watchdog_reset();
 
   Arduino_Portenta_OTA::Error ota_portenta_err = Arduino_Portenta_OTA::Error::None;
   /* Use 2nd partition of QSPI (1st partition contains WiFi firmware) */
   Arduino_Portenta_OTA_QSPI ota_portenta_qspi(QSPI_FLASH_FATFS_MBR, 2);
 
-  mbed_watchdog_reset();
+  watchdog_reset();
 
   /* Initialize the QSPI memory for OTA handling. */
   if((ota_portenta_err = ota_portenta_qspi.begin()) != Arduino_Portenta_OTA::Error::None) {
@@ -48,19 +48,19 @@ int portenta_h7_onOTARequest(char const * ota_url)
     return static_cast<int>(ota_portenta_err);
   }
 
-  mbed_watchdog_reset();
+  watchdog_reset();
 
   /* Just to be safe delete any remains from previous updates. */
   remove("/fs/UPDATE.BIN");
   remove("/fs/UPDATE.BIN.LZSS");
 
-  mbed_watchdog_reset();
+  watchdog_reset();
 
   /* Download the OTA file from the web storage location. */
   int const ota_portenta_qspi_download_ret_code = ota_portenta_qspi.download(ota_url, true /* is_https */);
   DEBUG_VERBOSE("Arduino_Portenta_OTA_QSPI::download(%s) returns %d", ota_url, ota_portenta_qspi_download_ret_code);
 
-  mbed_watchdog_reset();
+  watchdog_reset();
 
   /* Decompress the LZSS compressed OTA file. */
   int const ota_portenta_qspi_decompress_ret_code = ota_portenta_qspi.decompress();
@@ -71,7 +71,7 @@ int portenta_h7_onOTARequest(char const * ota_url)
     return ota_portenta_qspi_decompress_ret_code;
   }
 
-  mbed_watchdog_reset();
+  watchdog_reset();
 
   /* Schedule the firmware update. */
   if((ota_portenta_err = ota_portenta_qspi.update()) != Arduino_Portenta_OTA::Error::None) {

--- a/src/utility/ota/OTA-samd.cpp
+++ b/src/utility/ota/OTA-samd.cpp
@@ -38,14 +38,14 @@
 
 int samd_onOTARequest(char const * ota_url)
 {
-  samd_watchdog_reset();
+  watchdog_reset();
 
 #if OTA_STORAGE_SNU
   /* Just to be safe delete any remains from previous updates. */
   WiFiStorage.remove("/fs/UPDATE.BIN.LZSS");
   WiFiStorage.remove("/fs/UPDATE.BIN.LZSS.TMP");
 
-  samd_watchdog_reset();
+  watchdog_reset();
 
   /* Trigger direct download to nina module. */
   uint8_t nina_ota_err_code = 0;

--- a/src/utility/watchdog/Watchdog.cpp
+++ b/src/utility/watchdog/Watchdog.cpp
@@ -35,7 +35,7 @@
 #ifdef ARDUINO_ARCH_MBED
 #  include <watchdog_api.h>
 #  define PORTENTA_H7_WATCHDOG_MAX_TIMEOUT_ms (32760)
-#  define NANO_RP2040_WATCHDOG_MAX_TIMEOUT_ms (32760)
+#  define NANO_RP2040_WATCHDOG_MAX_TIMEOUT_ms (8389)
 #endif /* ARDUINO_ARCH_MBED */
 
 /******************************************************************************

--- a/src/utility/watchdog/Watchdog.cpp
+++ b/src/utility/watchdog/Watchdog.cpp
@@ -49,13 +49,13 @@ static bool is_watchdog_enabled = false;
  ******************************************************************************/
 
 #ifdef ARDUINO_ARCH_SAMD
-void samd_watchdog_enable()
+static void samd_watchdog_enable()
 {
   is_watchdog_enabled = true;
   Watchdog.enable(SAMD_WATCHDOG_MAX_TIME_ms);
 }
 
-void samd_watchdog_reset()
+static void samd_watchdog_reset()
 {
   if (is_watchdog_enabled) {
     Watchdog.reset();
@@ -85,7 +85,7 @@ void mkr_nb_feed_watchdog()
 #endif /* ARDUINO_ARCH_SAMD */
 
 #ifdef ARDUINO_ARCH_MBED
-void mbed_watchdog_enable()
+static void mbed_watchdog_enable()
 {
   watchdog_config_t cfg;
 #if defined(ARDUINO_PORTENTA_H7_M7) || defined(ARDUINO_PORTENTA_H7_M4)
@@ -104,7 +104,7 @@ void mbed_watchdog_enable()
   }
 }
 
-void mbed_watchdog_reset()
+static void mbed_watchdog_reset()
 {
   if (is_watchdog_enabled) {
     hal_watchdog_kick();
@@ -132,3 +132,23 @@ void mbed_watchdog_trigger_reset()
 
 }
 #endif /* ARDUINO_ARCH_MBED */
+
+#if defined (ARDUINO_ARCH_SAMD) || (ARDUINO_ARCH_MBED)
+void watchdog_enable()
+{
+#ifdef ARDUINO_ARCH_SAMD
+  samd_watchdog_enable();
+#else
+  mbed_watchdog_enable();
+#endif
+}
+
+void watchdog_reset()
+{
+#ifdef ARDUINO_ARCH_SAMD
+  samd_watchdog_reset();
+#else
+  mbed_watchdog_reset();
+#endif
+}
+#endif /* (ARDUINO_ARCH_SAMD) || (ARDUINO_ARCH_MBED) */

--- a/src/utility/watchdog/Watchdog.cpp
+++ b/src/utility/watchdog/Watchdog.cpp
@@ -68,10 +68,12 @@ static void samd_watchdog_reset()
  * is defined a weak function there and overwritten by this "strong"
  * function here.
  */
+#ifndef WIFI_HAS_FEED_WATCHDOG_FUNC
 void wifi_nina_feed_watchdog()
 {
   samd_watchdog_reset();
 }
+#endif
 
 void mkr_gsm_feed_watchdog()
 {

--- a/src/utility/watchdog/Watchdog.h
+++ b/src/utility/watchdog/Watchdog.h
@@ -22,14 +22,12 @@
  * FUNCTION DECLARATION
  ******************************************************************************/
 
-#ifdef ARDUINO_ARCH_SAMD
-void samd_watchdog_enable();
-void samd_watchdog_reset();
-#endif /* ARDUINO_ARCH_SAMD */
+#if defined (ARDUINO_ARCH_SAMD) || (ARDUINO_ARCH_MBED)
+void watchdog_enable();
+void watchdog_reset();
+#endif /* (ARDUINO_ARCH_SAMD) || (ARDUINO_ARCH_MBED) */
 
 #ifdef ARDUINO_ARCH_MBED
-void mbed_watchdog_enable();
-void mbed_watchdog_reset();
 void mbed_watchdog_trigger_reset();
 #endif /* ARDUINO_ARCH_MBED */
 


### PR DESCRIPTION
Aim of this pr is to cleanup watchdog handling replacing architecture specific function calls with an unique implementation that actually takes care of the architecture.

I've added also an out of scope commit that fixes the declared NANO_RP2040 maximum watchdog timeout.

I didn't change the `mbed_watchdog_trigger_reset` function with the hope to find a better fix in the future and remove it.

I'm opening as a draft to start testing.

| Board  | Result |
| ------------- | ------------- |
| NANO RP2040  | :heavy_check_mark:|
| PORTENTA H7  |   |
| NANO 33 IoT |:heavy_check_mark: |
| MKR WIFI 1010 |:heavy_check_mark: |