### PR TITLE
Fix Unexpected input warning running unit-tests workflow

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -27,7 +27,8 @@ jobs:
 
       - uses: arduino/cpp-test-action@main
         with:
-          runtime-paths: extras/test/build/bin/testArduinoIoTCloud
+          runtime-paths: |
+            - extras/test/build/bin/testArduinoIoTCloud
           coverage-exclude-paths: |
             - '*/extras/test/*'
             - '/usr/*'

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -27,7 +27,7 @@ jobs:
 
       - uses: arduino/cpp-test-action@main
         with:
-          runtime-path: extras/test/build/bin/testArduinoIoTCloud
+          runtime-paths: extras/test/build/bin/testArduinoIoTCloud
           coverage-exclude-paths: |
             - '*/extras/test/*'
             - '/usr/*'


### PR DESCRIPTION
The runtime-path input is deprecated. We should use runtime-paths instead. See :
* https://github.com/arduino-libraries/ArduinoIoTCloud/runs/8249063541?check_suite_focus=true