### PR TITLE
Add esp32 architecture in library.properties file

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -6,6 +6,6 @@ sentence=This library allows to connect to the Arduino IoT Cloud service.
 paragraph=It provides a ConnectionManager to handle connection/disconnection, property-change updates and events callbacks. The supported boards are MKRGSM, MKR1000 and WiFi101.
 category=Communication
 url=https://github.com/arduino-libraries/ArduinoIoTCloud
-architectures=mbed,samd,esp8266,mbed_nano,mbed_portenta,mbed_nicla
+architectures=mbed,samd,esp8266,mbed_nano,mbed_portenta,mbed_nicla,esp32
 includes=ArduinoIoTCloud.h
 depends=Arduino_ConnectionHandler,Arduino_DebugUtils,ArduinoMqttClient,ArduinoECCX08,RTCZero,Adafruit SleepyDog Library


### PR DESCRIPTION
ESP32 architecture is currently supported through thid-party [arduino-esp32](https://github.com/espressif/arduino-esp32/releases/tag/1.0.6) core version1.0.6