### PR TITLE
added definition of generic ESP32 to ARCH test

### DIFF
--- a/src/AIoTC_Config.h
+++ b/src/AIoTC_Config.h
@@ -131,7 +131,7 @@
   #define HAS_LORA
 #endif
 
-#if defined(ARDUINO_ESP8266_ESP12) || defined(ARDUINO_ARCH_ESP32) || defined(ESP8266)
+#if defined(ARDUINO_ESP8266_ESP12) || defined(ARDUINO_ARCH_ESP32) || defined(ESP8266) || defined(ESP32)
   #define BOARD_ESP
   #define HAS_TCP
 #endif


### PR DESCRIPTION
Some platforms do not define `ARDUINO_ARCH_ESP32` in favour of their own (see InkPlate's `ARCH_ARDUINO_INKPLATE).
This will cause compilation to fail for those devices.
Since every `ESP32` core defines `ESP32`, this has been added to the ARCH test in order to define `BOARD_ESP`