### PR TITLE
Deferred OTA

### DIFF
--- a/examples/ArduinoIoTCloud-DeferredOTA/ArduinoIoTCloud-DeferredOTA.ino
+++ b/examples/ArduinoIoTCloud-DeferredOTA/ArduinoIoTCloud-DeferredOTA.ino
@@ -46,6 +46,14 @@ bool ask_user_via_serial() {
   return false;
 }
 
+bool onOTARequestCallback()
+{
+  /* Select the preferred behaviour changing the called function */
+  //return always_deny();
+  //return always_allow();
+  return ask_user_via_serial();
+}
+
 void setup() {
   /* Initialize serial and wait up to 5 seconds for port to open */
   Serial.begin(9600);
@@ -61,7 +69,7 @@ void setup() {
   ArduinoCloud.begin(ArduinoIoTPreferredConnection);
 
   /* Setup OTA callback */
-  ArduinoCloud.onOTARequestCb(always_deny);
+  ArduinoCloud.onOTARequestCb(onOTARequestCallback);
 
   setDebugMessageLevel(DBG_INFO);
   ArduinoCloud.printDebugInfo();

--- a/examples/ArduinoIoTCloud-DeferredOTA/ArduinoIoTCloud-DeferredOTA.ino
+++ b/examples/ArduinoIoTCloud-DeferredOTA/ArduinoIoTCloud-DeferredOTA.ino
@@ -1,0 +1,81 @@
+/*
+  This sketch demonstrates how to handle deferred OTA from Arduino IoT Cloud.
+
+  Deferred OTA can be triggered using the arduino-cloud-cli with the following command:
+  ./arduino-cloud-cli ota upload --device-id xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx --file filename.ino.bin --deferred
+  The update file and the download link will be available to be used within one week.
+
+  * always_deny callback will always postpone the OTA update
+  * always_allow callback will immediately apply the OTA update
+  * ask_user_via_serial callback will read user input from serial to apply or postpone OTA update
+
+  This sketch is compatible with:
+   - MKR WIFI 1010
+   - Nano 33 IoT
+   - Portenta
+   - Nano RP2040
+*/
+
+#include "arduino_secrets.h"
+#include "thingProperties.h"
+
+#if defined(ESP32)
+static int const LED_BUILTIN = 2;
+#endif
+
+bool always_deny() {
+  return false;
+}
+
+bool always_allow() {
+  return true;
+}
+
+static bool ask_user_via_serial_first_run = true;
+bool ask_user_via_serial() {
+  if (ask_user_via_serial_first_run) {
+    Serial.println("Apply OTA? y / [n]");
+    ask_user_via_serial_first_run = false;
+  }
+  if (Serial.available()) {
+    char c = Serial.read();
+    if (c == 'y' || c == 'Y') {
+      return true;  
+    }
+  }
+  return false;
+}
+
+void setup() {
+  /* Initialize serial and wait up to 5 seconds for port to open */
+  Serial.begin(9600);
+  for(unsigned long const serialBeginTime = millis(); !Serial && (millis() - serialBeginTime > 5000); ) { }
+
+  /* Configure LED pin as an output */
+  pinMode(LED_BUILTIN, OUTPUT);
+
+  /* This function takes care of connecting your sketch variables to the ArduinoIoTCloud object */
+  initProperties();
+
+  /* Initialize Arduino IoT Cloud library */
+  ArduinoCloud.begin(ArduinoIoTPreferredConnection);
+
+  /* Setup OTA callback */
+  ArduinoCloud.onOTARequestCb(always_deny);
+
+  setDebugMessageLevel(DBG_INFO);
+  ArduinoCloud.printDebugInfo();
+}
+
+void loop() {
+  ArduinoCloud.update();
+}
+
+/*
+ * 'onLedChange' is called when the "led" property of your Thing changes
+ */
+void onLedChange() {
+  Serial.print("LED set to ");
+  Serial.println(led);
+  digitalWrite(LED_BUILTIN, led);
+}

--- a/examples/ArduinoIoTCloud-DeferredOTA/arduino_secrets.h
+++ b/examples/ArduinoIoTCloud-DeferredOTA/arduino_secrets.h
@@ -1,0 +1,34 @@
+#include <Arduino_ConnectionHandler.h>
+
+/* MKR1000, MKR WiFi 1010 */
+#if defined(BOARD_HAS_WIFI)
+  #define SECRET_SSID "YOUR_WIFI_NETWORK_NAME"
+  #define SECRET_PASS "YOUR_WIFI_PASSWORD"
+#endif
+
+/* ESP8266 */
+#if defined(BOARD_ESP8266)
+  #define SECRET_DEVICE_KEY "my-device-password"
+#endif
+
+/* MKR GSM 1400 */
+#if defined(BOARD_HAS_GSM)
+  #define SECRET_PIN ""
+  #define SECRET_APN ""
+  #define SECRET_LOGIN ""
+  #define SECRET_PASS ""
+#endif
+
+/* MKR WAN 1300/1310 */
+#if defined(BOARD_HAS_LORA)
+  #define SECRET_APP_EUI ""
+  #define SECRET_APP_KEY ""
+#endif
+
+/* MKR NB 1500 */
+#if defined(BOARD_HAS_NB)
+  #define SECRET_PIN ""
+  #define SECRET_APN ""
+  #define SECRET_LOGIN ""
+  #define SECRET_PASS ""
+#endif

--- a/examples/ArduinoIoTCloud-DeferredOTA/thingProperties.h
+++ b/examples/ArduinoIoTCloud-DeferredOTA/thingProperties.h
@@ -1,0 +1,40 @@
+#include <ArduinoIoTCloud.h>
+#include <Arduino_ConnectionHandler.h>
+
+#if defined(BOARD_HAS_WIFI)
+#elif defined(BOARD_HAS_GSM)
+#elif defined(BOARD_HAS_LORA)
+#elif defined(BOARD_HAS_NB)
+#else
+  #error "Arduino IoT Cloud currently only supports MKR1000, MKR WiFi 1010, MKR WAN 1300/1310, MKR NB 1500 and MKR GSM 1400"
+#endif
+
+#define THING_ID "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
+#define BOARD_ID "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
+
+void onLedChange();
+
+bool led;
+
+void initProperties() {
+#if defined(BOARD_ESP8266)
+  ArduinoCloud.setBoardId(BOARD_ID);
+  ArduinoCloud.setSecretDeviceKey(SECRET_DEVICE_KEY);
+#endif
+  ArduinoCloud.setThingId(THING_ID);
+#if defined(BOARD_HAS_WIFI) || defined(BOARD_HAS_GSM) || defined(BOARD_HAS_NB)
+  ArduinoCloud.addProperty(led, Permission::Write).onUpdate(onLedChange);
+#elif defined(BOARD_HAS_LORA)
+  ArduinoCloud.addProperty(led, 1, READWRITE, ON_CHANGE, onLedChange);
+#endif
+}
+
+#if defined(BOARD_HAS_WIFI)
+  WiFiConnectionHandler ArduinoIoTPreferredConnection(SECRET_SSID, SECRET_PASS);
+#elif defined(BOARD_HAS_GSM)
+  GSMConnectionHandler ArduinoIoTPreferredConnection(SECRET_PIN, SECRET_APN, SECRET_LOGIN, SECRET_PASS);
+#elif defined(BOARD_HAS_LORA)
+  LoRaConnectionHandler ArduinoIoTPreferredConnection(SECRET_APP_EUI, SECRET_APP_KEY, _lora_band::EU868, _lora_class::CLASS_A);
+#elif defined(BOARD_HAS_NB)
+  NBConnectionHandler ArduinoIoTPreferredConnection(SECRET_PIN, SECRET_APN, SECRET_LOGIN, SECRET_PASS);
+#endif

--- a/examples/ArduinoIoTCloud-DeferredOTA/thingProperties.h
+++ b/examples/ArduinoIoTCloud-DeferredOTA/thingProperties.h
@@ -34,7 +34,7 @@ void initProperties() {
 #elif defined(BOARD_HAS_GSM)
   GSMConnectionHandler ArduinoIoTPreferredConnection(SECRET_PIN, SECRET_APN, SECRET_LOGIN, SECRET_PASS);
 #elif defined(BOARD_HAS_LORA)
-  LoRaConnectionHandler ArduinoIoTPreferredConnection(SECRET_APP_EUI, SECRET_APP_KEY, _lora_band::EU868, _lora_class::CLASS_A);
+  LoRaConnectionHandler ArduinoIoTPreferredConnection(SECRET_APP_EUI, SECRET_APP_KEY, _lora_band::EU868, NULL, _lora_class::CLASS_A);
 #elif defined(BOARD_HAS_NB)
   NBConnectionHandler ArduinoIoTPreferredConnection(SECRET_PIN, SECRET_APN, SECRET_LOGIN, SECRET_PASS);
 #endif

--- a/src/ArduinoIoTCloudTCP.cpp
+++ b/src/ArduinoIoTCloudTCP.cpp
@@ -511,14 +511,16 @@ ArduinoIoTCloudTCP::State ArduinoIoTCloudTCP::handle_Connected()
 
     if (_ota_req)
     {
-      /* Clear the error flag. */
-      _ota_error = static_cast<int>(OTAError::None);
-      /* Transmit the cleared error flag to the cloud. */
-      sendPropertiesToCloud();
-      /* Clear the request flag. */
-      _ota_req = false;
-      /* Call member function to handle OTA request. */
-      onOTARequest();
+      if (_automatic_ota || (_get_ota_confirmation != nullptr && _get_ota_confirmation())) {
+        /* Clear the error flag. */
+        _ota_error = static_cast<int>(OTAError::None);
+        /* Transmit the cleared error flag to the cloud. */
+        sendPropertiesToCloud();
+        /* Clear the request flag. */
+        _ota_req = false;
+        /* Call member function to handle OTA request. */
+        onOTARequest();
+      }
     }
 #endif /* OTA_ENABLED */
 

--- a/src/ArduinoIoTCloudTCP.cpp
+++ b/src/ArduinoIoTCloudTCP.cpp
@@ -514,10 +514,10 @@ ArduinoIoTCloudTCP::State ArduinoIoTCloudTCP::handle_Connected()
       if (_automatic_ota || (_get_ota_confirmation != nullptr && _get_ota_confirmation())) {
         /* Clear the error flag. */
         _ota_error = static_cast<int>(OTAError::None);
-        /* Transmit the cleared error flag to the cloud. */
-        sendPropertiesToCloud();
         /* Clear the request flag. */
         _ota_req = false;
+        /* Transmit the cleared error and request flags to the cloud. */
+        sendPropertiesToCloud();
         /* Call member function to handle OTA request. */
         onOTARequest();
       }

--- a/src/ArduinoIoTCloudTCP.cpp
+++ b/src/ArduinoIoTCloudTCP.cpp
@@ -96,6 +96,7 @@ ArduinoIoTCloudTCP::ArduinoIoTCloudTCP()
 , _ota_url{""}
 , _ota_req{false}
 , _ask_user_before_executing_ota{false}
+, _get_ota_confirmation{nullptr}
 #endif /* OTA_ENABLED */
 {
 

--- a/src/ArduinoIoTCloudTCP.cpp
+++ b/src/ArduinoIoTCloudTCP.cpp
@@ -95,6 +95,7 @@ ArduinoIoTCloudTCP::ArduinoIoTCloudTCP()
 , _ota_img_sha256{"Inv."}
 , _ota_url{""}
 , _ota_req{false}
+, _ask_user_before_executing_ota{false}
 #endif /* OTA_ENABLED */
 {
 
@@ -506,7 +507,9 @@ ArduinoIoTCloudTCP::State ArduinoIoTCloudTCP::handle_Connected()
 
     if (_ota_req)
     {
-      if (_automatic_ota || (_get_ota_confirmation != nullptr && _get_ota_confirmation())) {
+      bool const ota_execution_allowed_by_user = (_get_ota_confirmation != nullptr && _get_ota_confirmation());
+      bool const perform_ota_now = ota_execution_allowed_by_user || !_ask_user_before_executing_ota;
+      if (perform_ota_now) {
         /* Clear the error flag. */
         _ota_error = static_cast<int>(OTAError::None);
         /* Clear the request flag. */

--- a/src/ArduinoIoTCloudTCP.cpp
+++ b/src/ArduinoIoTCloudTCP.cpp
@@ -238,8 +238,8 @@ int ArduinoIoTCloudTCP::begin(bool const enable_watchdog, String brokerAddress, 
   addPropertyReal(_ota_cap, "OTA_CAP", Permission::Read);
   addPropertyReal(_ota_error, "OTA_ERROR", Permission::Read);
   addPropertyReal(_ota_img_sha256, "OTA_SHA256", Permission::Read);
-  addPropertyReal(_ota_url, "OTA_URL", Permission::ReadWrite).onSync(DEVICE_WINS);
-  addPropertyReal(_ota_req, "OTA_REQ", Permission::ReadWrite).onSync(DEVICE_WINS);
+  addPropertyReal(_ota_url, "OTA_URL", Permission::ReadWrite).onSync(CLOUD_WINS);
+  addPropertyReal(_ota_req, "OTA_REQ", Permission::ReadWrite).onSync(CLOUD_WINS);
 #endif /* OTA_ENABLED */
 
 #if OTA_STORAGE_PORTENTA_QSPI

--- a/src/ArduinoIoTCloudTCP.cpp
+++ b/src/ArduinoIoTCloudTCP.cpp
@@ -499,11 +499,6 @@ ArduinoIoTCloudTCP::State ArduinoIoTCloudTCP::handle_Connected()
       _mqtt_data_request_retransmit = false;
     }
 
-    /* Check if any properties need encoding and send them to
-    * the cloud if necessary.
-    */
-    sendPropertiesToCloud();
-
 #if OTA_ENABLED
     /* Request a OTA download if the hidden property
      * OTA request has been set.
@@ -523,6 +518,11 @@ ArduinoIoTCloudTCP::State ArduinoIoTCloudTCP::handle_Connected()
       }
     }
 #endif /* OTA_ENABLED */
+
+    /* Check if any properties need encoding and send them to
+    * the cloud if necessary.
+    */
+    sendPropertiesToCloud();
 
     return State::Connected;
   }

--- a/src/ArduinoIoTCloudTCP.h
+++ b/src/ArduinoIoTCloudTCP.h
@@ -85,6 +85,7 @@ class ArduinoIoTCloudTCP: public ArduinoIoTCloudClass
 #if OTA_ENABLED
     /* The callback is triggered when the OTA is initiated and it gets executed until _ota_req flag is cleared.
      * It should return true when the OTA can be applied or false otherwise.
+     * See example ArduinoIoTCloud-DeferredOTA.ino
      */
     void onOTARequestCb(otaConfirmationStatus cb) {
       _get_ota_confirmation = cb;

--- a/src/ArduinoIoTCloudTCP.h
+++ b/src/ArduinoIoTCloudTCP.h
@@ -49,7 +49,11 @@ static uint16_t const DEFAULT_BROKER_PORT_SECURE_AUTH = 8883;
 static char const DEFAULT_BROKER_ADDRESS_USER_PASS_AUTH[] = "mqtts-up.iot.arduino.cc";
 static uint16_t const DEFAULT_BROKER_PORT_USER_PASS_AUTH = 8884;
 
-typedef bool (*otaConfirmationStatus)(void);
+/******************************************************************************
+ * TYPEDEF
+ ******************************************************************************/
+
+typedef bool (*onOTARequestCallbackFunc)(void);
 
 /******************************************************************************
  * CLASS DECLARATION
@@ -87,7 +91,7 @@ class ArduinoIoTCloudTCP: public ArduinoIoTCloudClass
      * It should return true when the OTA can be applied or false otherwise.
      * See example ArduinoIoTCloud-DeferredOTA.ino
      */
-    void onOTARequestCb(otaConfirmationStatus cb) {
+    void onOTARequestCb(onOTARequestCallbackFunc cb) {
       _get_ota_confirmation = cb;
       _ask_user_before_executing_ota = true;
     }
@@ -143,6 +147,7 @@ class ArduinoIoTCloudTCP: public ArduinoIoTCloudClass
     String _ota_url;
     bool _ota_req;
     bool _ask_user_before_executing_ota;
+    onOTARequestCallbackFunc _get_ota_confirmation;
 #endif /* OTA_ENABLED */
 
     inline String getTopic_shadowout() { return ( getThingId().length() == 0) ? String("")                            : String("/a/t/" + getThingId() + "/shadow/o"); }
@@ -167,7 +172,6 @@ class ArduinoIoTCloudTCP: public ArduinoIoTCloudClass
     void onOTARequest();
 #endif
 
-    otaConfirmationStatus _get_ota_confirmation = {nullptr};
 };
 
 /******************************************************************************

--- a/src/ArduinoIoTCloudTCP.h
+++ b/src/ArduinoIoTCloudTCP.h
@@ -49,6 +49,8 @@ static uint16_t const DEFAULT_BROKER_PORT_SECURE_AUTH = 8883;
 static char const DEFAULT_BROKER_ADDRESS_USER_PASS_AUTH[] = "mqtts-up.iot.arduino.cc";
 static uint16_t const DEFAULT_BROKER_PORT_USER_PASS_AUTH = 8884;
 
+typedef bool (*otaConfirmationStatus)(void);
+
 /******************************************************************************
  * CLASS DECLARATION
  ******************************************************************************/
@@ -80,6 +82,15 @@ class ArduinoIoTCloudTCP: public ArduinoIoTCloudClass
     inline String   getBrokerAddress() const { return _brokerAddress; }
     inline uint16_t getBrokerPort   () const { return _brokerPort; }
 
+#if OTA_ENABLED
+    /* The callback is triggered when the OTA is initiated and it gets executed until _ota_req flag is cleared.
+     * It should return true when the OTA can be applied or false otherwise.
+     */
+    void onOTARequestCb(otaConfirmationStatus cb) {
+      _get_ota_confirmation = cb;
+      _automatic_ota = false;
+    }
+#endif
 
   private:
     static const int MQTT_TRANSMIT_BUFFER_SIZE = 256;
@@ -130,6 +141,7 @@ class ArduinoIoTCloudTCP: public ArduinoIoTCloudClass
     String _ota_img_sha256;
     String _ota_url;
     bool _ota_req;
+    bool _automatic_ota = true;
 #endif /* OTA_ENABLED */
 
     inline String getTopic_shadowout() { return ( getThingId().length() == 0) ? String("")                            : String("/a/t/" + getThingId() + "/shadow/o"); }
@@ -153,6 +165,8 @@ class ArduinoIoTCloudTCP: public ArduinoIoTCloudClass
 #if OTA_ENABLED
     void onOTARequest();
 #endif
+
+    otaConfirmationStatus _get_ota_confirmation = {nullptr};
 };
 
 /******************************************************************************

--- a/src/ArduinoIoTCloudTCP.h
+++ b/src/ArduinoIoTCloudTCP.h
@@ -89,7 +89,7 @@ class ArduinoIoTCloudTCP: public ArduinoIoTCloudClass
      */
     void onOTARequestCb(otaConfirmationStatus cb) {
       _get_ota_confirmation = cb;
-      _automatic_ota = false;
+      _ask_user_before_executing_ota = true;
     }
 #endif
 
@@ -142,7 +142,7 @@ class ArduinoIoTCloudTCP: public ArduinoIoTCloudClass
     String _ota_img_sha256;
     String _ota_url;
     bool _ota_req;
-    bool _automatic_ota = true;
+    bool _ask_user_before_executing_ota;
 #endif /* OTA_ENABLED */
 
     inline String getTopic_shadowout() { return ( getThingId().length() == 0) ? String("")                            : String("/a/t/" + getThingId() + "/shadow/o"); }


### PR DESCRIPTION
@facchinm i've took your PR #265 and made some small changes:
 - removed default transport overriding
 - Added https://github.com/arduino-libraries/ArduinoIoTCloud/commit/bfe9e1c05510cead57ea1300f6bac9316c21b86f https://github.com/arduino-libraries/ArduinoIoTCloud/commit/00f61ba7df82649a40dce98412de4d27b3a08b06 in order to sync `_ota_req` variable with the cloud and be able to start a deferred OTA after a board reset.
 - some other minor cosmetic change

Having this feature has some minor drawbacks:
- last_values message size is increased
- if for some reason the library fails to send the cleared _ota_req flag to the cloud then `onOTARequestCb()` will be called again even if the OTA update was already applied.

Tests:

WebIDE OTA:
Board |  Test
--- | ---
MKR WiFi 1010 | :heavy_check_mark: 
Portenta | :heavy_check_mark: 
NANO RP2040 | :heavy_check_mark: 


arduino-cloud-cli deferred OTA: 

`./arduino-cloud-cli ota upload --device-id xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx --file filename.ino.bin --deferred`

Board |  Test
--- | --- 
MKR WiFi 1010 |  :heavy_check_mark: 
Portenta | :heavy_check_mark: 
NANO RP2040 | :heavy_check_mark: 


/cc @eclipse1985 @manchoz 