### PR TITLE
Use NTP as primary time source and connection handler as fallback

### DIFF
--- a/src/utility/time/TimeService.cpp
+++ b/src/utility/time/TimeService.cpp
@@ -279,24 +279,24 @@ bool TimeServiceClass::connected()
 unsigned long TimeServiceClass::getRemoteTime()
 {
   if(connected()) {
-    /* At first try to see if a valid time can be obtained
-     * using the network time available via the connection
-     * handler.
-     */
-    unsigned long const connection_time = _con_hdl->getTime();
-    if(isTimeValid(connection_time)) {
-      return connection_time;
-    }
-
 #ifndef __AVR__
-    /* If no valid network time is available try to obtain the
-     * time via NTP next.
+    /* At first try to obtain a valid time via NTP.
+     * This is the most reliable time source and it will
+     * ensure a correct behaviour of the library.
      */
     unsigned long const ntp_time = NTPUtils::getTime(_con_hdl->getUDP());
     if(isTimeValid(ntp_time)) {
       return ntp_time;
     }
 #endif
+
+    /* As fallback if NTP request fails try to obtain the
+     * network time using the connection handler.
+     */
+    unsigned long const connection_time = _con_hdl->getTime();
+    if(isTimeValid(connection_time)) {
+      return connection_time;
+    }
   }
 
   /* Return the epoch timestamp at compile time as a last


### PR DESCRIPTION
Some user reported a wrong behaviour of the scheduler widget due to wrong time. After some investigations we discovered that the time readed from connection handler was wrong. 

https://forum.arduino.cc/t/arduino-cloud-scheduler-responding-to-utc-time-instead-of-local-time/992909/21

The issue needs some more investigation to understand if the root cause is a wrong time injected from the provider or some bug in the [MKRNB library](https://github.com/arduino-libraries/MKRNB/blob/e94641fba4a81dfaa72f13175cfe67e1a5b091ce/src/NB.cpp#L443 ), but it looks a good idea to change the priority of the time sources and use NTP as first choice and the connection handler as fallback.