### PR TITLE
Remove ArduinoBearSSL as a CI build dependency.

### DIFF
--- a/.github/workflows/compile-examples.yml
+++ b/.github/workflows/compile-examples.yml
@@ -88,7 +88,6 @@ jobs:
               - name: RTCZero
               - name: WiFiNINA
               - name: Arduino_JSON
-              - name: ArduinoBearSSL
               - source-url: https://github.com/adafruit/Adafruit_SleepyDog.git
             sketch-paths: |
               - examples/utility/Provisioning

--- a/examples/utility/SelfProvisioning/ECCX08Cert.cpp
+++ b/examples/utility/SelfProvisioning/ECCX08Cert.cpp
@@ -19,12 +19,10 @@
  * INCLUDE
  ******************************************************************************/
 
-#include <ArduinoBearSSL.h>
-
-#include "bearssl/bearssl_hash.h"
+#include <ArduinoIoTCloud.h>
 #include <ArduinoECCX08.h>
-
 #include "ECCX08Cert.h"
+#include "tls/utility/SHA256.h"
 
 /******************************************************************************
  * DEFINE
@@ -190,13 +188,13 @@ String ECCX08CertClass::endCSR() {
   *out++ = 0xa0;
   *out++ = 0x00;
 
-  br_sha256_context sha256Context;
+  SHA256 sha256;
   byte csrInfoSha256[64];
   byte signature[64];
 
-  br_sha256_init(&sha256Context);
-  br_sha256_update(&sha256Context, csrInfo, csrInfoHeaderLen + csrInfoLen);
-  br_sha256_out(&sha256Context, csrInfoSha256);
+  sha256.begin();
+  sha256.update(csrInfo, csrInfoHeaderLen + csrInfoLen);
+  sha256.finalize(csrInfoSha256);
 
   if (!ECCX08.ecSign(_keySlot, csrInfoSha256, signature)) {
     return "";


### PR DESCRIPTION
The code formerly integrated in ArduinoBearSSL has long since been integrated with ArduinoIoTCloud library.