### PR TITLE
Update compile-examples workflow in order to use ESP8266 core to version 3.0.2

### DIFF
--- a/.github/workflows/compile-examples.yml
+++ b/.github/workflows/compile-examples.yml
@@ -148,7 +148,7 @@ jobs:
               # Install ESP8266 platform via Boards Manager
               - name: esp8266:esp8266
                 source-url: https://arduino.esp8266.com/stable/package_esp8266com_index.json
-                version: 2.5.0
+                version: 3.0.2
             libraries:
             sketch-paths:
           # ESP32 boards


### PR DESCRIPTION
This Fix: https://github.com/arduino-libraries/ArduinoIoTCloud/actions/runs/1498499359

I don't know if the core was configured to version 2.5.0 for any specific reason or just because it was the most updated at time.