### PR TITLE
ESP TimeService: remove delays introduced by NTP requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,5 @@ OTA is supported by the following boards:
 Support for ESP boards is obtained through a third-party core with some differences and limitations compared to Arduino boards.
 
 - **Authentication scheme**: Board authentication is done through `DEVICE_LOGIN_NAME` and `DEVICE_KEY`, both values are included in the `thingProperties.h` file.
-- **RTC**: RTC support is not included thus each `ArduinoCould.update()` call will lead to an NTP request introducing delay in your `loop()` function. The scheduler widget will not work correctly if connection is lost after configuration.
 - **Watchdog**: Watchdog support is not included.
 - **OTA**: OTA support is not included

--- a/src/property/Property.cpp
+++ b/src/property/Property.cpp
@@ -21,10 +21,6 @@
 #undef min
 #include <algorithm>
 
-#if !defined ARDUINO_ARCH_SAMD && !defined ARDUINO_ARCH_MBED
-  #pragma message "No RTC available on this architecture - ArduinoIoTCloud will not keep track of local change timestamps ."
-#endif
-
 /******************************************************************************
    CTOR/DTOR
  ******************************************************************************/

--- a/src/utility/time/TimeService.cpp
+++ b/src/utility/time/TimeService.cpp
@@ -52,9 +52,7 @@ static time_t const EPOCH = 0;
 
 TimeService::TimeService()
 : _con_hdl(nullptr)
-#if defined (ARDUINO_ARCH_SAMD) || defined (ARDUINO_ARCH_MBED)
 , _is_rtc_configured(false)
-#endif
 , _is_tz_configured(false)
 , _timezone_offset(0)
 , _timezone_dst_until(0)
@@ -98,6 +96,13 @@ unsigned long TimeService::getTime()
       _is_rtc_configured = true;
     }
     return utc;
+  }
+  return time(NULL);
+#elif ARDUINO_ARCH_ESP32 || ARDUINO_ARCH_ESP8266
+  if(!_is_rtc_configured)
+  {
+    configTime(0, 0, "time.arduino.cc", "pool.ntp.org", "time.nist.gov");
+    _is_rtc_configured = true;
   }
   return time(NULL);
 #else

--- a/src/utility/time/TimeService.h
+++ b/src/utility/time/TimeService.h
@@ -60,6 +60,10 @@ private:
   bool _is_tz_configured;
   long _timezone_offset;
   unsigned long _timezone_dst_until;
+#ifdef ARDUINO_ARCH_ESP8266
+  unsigned long _soft_rtc_value;
+  unsigned long _soft_rtc_offset;
+#endif
 
   unsigned long getRemoteTime();
   bool connected();

--- a/src/utility/time/TimeService.h
+++ b/src/utility/time/TimeService.h
@@ -56,9 +56,7 @@ public:
 private:
 
   ConnectionHandler * _con_hdl;
-#if defined (ARDUINO_ARCH_SAMD) || defined (ARDUINO_ARCH_MBED)
   bool _is_rtc_configured;
-#endif
   bool _is_tz_configured;
   long _timezone_offset;
   unsigned long _timezone_dst_until;

--- a/src/utility/time/TimeService.h
+++ b/src/utility/time/TimeService.h
@@ -61,8 +61,9 @@ private:
   long _timezone_offset;
   unsigned long _timezone_dst_until;
 #ifdef ARDUINO_ARCH_ESP8266
-  unsigned long _soft_rtc_value;
-  unsigned long _soft_rtc_offset;
+  unsigned long _last_ntp_sync_tick;
+  unsigned long _last_rtc_update_tick;
+  unsigned long _rtc;
 #endif
 
   unsigned long getRemoteTime();


### PR DESCRIPTION
Using ESP boards each `ArduinoCloud.update()` call is firing an NTP request introducing potentially long delays in the `loop()`.
 * ESP32 boards have an internal RTC that can be configured and readed using core API.
 * ESP8266 do not have an internal RTC so the value is synced once a day with the NTP server and updated using `millis()`.
 
 Fixes #319