### PR TITLE
Add missing channelMask parameter

### DIFF
--- a/examples/ArduinoIoTCloud-Advanced/thingProperties.h
+++ b/examples/ArduinoIoTCloud-Advanced/thingProperties.h
@@ -33,7 +33,7 @@ void initProperties() {
 #elif defined(BOARD_HAS_GSM)
   GSMConnectionHandler ArduinoIoTPreferredConnection(SECRET_PIN, SECRET_APN, SECRET_LOGIN, SECRET_PASS);
 #elif defined(BOARD_HAS_LORA)
-  LoRaConnectionHandler ArduinoIoTPreferredConnection(SECRET_APP_EUI, SECRET_APP_KEY, _lora_band::EU868, _lora_class::CLASS_A);
+  LoRaConnectionHandler ArduinoIoTPreferredConnection(SECRET_APP_EUI, SECRET_APP_KEY, _lora_band::EU868, NULL, _lora_class::CLASS_A);
 #elif defined(BOARD_HAS_NB)
   NBConnectionHandler ArduinoIoTPreferredConnection(SECRET_PIN, SECRET_APN, SECRET_LOGIN, SECRET_PASS);
 #endif

--- a/examples/ArduinoIoTCloud-Basic/thingProperties.h
+++ b/examples/ArduinoIoTCloud-Basic/thingProperties.h
@@ -40,7 +40,7 @@ void initProperties() {
 #elif defined(BOARD_HAS_GSM)
   GSMConnectionHandler ArduinoIoTPreferredConnection(SECRET_PIN, SECRET_APN, SECRET_LOGIN, SECRET_PASS);
 #elif defined(BOARD_HAS_LORA)
-  LoRaConnectionHandler ArduinoIoTPreferredConnection(SECRET_APP_EUI, SECRET_APP_KEY, _lora_band::EU868, _lora_class::CLASS_A);
+  LoRaConnectionHandler ArduinoIoTPreferredConnection(SECRET_APP_EUI, SECRET_APP_KEY, _lora_band::EU868, NULL, _lora_class::CLASS_A);
 #elif defined(BOARD_HAS_NB)
   NBConnectionHandler ArduinoIoTPreferredConnection(SECRET_PIN, SECRET_APN, SECRET_LOGIN, SECRET_PASS);
 #endif

--- a/examples/ArduinoIoTCloud-Callbacks/thingProperties.h
+++ b/examples/ArduinoIoTCloud-Callbacks/thingProperties.h
@@ -27,7 +27,7 @@ void initProperties() {
 #elif defined(BOARD_HAS_GSM)
   GSMConnectionHandler ArduinoIoTPreferredConnection(SECRET_PIN, SECRET_APN, SECRET_LOGIN, SECRET_PASS);
 #elif defined(BOARD_HAS_LORA)
-  LoRaConnectionHandler ArduinoIoTPreferredConnection(SECRET_APP_EUI, SECRET_APP_KEY, _lora_band::EU868, _lora_class::CLASS_A);
+  LoRaConnectionHandler ArduinoIoTPreferredConnection(SECRET_APP_EUI, SECRET_APP_KEY, _lora_band::EU868, NULL, _lora_class::CLASS_A);
 #elif defined(BOARD_HAS_NB)
   NBConnectionHandler ArduinoIoTPreferredConnection(SECRET_PIN, SECRET_APN, SECRET_LOGIN, SECRET_PASS);
 #endif


### PR DESCRIPTION
This needs to be added after Arduino_ConnectionHandler [0.6.5 release ](https://github.com/arduino-libraries/Arduino_ConnectionHandler/releases/tag/0.6.5)