### PR TITLE
Prepare library to support SE050 crypto device

### DIFF
--- a/src/ArduinoIoTCloudTCP.cpp
+++ b/src/ArduinoIoTCloudTCP.cpp
@@ -208,7 +208,7 @@ int ArduinoIoTCloudTCP::begin(bool const enable_watchdog, String brokerAddress, 
   _ota_img_sha256 = sha256_str;
 #endif /* OTA_ENABLED */
 
-  #ifdef BOARD_HAS_OFFLOADED_ECCX08
+#if defined(BOARD_HAS_ECCX08) || defined(BOARD_HAS_OFFLOADED_ECCX08) || defined(BOARD_HAS_SE050)
   if (!_crypto.begin())
   {
     DEBUG_ERROR("_crypto.begin() failed.");
@@ -219,38 +219,29 @@ int ArduinoIoTCloudTCP::begin(bool const enable_watchdog, String brokerAddress, 
     DEBUG_ERROR("_crypto.readDeviceId(...) failed.");
     return 0;
   }
-  #endif
+#endif
 
-  #if defined(BOARD_HAS_ECCX08) || defined(BOARD_HAS_SE050)
-  if (!_crypto.begin())
-  {
-    DEBUG_ERROR("Cryptography processor failure. Make sure you have a compatible board.");
-    return 0;
-  }
-  if (!_crypto.readDeviceId(getDeviceId(), CryptoSlot::DeviceId))
-  {
-    DEBUG_ERROR("Cryptography processor read failure.");
-    return 0;
-  }
+#if defined(BOARD_HAS_ECCX08) || defined(BOARD_HAS_SE050)
   if (!_crypto.readCert(_cert, CryptoSlot::CompressedCertificate))
   {
     DEBUG_ERROR("Cryptography certificate reconstruction failure.");
     return 0;
   }
-  #ifndef BOARD_HAS_SE050
-  _sslClient.setClient(_connection->getClient());
-  #else
-  _sslClient.appendCustomCACert(AIoTSSCert);
-  #endif
   _sslClient.setEccSlot(static_cast<int>(CryptoSlot::Key), _cert.bytes(), _cert.length());
-  #elif defined(BOARD_ESP)
+#endif
+
+#if defined(BOARD_HAS_ECCX08)
+  _sslClient.setClient(_connection->getClient());
+#elif defined(BOARD_HAS_SE050)
+  _sslClient.appendCustomCACert(AIoTSSCert);
+#elif defined(BOARD_ESP)
   _sslClient.setInsecure();
-  #endif
+#endif
 
   _mqttClient.setClient(_sslClient);
-  #ifdef BOARD_ESP
+#ifdef BOARD_ESP
   _mqttClient.setUsernamePassword(getDeviceId(), _password);
-  #endif
+#endif
   _mqttClient.onMessage(ArduinoIoTCloudTCP::onMessage);
   _mqttClient.setKeepAliveInterval(30 * 1000);
   _mqttClient.setConnectionTimeout(1500);

--- a/src/ArduinoIoTCloudTCP.cpp
+++ b/src/ArduinoIoTCloudTCP.cpp
@@ -28,6 +28,11 @@
   #include "tls/utility/CryptoUtil.h"
 #endif
 
+#ifdef BOARD_HAS_SE050
+  #include "tls/AIoTCSSCert.h"
+  #include "tls/utility/CryptoUtil.h"
+#endif
+
 #ifdef BOARD_HAS_OFFLOADED_ECCX08
 #include <ArduinoECCX08.h>
 #include "tls/utility/CryptoUtil.h"
@@ -216,7 +221,7 @@ int ArduinoIoTCloudTCP::begin(bool const enable_watchdog, String brokerAddress, 
   }
   #endif
 
-  #ifdef BOARD_HAS_ECCX08
+  #if defined(BOARD_HAS_ECCX08) || defined(BOARD_HAS_SE050)
   if (!_crypto.begin())
   {
     DEBUG_ERROR("Cryptography processor failure. Make sure you have a compatible board.");
@@ -232,7 +237,11 @@ int ArduinoIoTCloudTCP::begin(bool const enable_watchdog, String brokerAddress, 
     DEBUG_ERROR("Cryptography certificate reconstruction failure.");
     return 0;
   }
+  #ifndef BOARD_HAS_SE050
   _sslClient.setClient(_connection->getClient());
+  #else
+  _sslClient.appendCustomCACert(AIoTSSCert);
+  #endif
   _sslClient.setEccSlot(static_cast<int>(CryptoSlot::Key), _cert.bytes(), _cert.length());
   #elif defined(BOARD_ESP)
   _sslClient.setInsecure();

--- a/src/ArduinoIoTCloudTCP.h
+++ b/src/ArduinoIoTCloudTCP.h
@@ -73,7 +73,7 @@ class ArduinoIoTCloudTCP: public ArduinoIoTCloudClass
     virtual int  connected     () override;
     virtual void printDebugInfo() override;
 
-    #if defined(BOARD_HAS_ECCX08) || defined(BOARD_HAS_OFFLOADED_ECCX08)
+    #if defined(BOARD_HAS_ECCX08) || defined(BOARD_HAS_OFFLOADED_ECCX08) || defined(BOARD_HAS_SE050)
     int begin(ConnectionHandler & connection, bool const enable_watchdog = true, String brokerAddress = DEFAULT_BROKER_ADDRESS_SECURE_AUTH, uint16_t brokerPort = DEFAULT_BROKER_PORT_SECURE_AUTH);
     #else
     int begin(ConnectionHandler & connection, bool const enable_watchdog = true, String brokerAddress = DEFAULT_BROKER_ADDRESS_USER_PASS_AUTH, uint16_t brokerPort = DEFAULT_BROKER_PORT_USER_PASS_AUTH);

--- a/src/ArduinoIoTCloudTCP.h
+++ b/src/ArduinoIoTCloudTCP.h
@@ -31,6 +31,8 @@
   #include "tls/utility/CryptoUtil.h"
 #elif defined(BOARD_ESP)
   #include <WiFiClientSecure.h>
+#elif defined(BOARD_HAS_SE050)
+  #include "tls/utility/CryptoUtil.h"
 #endif
 
 #ifdef BOARD_HAS_OFFLOADED_ECCX08
@@ -143,6 +145,10 @@ class ArduinoIoTCloudTCP: public ArduinoIoTCloudClass
     #elif defined(BOARD_ESP)
     WiFiClientSecure _sslClient;
     String _password;
+    #elif defined(BOARD_HAS_SE050)
+    ArduinoIoTCloudCertClass _cert;
+    WiFiSSLSE050Client _sslClient;
+    CryptoUtil _crypto;
     #endif
 
     MqttClient _mqttClient;

--- a/src/ArduinoIoTCloudTCP.h
+++ b/src/ArduinoIoTCloudTCP.h
@@ -33,6 +33,7 @@
   #include <WiFiClientSecure.h>
 #elif defined(BOARD_HAS_SE050)
   #include "tls/utility/CryptoUtil.h"
+  #include <WiFiSSLSE050Client.h>
 #endif
 
 #ifdef BOARD_HAS_OFFLOADED_ECCX08

--- a/src/tls/AIoTCSSCert.h
+++ b/src/tls/AIoTCSSCert.h
@@ -1,0 +1,48 @@
+/*
+   This file is part of ArduinoIoTBearSSL.
+
+   Copyright 2019 ARDUINO SA (http://www.arduino.cc/)
+
+   This software is released under the GNU General Public License version 3,
+   which covers the main part of ArduinoIoTBearSSL.
+   The terms of this license can be found at:
+   https://www.gnu.org/licenses/gpl-3.0.en.html
+
+   You can be released from the requirements of the above licenses by purchasing
+   a commercial license. Buying such a license is mandatory if you want to modify or
+   otherwise use the software for commercial activities involving the Arduino
+   software without disclosing the source code of your own applications. To purchase
+   a commercial license, send an email to license@arduino.cc.
+
+*/
+
+#ifndef _AIOTC_SS_CERT_H_
+#define _AIOTC_SS_CERT_H_
+
+/******************************************************************************
+ * INCLUDE
+ ******************************************************************************/
+
+#include <AIoTC_Config.h>
+#ifdef BOARD_HAS_SE050
+
+/******************************************************************************
+ * CONSTANTS
+ ******************************************************************************/
+static const char AIoTSSCert[] =
+"-----BEGIN CERTIFICATE-----\n"
+"MIIBzzCCAXSgAwIBAgIUHxAd66fhJecnwaOR4+wNF03tSlkwCgYIKoZIzj0EAwIw\n"
+"RTELMAkGA1UEBhMCVVMxFzAVBgNVBAoTDkFyZHVpbm8gTExDIFVTMQswCQYDVQQL\n"
+"EwJJVDEQMA4GA1UEAxMHQXJkdWlubzAeFw0xODA3MjQwOTQ3MDBaFw00ODA3MTYw\n"
+"OTQ3MDBaMEUxCzAJBgNVBAYTAlVTMRcwFQYDVQQKEw5BcmR1aW5vIExMQyBVUzEL\n"
+"MAkGA1UECxMCSVQxEDAOBgNVBAMTB0FyZHVpbm8wWTATBgcqhkjOPQIBBggqhkjO\n"
+"PQMBBwNCAARtd2xaz2EcfUSYUfJe4QJAd7ecvUmio4xOq16YrIL8aVtEIne0TS6O\n"
+"3ypxwTls1jkUvdlrGEtL7LPV7kKJiVUio0IwQDAOBgNVHQ8BAf8EBAMCAQYwDwYD\n"
+"VR0TAQH/BAUwAwEB/zAdBgNVHQ4EFgQUWz4qa47JsBqoVOY2m4wJ+fzhuYAwCgYI\n"
+"KoZIzj0EAwIDSQAwRgIhAL/T3CNmaLUK3D8NDsNz4grH92CqEA3TIL/hApabawXY\n"
+"AiEA6tnZ2lrNElKXCajtZg/hjWRE/+giFzBP8riar8qOz2w=\n"
+"-----END CERTIFICATE-----\n";
+
+#endif /* #ifdef BOARD_HAS_SE050 */
+
+#endif /* _AIOTC_SS_CERT_H_ */

--- a/src/tls/bearssl/dec32be.c
+++ b/src/tls/bearssl/dec32be.c
@@ -23,7 +23,7 @@
  */
 
 #include <AIoTC_Config.h>
-#if defined(BOARD_HAS_ECCX08) || defined(BOARD_HAS_OFFLOADED_ECCX08)
+#if defined(BOARD_HAS_ECCX08) || defined(BOARD_HAS_OFFLOADED_ECCX08) || defined(BOARD_HAS_SE050)
 
 #include "inner.h"
 

--- a/src/tls/bearssl/enc32be.c
+++ b/src/tls/bearssl/enc32be.c
@@ -23,7 +23,7 @@
  */
 
 #include <AIoTC_Config.h>
-#if defined(BOARD_HAS_ECCX08) || defined(BOARD_HAS_OFFLOADED_ECCX08)
+#if defined(BOARD_HAS_ECCX08) || defined(BOARD_HAS_OFFLOADED_ECCX08) || defined(BOARD_HAS_SE050)
 
 #include "inner.h"
 

--- a/src/tls/bearssl/sha2small.c
+++ b/src/tls/bearssl/sha2small.c
@@ -23,7 +23,7 @@
  */
 
 #include <AIoTC_Config.h>
-#if defined(BOARD_HAS_ECCX08) || defined(BOARD_HAS_OFFLOADED_ECCX08)
+#if defined(BOARD_HAS_ECCX08) || defined(BOARD_HAS_OFFLOADED_ECCX08) || defined(BOARD_HAS_SE050)
 
 #include "inner.h"
 

--- a/src/tls/utility/Cert.cpp
+++ b/src/tls/utility/Cert.cpp
@@ -23,7 +23,7 @@
 
 #include <AIoTC_Config.h>
 
-#if defined(BOARD_HAS_ECCX08) || defined(BOARD_HAS_OFFLOADED_ECCX08)
+#if defined(BOARD_HAS_ECCX08) || defined(BOARD_HAS_OFFLOADED_ECCX08) || defined(BOARD_HAS_SE050)
 
 #include "Cert.h"
 
@@ -915,4 +915,4 @@ int ArduinoIoTCloudCertClass::appendAuthorityKeyId(const byte authorityKeyId[], 
   return length + 17;
 }
 
-#endif /* (BOARD_HAS_ECCX08) || defined(BOARD_HAS_OFFLOADED_ECCX08) */
+#endif /* (BOARD_HAS_ECCX08) || defined(BOARD_HAS_OFFLOADED_ECCX08) || defined(BOARD_HAS_SE050) */

--- a/src/tls/utility/Cert.h
+++ b/src/tls/utility/Cert.h
@@ -24,7 +24,7 @@
 
 #include <AIoTC_Config.h>
 
-#if defined(BOARD_HAS_ECCX08) || defined(BOARD_HAS_OFFLOADED_ECCX08)
+#if defined(BOARD_HAS_ECCX08) || defined(BOARD_HAS_OFFLOADED_ECCX08) || defined(BOARD_HAS_SE050)
 
 /******************************************************************************
  * DEFINE
@@ -182,6 +182,6 @@ private:
 
 };
 
-#endif /* BOARD_HAS_ECCX08 || BOARD_HAS_OFFLOADED_ECCX08 */
+#endif /* BOARD_HAS_ECCX08 || BOARD_HAS_OFFLOADED_ECCX08 || BOARD_HAS_SE050*/
 
 #endif /* ARDUINO_IOT_CLOUD_CERT_H */

--- a/src/tls/utility/CryptoUtil.h
+++ b/src/tls/utility/CryptoUtil.h
@@ -24,20 +24,34 @@
 
 #include <AIoTC_Config.h>
 
-#if defined(BOARD_HAS_ECCX08) || defined(BOARD_HAS_OFFLOADED_ECCX08)
+#if defined(BOARD_HAS_ECCX08) || defined(BOARD_HAS_OFFLOADED_ECCX08) || defined(BOARD_HAS_SE050)
 #include <Arduino.h>
 #include "Cert.h"
+
+#if defined(BOARD_HAS_SE050)
+#include <SE05X.h>
+#else
 #include <ArduinoECCX08.h>
+#endif
+
+/******************************************************************************
+ * DEFINE
+ ******************************************************************************/
+#if defined(BOARD_HAS_SE050)
+#define CRYPTO_SLOT_OFFSET                100
+#else
+#define CRYPTO_SLOT_OFFSET                0
+#endif
 
 /******************************************************************************
    TYPEDEF
  ******************************************************************************/
 enum class CryptoSlot : int
 {
-  Key                                   = 0,
-  CompressedCertificate                 = 10,
-  SerialNumberAndAuthorityKeyIdentifier = 11,
-  DeviceId                              = 12
+  Key                                   = (0  + CRYPTO_SLOT_OFFSET),
+  CompressedCertificate                 = (10 + CRYPTO_SLOT_OFFSET),
+  SerialNumberAndAuthorityKeyIdentifier = (11 + CRYPTO_SLOT_OFFSET),
+  DeviceId                              = (12 + CRYPTO_SLOT_OFFSET)
 };
 
 /******************************************************************************
@@ -64,10 +78,14 @@ public:
   int readCert(ArduinoIoTCloudCertClass & cert, const CryptoSlot certSlot);
 
 private:
+#if defined(BOARD_HAS_SE050)
+  SE05XClass & _crypto;
+#else
   ECCX08Class & _crypto;
+#endif
 
 };
 
-#endif /* BOARD_HAS_ECCX08 || BOARD_HAS_OFFLOADED_ECCX08 */
+#endif /* BOARD_HAS_ECCX08 || BOARD_HAS_OFFLOADED_ECCX08 || BOARD_HAS_SE050 */
 
 #endif /* ARDUINO_IOT_CLOUD_UTILITY_CRYPTO_CRYPTO_UTIL_H_ */


### PR DESCRIPTION
This PR should be rebased and applied after #307 so only commits from https://github.com/arduino-libraries/ArduinoIoTCloud/commit/44a5920ddbd07c796397d7d1526df02d8d59830f to https://github.com/arduino-libraries/ArduinoIoTCloud/commit/3d79839629d963e80ce09cc5bc39c2a6b9562684 are meaningful. I did not found a better way to stack PRs from a fork...

Its goal is to prepare the library and add support to the `SE050` crypto device.

As of now this `SE050` can be found on `PORTENTA H7` boards, but it is not yet enabled in AIoTC_Config.h neither supported by the core.