### PR TITLE
Change val MapEntry from float to double

### DIFF
--- a/src/property/Property.h
+++ b/src/property/Property.h
@@ -113,7 +113,7 @@ class CborMapData {
     MapEntry<String> attribute_name;
     MapEntry<int>    attribute_identifier;
     MapEntry<int>    property_identifier;
-    MapEntry<float>  val;
+    MapEntry<double> val;
     MapEntry<String> str_val;
     MapEntry<bool>   bool_val;
     MapEntry<double> time;


### PR DESCRIPTION
Using this [sketch](https://create-dev.arduino.cc/editor/eclipse85/b18100b3-739e-4940-abae-15cae42993a4/preview?F=thingProperties.h) assigning from the dashboard the vale of 1609459800 to `time2` variable it will result to print 1609459840.

Looking at [CborMapData](https://github.com/arduino-libraries/ArduinoIoTCloud/blob/41660e01a813de414c6e26fdfe4119465d78ffaa/src/property/Property.h#L104) class, the  1609459800 value is stored into a `float` variable and its hexadecimal rapresentation will be 0x4EBFDCD1; going back to `int` we will get 1609459840.

Storing the value in a double variable will avoid conversion errors.

I've used this web converters to check conversion error:
 - https://babbage.cs.qc.cuny.edu/ieee-754.old/Decimal.html
 - https://babbage.cs.qc.cuny.edu/ieee-754.old/32bit.html
 
 /cc @eclipse1985 

