### PR TITLE
added Adafruit_SleepyDog library to dependencies

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -8,4 +8,4 @@ category=Communication
 url=https://github.com/arduino-libraries/ArduinoIoTCloud
 architectures=mbed,samd,esp8266,mbed_nano,mbed_portenta
 includes=ArduinoIoTCloud.h
-depends=Arduino_ConnectionHandler,Arduino_DebugUtils,ArduinoMqttClient,ArduinoECCX08,RTCZero
+depends=Arduino_ConnectionHandler,Arduino_DebugUtils,ArduinoMqttClient,ArduinoECCX08,RTCZero,Adafruit_SleepyDog


### PR DESCRIPTION
When installing ArduinoIoTCloud this required library is not installed and compilation fails