### PR TITLE
Add comment to "Compile Examples" workflow re: `esp8266:esp8266` version

### DIFF
--- a/.github/workflows/compile-examples.yml
+++ b/.github/workflows/compile-examples.yml
@@ -157,6 +157,7 @@ jobs:
               # Install ESP8266 platform via Boards Manager
               - name: esp8266:esp8266
                 source-url: https://arduino.esp8266.com/stable/package_esp8266com_index.json
+                # Use the version currently installed in Arduino Cloud
                 version: 2.5.0
             libraries:
             sketch-paths:


### PR DESCRIPTION
A specific version of [the "**esp8266**" boards platform](https://github.com/esp8266/arduino) is installed on the Arduino Cloud servers.

Since that is the primary environment the sketches using this library are compiled in, it is necessary for the "Compile Examples" GitHub Actions workflow to use the same version of the platform when running the test compilations of the library examples in order to ensure the results from the CI system will match those from real usage.

This requirement is not obvious. Since the workflow does not pin the other platform versions (because Arduino Cloud typically uses the latest version), the pinning of this platform specifically might be the source of confusion for the maintainers (e.g., https://github.com/arduino-libraries/ArduinoIoTCloud/pull/290). So it is worth documenting the reason.