### PR TITLE
Add ethernet interface support (OTA and Watchdog) for Portenta H7

### DIFF
--- a/src/ArduinoIoTCloudTCP.cpp
+++ b/src/ArduinoIoTCloudTCP.cpp
@@ -830,7 +830,8 @@ void ArduinoIoTCloudTCP::onOTARequest()
 #endif
 
 #ifdef BOARD_STM32H7
-  _ota_error = portenta_h7_onOTARequest(_ota_url.c_str());
+  bool const use_ethernet = _connection->getInterface() == NetworkAdapter::ETHERNET ? true : false;
+  _ota_error = portenta_h7_onOTARequest(_ota_url.c_str(), use_ethernet);
 #endif
 }
 #endif

--- a/src/ArduinoIoTCloudTCP.cpp
+++ b/src/ArduinoIoTCloudTCP.cpp
@@ -307,10 +307,8 @@ int ArduinoIoTCloudTCP::begin(bool const enable_watchdog, String brokerAddress, 
 #if defined (ARDUINO_ARCH_SAMD) || defined (ARDUINO_ARCH_MBED)
   if (enable_watchdog) {
     watchdog_enable();
-#if defined (WIFI_HAS_FEED_WATCHDOG_FUNC) || defined (ARDUINO_PORTENTA_H7_WIFI_HAS_FEED_WATCHDOG_FUNC)
     bool const use_ethernet = _connection->getInterface() == NetworkAdapter::ETHERNET ? true : false;
     watchdog_enable_network_feed(use_ethernet);
-#endif
   }
 #endif
 

--- a/src/ArduinoIoTCloudTCP.cpp
+++ b/src/ArduinoIoTCloudTCP.cpp
@@ -308,7 +308,8 @@ int ArduinoIoTCloudTCP::begin(bool const enable_watchdog, String brokerAddress, 
   if (enable_watchdog) {
     watchdog_enable();
 #if defined (WIFI_HAS_FEED_WATCHDOG_FUNC) || defined (ARDUINO_PORTENTA_H7_WIFI_HAS_FEED_WATCHDOG_FUNC)
-      WiFi.setFeedWatchdogFunc(watchdog_reset);
+    bool const use_ethernet = _connection->getInterface() == NetworkAdapter::ETHERNET ? true : false;
+    watchdog_enable_network_feed(use_ethernet);
 #endif
   }
 #endif

--- a/src/utility/ota/OTA-portenta-h7.cpp
+++ b/src/utility/ota/OTA-portenta-h7.cpp
@@ -28,13 +28,16 @@
 #include <Arduino_DebugUtils.h>
 #include <Arduino_Portenta_OTA.h>
 
+#include <WiFi.h>
+#include <Ethernet.h>
+
 #include "../watchdog/Watchdog.h"
 
 /******************************************************************************
  * FUNCTION DEFINITION
  ******************************************************************************/
 
-int portenta_h7_onOTARequest(char const * ota_url)
+int portenta_h7_onOTARequest(char const * ota_url, bool use_ethernet)
 {
   watchdog_reset();
 
@@ -63,7 +66,13 @@ int portenta_h7_onOTARequest(char const * ota_url)
   watchdog_reset();
 
   /* Download the OTA file from the web storage location. */
-  int const ota_portenta_qspi_download_ret_code = ota_portenta_qspi.download(ota_url, true /* is_https */);
+  MbedSocketClass * download_socket = static_cast<MbedSocketClass*>(&WiFi);
+#if defined (ARDUINO_PORTENTA_H7_M7)
+  if(use_ethernet) {
+    download_socket = static_cast<MbedSocketClass*>(&Ethernet);
+  }
+#endif
+  int const ota_portenta_qspi_download_ret_code = ota_portenta_qspi.download(ota_url, true /* is_https */, download_socket);
   DEBUG_VERBOSE("Arduino_Portenta_OTA_QSPI::download(%s) returns %d", ota_url, ota_portenta_qspi_download_ret_code);
 
   watchdog_reset();

--- a/src/utility/ota/OTA-portenta-h7.cpp
+++ b/src/utility/ota/OTA-portenta-h7.cpp
@@ -27,9 +27,7 @@
 
 #include <Arduino_DebugUtils.h>
 #include <Arduino_Portenta_OTA.h>
-
-#include <WiFi.h>
-#include <Ethernet.h>
+#include <Arduino_ConnectionHandler.h>
 
 #include "../watchdog/Watchdog.h"
 
@@ -67,7 +65,7 @@ int portenta_h7_onOTARequest(char const * ota_url, const bool use_ethernet)
 
   /* Download the OTA file from the web storage location. */
   MbedSocketClass * download_socket = static_cast<MbedSocketClass*>(&WiFi);
-#if defined (ARDUINO_PORTENTA_H7_M7)
+#if defined (BOARD_HAS_ETHERNET)
   if(use_ethernet) {
     download_socket = static_cast<MbedSocketClass*>(&Ethernet);
   }

--- a/src/utility/ota/OTA-portenta-h7.cpp
+++ b/src/utility/ota/OTA-portenta-h7.cpp
@@ -37,7 +37,7 @@
  * FUNCTION DEFINITION
  ******************************************************************************/
 
-int portenta_h7_onOTARequest(char const * ota_url, bool use_ethernet)
+int portenta_h7_onOTARequest(char const * ota_url, const bool use_ethernet)
 {
   watchdog_reset();
 

--- a/src/utility/ota/OTA.h
+++ b/src/utility/ota/OTA.h
@@ -63,7 +63,7 @@ int rp2040_connect_onOTARequest(char const * ota_url);
 #endif
 
 #ifdef BOARD_STM32H7
-int portenta_h7_onOTARequest(char const * ota_url);
+int portenta_h7_onOTARequest(char const * ota_url, bool use_ethernet);
 #endif
 
 #endif /* ARDUINO_OTA_LOGIC_H_ */

--- a/src/utility/ota/OTA.h
+++ b/src/utility/ota/OTA.h
@@ -63,7 +63,7 @@ int rp2040_connect_onOTARequest(char const * ota_url);
 #endif
 
 #ifdef BOARD_STM32H7
-int portenta_h7_onOTARequest(char const * ota_url, bool use_ethernet);
+int portenta_h7_onOTARequest(char const * ota_url, const bool use_ethernet);
 #endif
 
 #endif /* ARDUINO_OTA_LOGIC_H_ */

--- a/src/utility/watchdog/Watchdog.cpp
+++ b/src/utility/watchdog/Watchdog.cpp
@@ -29,17 +29,16 @@
 
 #ifdef ARDUINO_ARCH_SAMD
 #  include <Adafruit_SleepyDog.h>
-#  include <WiFi.h>
 #  define SAMD_WATCHDOG_MAX_TIME_ms (16 * 1000)
 #endif /* ARDUINO_ARCH_SAMD */
 
 #ifdef ARDUINO_ARCH_MBED
 #  include <watchdog_api.h>
-#  include <WiFi.h>
-#  include <Ethernet.h>
 #  define PORTENTA_H7_WATCHDOG_MAX_TIMEOUT_ms (32760)
 #  define NANO_RP2040_WATCHDOG_MAX_TIMEOUT_ms (8389)
 #endif /* ARDUINO_ARCH_MBED */
+
+#include <Arduino_ConnectionHandler.h>
 
 /******************************************************************************
  * GLOBAL VARIABLES
@@ -127,13 +126,13 @@ static void mbed_watchdog_reset()
 #if defined (ARDUINO_PORTENTA_H7_WIFI_HAS_FEED_WATCHDOG_FUNC)
 static void mbed_watchdog_enable_network_feed(const bool use_ethernet)
 {
+#if defined(BOARD_HAS_ETHERNET)
   if(use_ethernet) {
-#if defined(ARDUINO_PORTENTA_H7_M7)
     Ethernet.setFeedWatchdogFunc(watchdog_reset);
+  } else
 #endif
-  } else {
     WiFi.setFeedWatchdogFunc(watchdog_reset);
-  }
+
 }
 #endif
 

--- a/src/utility/watchdog/Watchdog.cpp
+++ b/src/utility/watchdog/Watchdog.cpp
@@ -65,13 +65,6 @@ static void samd_watchdog_reset()
   }
 }
 
-#if defined (WIFI_HAS_FEED_WATCHDOG_FUNC)
-static void samd_watchdog_enable_network_feed()
-{
-  WiFi.setFeedWatchdogFunc(watchdog_reset);
-}
-#endif
-
 /* This function is called within the WiFiNINA library when invoking
  * the method 'connectBearSSL' in order to prevent a premature bite
  * of the watchdog (max timeout on SAMD is 16 s). wifi_nina_feed...
@@ -177,14 +170,14 @@ void watchdog_reset()
 #endif
 }
 
-#if defined (WIFI_HAS_FEED_WATCHDOG_FUNC) || defined (ARDUINO_PORTENTA_H7_WIFI_HAS_FEED_WATCHDOG_FUNC)
 void watchdog_enable_network_feed(const bool use_ethernet)
 {
-#ifdef ARDUINO_ARCH_SAMD
-  samd_watchdog_enable_network_feed();
-#else
+#ifdef WIFI_HAS_FEED_WATCHDOG_FUNC
+  WiFi.setFeedWatchdogFunc(watchdog_reset);
+#endif
+
+#ifdef ARDUINO_PORTENTA_H7_WIFI_HAS_FEED_WATCHDOG_FUNC
   mbed_watchdog_enable_network_feed(use_ethernet);
 #endif
 }
-#endif
 #endif /* (ARDUINO_ARCH_SAMD) || (ARDUINO_ARCH_MBED) */

--- a/src/utility/watchdog/Watchdog.h
+++ b/src/utility/watchdog/Watchdog.h
@@ -25,6 +25,7 @@
 #if defined (ARDUINO_ARCH_SAMD) || defined (ARDUINO_ARCH_MBED)
 void watchdog_enable();
 void watchdog_reset();
+void watchdog_enable_network_feed(bool use_ethernet);
 #endif /* (ARDUINO_ARCH_SAMD) || (ARDUINO_ARCH_MBED) */
 
 #ifdef ARDUINO_ARCH_MBED

--- a/src/utility/watchdog/Watchdog.h
+++ b/src/utility/watchdog/Watchdog.h
@@ -25,7 +25,7 @@
 #if defined (ARDUINO_ARCH_SAMD) || defined (ARDUINO_ARCH_MBED)
 void watchdog_enable();
 void watchdog_reset();
-void watchdog_enable_network_feed(bool use_ethernet);
+void watchdog_enable_network_feed(const bool use_ethernet);
 #endif /* (ARDUINO_ARCH_SAMD) || (ARDUINO_ARCH_MBED) */
 
 #ifdef ARDUINO_ARCH_MBED


### PR DESCRIPTION
Needs: 
* https://github.com/arduino-libraries/Arduino_ConnectionHandler/pull/81 and 
  https://github.com/arduino/ArduinoCore-mbed/pull/526 for Ethernet connection
* https://github.com/arduino-libraries/Arduino_Portenta_OTA/pull/30 for OTA
