### PR TITLE
Minor change: Schedule example sketch: Fix supported boards list

### DIFF
--- a/examples/ArduinoIoTCloud-Schedule/ArduinoIoTCloud-Schedule.ino
+++ b/examples/ArduinoIoTCloud-Schedule/ArduinoIoTCloud-Schedule.ino
@@ -6,7 +6,6 @@
    - MKR WIFI 1010
    - MKR GSM 1400
    - MKR NB 1500
-   - MKR WAN 1300/1310
    - Nano 33 IoT
    - ESP 8266
 */


### PR DESCRIPTION
removing MKR WAN boards from the header of ArduinoIoTCloud-Schedule.ino example sketch because MKR WAN have no information about time so the scheduler wont work.