### PR TITLE
PORTENTA_H7_M4: Remove M4 core from supported build options

### DIFF
--- a/.github/workflows/compile-examples.yml
+++ b/.github/workflows/compile-examples.yml
@@ -50,8 +50,6 @@ jobs:
             type: gsm
           - fqbn: arduino:samd:mkrnb1500
             type: nb
-          - fqbn: arduino:mbed:envie_m4
-            type: mbed
           - fqbn: arduino:mbed:envie_m7
             type: mbed
           - fqbn: esp8266:esp8266:huzzah

--- a/src/AIoTC_Config.h
+++ b/src/AIoTC_Config.h
@@ -116,7 +116,7 @@
 
 #if defined(ARDUINO_SAMD_MKRGSM1400) || defined(ARDUINO_SAMD_MKR1000) ||   \
   defined(ARDUINO_SAMD_MKRNB1500) || defined(ARDUINO_PORTENTA_H7_M7)      ||   \
-  defined(ARDUINO_PORTENTA_H7_M4) || defined (ARDUINO_NANO_RP2040_CONNECT)
+  defined (ARDUINO_NANO_RP2040_CONNECT)
   #define BOARD_HAS_ECCX08
   #define HAS_TCP
 #endif

--- a/src/ArduinoIoTCloudTCP.cpp
+++ b/src/ArduinoIoTCloudTCP.cpp
@@ -38,7 +38,7 @@
 #include "tls/utility/CryptoUtil.h"
 #endif
 
-#if defined(ARDUINO_PORTENTA_H7_M7) || defined(ARDUINO_PORTENTA_H7_M4) || defined(ARDUINO_NICLA_VISION)
+#if defined(ARDUINO_PORTENTA_H7_M7) || defined(ARDUINO_NICLA_VISION)
 #  include "tls/utility/SHA256.h"
 #  include <stm32h7xx_hal_rtc_ex.h>
 #  include <WiFi.h>

--- a/src/ArduinoIoTCloudTCP.cpp
+++ b/src/ArduinoIoTCloudTCP.cpp
@@ -826,7 +826,7 @@ void ArduinoIoTCloudTCP::onOTARequest()
   _ota_error = rp2040_connect_onOTARequest(_ota_url.c_str());
 #endif
 
-#if defined(ARDUINO_PORTENTA_H7_M7) || defined(ARDUINO_PORTENTA_H7_M4) || defined(ARDUINO_NICLA_VISION)
+#if defined(ARDUINO_PORTENTA_H7_M7) || defined(ARDUINO_NICLA_VISION)
   _ota_error = portenta_h7_onOTARequest(_ota_url.c_str());
 #endif
 }

--- a/src/utility/ota/OTA-portenta-h7.cpp
+++ b/src/utility/ota/OTA-portenta-h7.cpp
@@ -15,7 +15,7 @@
    a commercial license, send an email to license@arduino.cc.
 */
 
-#if defined(ARDUINO_PORTENTA_H7_M7) || defined(ARDUINO_PORTENTA_H7_M4) || defined(ARDUINO_NICLA_VISION)
+#if defined(ARDUINO_PORTENTA_H7_M7) || defined(ARDUINO_NICLA_VISION)
 
 /******************************************************************************
  * INCLUDE
@@ -87,4 +87,4 @@ int portenta_h7_onOTARequest(char const * ota_url)
   NVIC_SystemReset();
 }
 
-#endif /* defined(ARDUINO_PORTENTA_H7_M7) || defined(ARDUINO_PORTENTA_H7_M4) || defined(ARDUINO_NICLA_VISION) */
+#endif /* defined(ARDUINO_PORTENTA_H7_M7) || defined(ARDUINO_NICLA_VISION) */

--- a/src/utility/ota/OTA.h
+++ b/src/utility/ota/OTA.h
@@ -62,7 +62,7 @@ int samd_onOTARequest(char const * ota_url);
 int rp2040_connect_onOTARequest(char const * ota_url);
 #endif
 
-#if defined(ARDUINO_PORTENTA_H7_M7) || defined(ARDUINO_PORTENTA_H7_M4) || defined(ARDUINO_NICLA_VISION)
+#if defined(ARDUINO_PORTENTA_H7_M7) || defined(ARDUINO_NICLA_VISION)
 int portenta_h7_onOTARequest(char const * ota_url);
 #endif
 

--- a/src/utility/watchdog/Watchdog.cpp
+++ b/src/utility/watchdog/Watchdog.cpp
@@ -90,7 +90,7 @@ void mkr_nb_feed_watchdog()
 static void mbed_watchdog_enable()
 {
   watchdog_config_t cfg;
-#if defined(ARDUINO_PORTENTA_H7_M7) || defined(ARDUINO_PORTENTA_H7_M4) || defined(ARDUINO_NICLA_VISION)
+#if defined(ARDUINO_PORTENTA_H7_M7) || defined(ARDUINO_NICLA_VISION)
   cfg.timeout_ms = PORTENTA_H7_WATCHDOG_MAX_TIMEOUT_ms;
 #elif defined(ARDUINO_NANO_RP2040_CONNECT)
   cfg.timeout_ms = NANO_RP2040_WATCHDOG_MAX_TIMEOUT_ms;
@@ -116,7 +116,7 @@ static void mbed_watchdog_reset()
 void mbed_watchdog_trigger_reset()
 {
   watchdog_config_t cfg;
-#if defined(ARDUINO_PORTENTA_H7_M7) || defined(ARDUINO_PORTENTA_H7_M4) || defined(ARDUINO_NICLA_VISION)
+#if defined(ARDUINO_PORTENTA_H7_M7) || defined(ARDUINO_NICLA_VISION)
   cfg.timeout_ms = 1;
 #elif defined(ARDUINO_NANO_RP2040_CONNECT)
   cfg.timeout_ms = 1;


### PR DESCRIPTION
With the actual configuration of the library OTA is not enabled for PORTENTA_H7_M4:

https://github.com/arduino-libraries/ArduinoIoTCloud/blob/45d5672c4473c9663720dc1f187c03bffce46c6e/src/AIoTC_Config.h#L105-L115

so is it safe to not compile `portenta_h7_onOTARequest()` function for the M4 build.

This is also a possible fix for the compile-examples failure of the last release caused by restricting the support of Arduino_Portenta_OTA only to the M7 core:

https://github.com/arduino-libraries/Arduino_Portenta_OTA/blob/0652134e737b67575e2d1c41cb9fac238922ebd0/src/Arduino_Portenta_OTA_Config.h#L27-L31