### PR TITLE
Remove setThingId(THING_ID) from library examples

### DIFF
--- a/examples/ArduinoIoTCloud-Advanced/thingProperties.h
+++ b/examples/ArduinoIoTCloud-Advanced/thingProperties.h
@@ -1,7 +1,6 @@
 #include <ArduinoIoTCloud.h>
 #include <Arduino_ConnectionHandler.h>
 
-#define THING_ID "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
 #define BOARD_ID "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
 
 void onSwitchButtonChange();
@@ -16,7 +15,6 @@ void initProperties() {
   ArduinoCloud.setBoardId(BOARD_ID);
   ArduinoCloud.setSecretDeviceKey(SECRET_DEVICE_KEY);
 #endif
-  ArduinoCloud.setThingId(THING_ID);
 #if defined(BOARD_HAS_WIFI) || defined(BOARD_HAS_GSM) || defined(BOARD_HAS_NB)
   ArduinoCloud.addProperty(switchButton, WRITE, ON_CHANGE, onSwitchButtonChange);
   ArduinoCloud.addProperty(location, READ, ON_CHANGE);

--- a/examples/ArduinoIoTCloud-Basic/thingProperties.h
+++ b/examples/ArduinoIoTCloud-Basic/thingProperties.h
@@ -9,7 +9,6 @@
   #error "Arduino IoT Cloud currently only supports MKR1000, MKR WiFi 1010, MKR WAN 1300/1310, MKR NB 1500 and MKR GSM 1400"
 #endif
 
-#define THING_ID "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
 #define BOARD_ID "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
 
 void onLedChange();
@@ -23,7 +22,6 @@ void initProperties() {
   ArduinoCloud.setBoardId(BOARD_ID);
   ArduinoCloud.setSecretDeviceKey(SECRET_DEVICE_KEY);
 #endif
-  ArduinoCloud.setThingId(THING_ID);
 #if defined(BOARD_HAS_WIFI) || defined(BOARD_HAS_GSM) || defined(BOARD_HAS_NB)
   ArduinoCloud.addProperty(led, Permission::Write).onUpdate(onLedChange);
   ArduinoCloud.addProperty(potentiometer, Permission::Read).publishOnChange(10);

--- a/examples/ArduinoIoTCloud-Callbacks/thingProperties.h
+++ b/examples/ArduinoIoTCloud-Callbacks/thingProperties.h
@@ -9,8 +9,6 @@
   #error "Arduino IoT Cloud currently only supports MKR1000, MKR WiFi 1010, MKR WAN 1300/1310, MKR NB 1500 and MKR GSM 1400"
 #endif
 
-#define THING_ID "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
-
 /* BOARD_ID is only required if you are using an ESP8266 */
 #define BOARD_ID "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
 
@@ -19,7 +17,6 @@ void initProperties() {
   ArduinoCloud.setBoardId(BOARD_ID);
   ArduinoCloud.setSecretDeviceKey(SECRET_DEVICE_KEY);
 #endif
-  ArduinoCloud.setThingId(THING_ID);
 }
 
 #if defined(BOARD_HAS_WIFI)

--- a/examples/ArduinoIoTCloud-DeferredOTA/thingProperties.h
+++ b/examples/ArduinoIoTCloud-DeferredOTA/thingProperties.h
@@ -9,7 +9,6 @@
   #error "Arduino IoT Cloud currently only supports MKR1000, MKR WiFi 1010, MKR WAN 1300/1310, MKR NB 1500 and MKR GSM 1400"
 #endif
 
-#define THING_ID "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
 #define BOARD_ID "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
 
 void onLedChange();
@@ -21,7 +20,6 @@ void initProperties() {
   ArduinoCloud.setBoardId(BOARD_ID);
   ArduinoCloud.setSecretDeviceKey(SECRET_DEVICE_KEY);
 #endif
-  ArduinoCloud.setThingId(THING_ID);
 #if defined(BOARD_HAS_WIFI) || defined(BOARD_HAS_GSM) || defined(BOARD_HAS_NB)
   ArduinoCloud.addProperty(led, Permission::Write).onUpdate(onLedChange);
 #elif defined(BOARD_HAS_LORA)

--- a/examples/ArduinoIoTCloud-Schedule/thingProperties.h
+++ b/examples/ArduinoIoTCloud-Schedule/thingProperties.h
@@ -1,7 +1,6 @@
 #include <ArduinoIoTCloud.h>
 #include <Arduino_ConnectionHandler.h>
 
-#define THING_ID "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
 #define BOARD_ID "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
 
 void onSwitchButtonChange();
@@ -20,7 +19,6 @@ void initProperties() {
   ArduinoCloud.setBoardId(BOARD_ID);
   ArduinoCloud.setSecretDeviceKey(SECRET_DEVICE_KEY);
 #endif
-  ArduinoCloud.setThingId(THING_ID);
 #if defined(BOARD_HAS_WIFI) || defined(BOARD_HAS_GSM) || defined(BOARD_HAS_NB)
   ArduinoCloud.addProperty(switchButton, WRITE, ON_CHANGE);
   ArduinoCloud.addProperty(oneShot, READWRITE, ON_CHANGE);

--- a/examples/utility/ArduinoIoTCloud_Travis_CI/thingProperties.h
+++ b/examples/utility/ArduinoIoTCloud_Travis_CI/thingProperties.h
@@ -14,12 +14,6 @@
 #endif
 
 /******************************************************************************
-   DEFINES
- ******************************************************************************/
-
-#define THING_ID "ARDUINO_IOT_CLOUD_THING_ID"
-
-/******************************************************************************
    GLOBAL CONSTANTS
  ******************************************************************************/
 
@@ -78,7 +72,6 @@ void onStringPropertyChange();
  ******************************************************************************/
 #if defined(BOARD_HAS_WIFI) || defined(BOARD_HAS_GSM) || defined (BOARD_HAS_NB)
 void initProperties() {
-  ArduinoCloud.setThingId(THING_ID);
 
   ArduinoCloud.addProperty(bool_property_1,  READWRITE, 1 * SECONDS);
   ArduinoCloud.addProperty(int_property_1,   READ,      2 * MINUTES);
@@ -109,7 +102,6 @@ void initProperties() {
 
 #elif defined(BOARD_HAS_LORA)
 void initProperties() {
-  ArduinoCloud.setThingId(THING_ID);
 
   ArduinoCloud.addProperty(bool_property_1,  1,   READWRITE, 1 * SECONDS);
   ArduinoCloud.addProperty(int_property_1,   2,   READ,      2 * MINUTES);


### PR DESCRIPTION
After release [1.5.0](https://github.com/arduino-libraries/ArduinoIoTCloud/releases/tag/1.5.0) is no more necessary to configure the `thing_id` from the sketch. The board retrieves  the attached `thing_id` from the cloud  using the `device_id`.

Fixes #304 