### PR TITLE
Fix OTA properties synchronization

### DIFF
--- a/src/ArduinoIoTCloudTCP.h
+++ b/src/ArduinoIoTCloudTCP.h
@@ -164,6 +164,7 @@ class ArduinoIoTCloudTCP: public ArduinoIoTCloudClass
 
     static void onMessage(int length);
     void handleMessage(int length);
+    void sendPropertyContainerToCloud(PropertyContainer & property_container);
     void sendPropertiesToCloud();
     void sendOTAPropertiesToCloud();
     void requestLastValue();

--- a/src/ArduinoIoTCloudTCP.h
+++ b/src/ArduinoIoTCloudTCP.h
@@ -165,6 +165,7 @@ class ArduinoIoTCloudTCP: public ArduinoIoTCloudClass
     static void onMessage(int length);
     void handleMessage(int length);
     void sendPropertiesToCloud();
+    void sendOTAPropertiesToCloud();
     void requestLastValue();
     int write(String const topic, byte const data[], int const length);
 


### PR DESCRIPTION
Switching to  ArduinoIoTCloud 1.3.0 from earlier version can lead to an OTA loop caused by bad synchronization of OTA_REQ property. The OTA loop occurs when the resulting CBOR message created calling sendPropertiesToCloud() is greater than 256 byte and thus it gets splitted in multiple parts. If the OTA variables are not synched within the firs part of the message the OTA process restart before the remainig properties are synched.

With this PR the OTA properties are synched all together within the same CBOR message ensuring a correct synchronization.

Updating an application builded with an ArduinoIoTCloud library < 1.3.0 with an OTA will still lead to an OTA process executed two times.

Thanks @eclipse1985 for spotting this.

/cc @zmoog