### PR TITLE
Correct library dependency name in metadata

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -8,4 +8,4 @@ category=Communication
 url=https://github.com/arduino-libraries/ArduinoIoTCloud
 architectures=mbed,samd,esp8266,mbed_nano,mbed_portenta
 includes=ArduinoIoTCloud.h
-depends=Arduino_ConnectionHandler,Arduino_DebugUtils,ArduinoMqttClient,ArduinoECCX08,RTCZero,Adafruit_SleepyDog
+depends=Arduino_ConnectionHandler,Arduino_DebugUtils,ArduinoMqttClient,ArduinoECCX08,RTCZero,Adafruit SleepyDog Library


### PR DESCRIPTION
The `depends` field of [the library.properties metadata file](https://arduino.github.io/arduino-cli/dev/library-specification/#library-metadata) can be used to provide a list of library dependencies that should be installed in addition during a Library Manager installation. The library names must match exactly to the `name` value in the dependency's library.properties metadata file, which is the unique identifier used by Library Manager.

The name of the "Adafruit SleepyDog Library" [is just like that](https://github.com/adafruit/Adafruit_SleepyDog/blob/1.5.0/library.properties#L1), but an incorrect name "Adafruit_SleepyDog" was used instead when attempting to add it to the dependencies list. This resulted in the following:

- Classic Arduino IDE: the incorrect name was ignored and the dependency not installed
- Arduino IDE 2.x: installation of the ArduinoIoTCloud library fails silently
- Arduino CLI: installation of the ArduinoIoTCloud library fails with "Error installing ArduinoIoTCloud: No valid dependencies solution found: dependency 'Adafruit_SleepyDog' is not available"
- Arduino Create/Cloud: no effect because all Library Manager libraries are pre-installed and thus the `depends` field is not used