### PR TITLE
Ethernet: examples and readme update

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ The `ArduinoIoTCloud` library is the central element of the firmware enabling ce
 * **GSM**: [`MKR GSM 1400`](https://store.arduino.cc/arduino-mkr-gsm-1400-1415)
 * **5G**: [`MKR NB 1500`](https://store.arduino.cc/arduino-mkr-nb-1500-1413)
 * **LoRa**: [`MKR WAN 1300/1310`](https://store.arduino.cc/mkr-wan-1310)
+* **Ethernet**: [`Portenta H7`](https://store.arduino.cc/products/portenta-h7) + [`Vision Shield Ethernet`](https://store.arduino.cc/products/arduino-portenta-vision-shield-ethernet), [`Max Carrier`](https://store.arduino.cc/products/portenta-max-carrier), [`Breakout`](https://store.arduino.cc/products/arduino-portenta-breakout), [`Portenta Machine Control`](https://store.arduino.cc/products/arduino-portenta-machine-control)
 
 ### How?
 1) Register your Arduino IoT Cloud capable board via [Arduino IoT Cloud](https://create.arduino.cc/iot) (Devices Section).

--- a/examples/ArduinoIoTCloud-Advanced/ArduinoIoTCloud-Advanced.ino
+++ b/examples/ArduinoIoTCloud-Advanced/ArduinoIoTCloud-Advanced.ino
@@ -1,7 +1,12 @@
 /*
   This sketch demonstrates how to use more complex cloud data types such as a colour or coordinates.
 
-  This sketch is compatible with:
+  IMPORTANT:
+  This sketch works with WiFi, GSM, NB, Ethernet and Lora enabled boards supported by Arduino IoT Cloud.
+  On a LoRa board, if it is configured as a class A device (default and preferred option), values from Cloud dashboard are received
+  only after a value is sent to Cloud.
+
+  The full list of compatible boards can be found here:
    - https://github.com/arduino-libraries/ArduinoIoTCloud#what
 */
 

--- a/examples/ArduinoIoTCloud-Advanced/arduino_secrets.h
+++ b/examples/ArduinoIoTCloud-Advanced/arduino_secrets.h
@@ -35,3 +35,11 @@
   #define SECRET_LOGIN ""
   #define SECRET_PASS ""
 #endif
+
+/* Portenta H7 + Ethernet shield */
+#if defined(BOARD_HAS_ETHERNET)
+  #define SECRET_OPTIONAL_IP ""
+  #define SECRET_OPTIONAL_DNS ""
+  #define SECRET_OPTIONAL_GATEWAY ""
+  #define SECRET_OPTIONAL_NETMASK ""
+#endif

--- a/examples/ArduinoIoTCloud-Advanced/thingProperties.h
+++ b/examples/ArduinoIoTCloud-Advanced/thingProperties.h
@@ -2,6 +2,7 @@
 #elif defined(BOARD_HAS_GSM)
 #elif defined(BOARD_HAS_LORA)
 #elif defined(BOARD_HAS_NB)
+#elif defined(BOARD_HAS_ETHERNET)
 #else
   #error "Please check Arduino IoT Cloud supported boards list: https://github.com/arduino-libraries/ArduinoIoTCloud/#what"
 #endif
@@ -41,4 +42,9 @@ void initProperties() {
   LoRaConnectionHandler ArduinoIoTPreferredConnection(SECRET_APP_EUI, SECRET_APP_KEY, _lora_band::EU868, NULL, _lora_class::CLASS_A);
 #elif defined(BOARD_HAS_NB)
   NBConnectionHandler ArduinoIoTPreferredConnection(SECRET_PIN, SECRET_APN, SECRET_LOGIN, SECRET_PASS);
+#elif defined(BOARD_HAS_ETHERNET)
+  /* DHCP mode */
+  //EthernetConnectionHandler ArduinoIoTPreferredConnection;
+  /* Manual mode. It will fallback in DHCP mode if SECRET_OPTIONAL_IP is invalid or equal to "0.0.0.0" */
+  EthernetConnectionHandler ArduinoIoTPreferredConnection(SECRET_OPTIONAL_IP, SECRET_OPTIONAL_DNS, SECRET_OPTIONAL_GATEWAY, SECRET_OPTIONAL_NETMASK);
 #endif

--- a/examples/ArduinoIoTCloud-Basic/ArduinoIoTCloud-Basic.ino
+++ b/examples/ArduinoIoTCloud-Basic/ArduinoIoTCloud-Basic.ino
@@ -6,11 +6,11 @@
   * When you flip the switch in the Cloud dashboard the onboard LED lights gets turned ON or OFF.
 
   IMPORTANT:
-  This sketch works with WiFi, GSM, NB and Lora enabled boards supported by Arduino IoT Cloud.
+  This sketch works with WiFi, GSM, NB, Ethernet and Lora enabled boards supported by Arduino IoT Cloud.
   On a LoRa board, if it is configured as a class A device (default and preferred option), values from Cloud dashboard are received
   only after a value is sent to Cloud.
 
-  This sketch is compatible with:
+  The full list of compatible boards can be found here:
    - https://github.com/arduino-libraries/ArduinoIoTCloud#what
 */
 

--- a/examples/ArduinoIoTCloud-Basic/ArduinoIoTCloud-Basic.ino
+++ b/examples/ArduinoIoTCloud-Basic/ArduinoIoTCloud-Basic.ino
@@ -17,7 +17,7 @@
 #include "arduino_secrets.h"
 #include "thingProperties.h"
 
-#if defined(ESP32)
+#if !defined(LED_BUILTIN)
 static int const LED_BUILTIN = 2;
 #endif
 

--- a/examples/ArduinoIoTCloud-Basic/arduino_secrets.h
+++ b/examples/ArduinoIoTCloud-Basic/arduino_secrets.h
@@ -9,7 +9,7 @@
   #define SECRET_PASS "YOUR_WIFI_PASSWORD"
 #endif
 
-/* ESP8266 */
+/* ESP8266 ESP32*/
 #if defined(BOARD_ESP)
   #define SECRET_DEVICE_KEY "my-device-password"
 #endif
@@ -34,4 +34,12 @@
   #define SECRET_APN ""
   #define SECRET_LOGIN ""
   #define SECRET_PASS ""
+#endif
+
+/* Portenta H7 + Ethernet shield */
+#if defined(BOARD_HAS_ETHERNET)
+  #define SECRET_OPTIONAL_IP ""
+  #define SECRET_OPTIONAL_DNS ""
+  #define SECRET_OPTIONAL_GATEWAY ""
+  #define SECRET_OPTIONAL_NETMASK ""
 #endif

--- a/examples/ArduinoIoTCloud-Basic/thingProperties.h
+++ b/examples/ArduinoIoTCloud-Basic/thingProperties.h
@@ -2,6 +2,7 @@
 #elif defined(BOARD_HAS_GSM)
 #elif defined(BOARD_HAS_LORA)
 #elif defined(BOARD_HAS_NB)
+#elif defined(BOARD_HAS_ETHERNET)
 #else
   #error "Please check Arduino IoT Cloud supported boards list: https://github.com/arduino-libraries/ArduinoIoTCloud/#what"
 #endif
@@ -21,7 +22,7 @@ void initProperties() {
   ArduinoCloud.setBoardId(BOARD_ID);
   ArduinoCloud.setSecretDeviceKey(SECRET_DEVICE_KEY);
 #endif
-#if defined(BOARD_HAS_WIFI) || defined(BOARD_HAS_GSM) || defined(BOARD_HAS_NB)
+#if defined(BOARD_HAS_WIFI) || defined(BOARD_HAS_GSM) || defined(BOARD_HAS_NB) || defined(BOARD_HAS_ETHERNET)
   ArduinoCloud.addProperty(led, Permission::Write).onUpdate(onLedChange);
   ArduinoCloud.addProperty(potentiometer, Permission::Read).publishOnChange(10);
   ArduinoCloud.addProperty(seconds, Permission::Read).publishOnChange(1);
@@ -32,7 +33,12 @@ void initProperties() {
 #endif
 }
 
-#if defined(BOARD_HAS_WIFI)
+#if defined(BOARD_HAS_ETHERNET)
+  /* DHCP mode */
+  //EthernetConnectionHandler ArduinoIoTPreferredConnection;
+  /* Manual mode. It will fallback in DHCP mode if SECRET_OPTIONAL_IP is invalid or equal to "0.0.0.0" */
+  EthernetConnectionHandler ArduinoIoTPreferredConnection(SECRET_OPTIONAL_IP, SECRET_OPTIONAL_DNS, SECRET_OPTIONAL_GATEWAY, SECRET_OPTIONAL_NETMASK);
+#elif defined(BOARD_HAS_WIFI)
   WiFiConnectionHandler ArduinoIoTPreferredConnection(SECRET_SSID, SECRET_PASS);
 #elif defined(BOARD_HAS_GSM)
   GSMConnectionHandler ArduinoIoTPreferredConnection(SECRET_PIN, SECRET_APN, SECRET_LOGIN, SECRET_PASS);

--- a/examples/ArduinoIoTCloud-Callbacks/ArduinoIoTCloud-Callbacks.ino
+++ b/examples/ArduinoIoTCloud-Callbacks/ArduinoIoTCloud-Callbacks.ino
@@ -18,11 +18,11 @@
   One function per event can be assigned.
 
   IMPORTANT:
-  This sketch works with WiFi, GSM, NB and Lora enabled boards supported by Arduino IoT Cloud.
+  This sketch works with WiFi, GSM, NB, Ethernet and Lora enabled boards supported by Arduino IoT Cloud.
   On a LoRa board, if it is configured as a class A device (default and preferred option), values from Cloud dashboard are received
   only after a value is sent to Cloud.
 
-  This sketch is compatible with:
+  The full list of compatible boards can be found here:
    - https://github.com/arduino-libraries/ArduinoIoTCloud#what
 */
 

--- a/examples/ArduinoIoTCloud-Callbacks/arduino_secrets.h
+++ b/examples/ArduinoIoTCloud-Callbacks/arduino_secrets.h
@@ -35,3 +35,11 @@
   #define SECRET_LOGIN ""
   #define SECRET_PASS ""
 #endif
+
+/* Portenta H7 + Ethernet shield */
+#if defined(BOARD_HAS_ETHERNET)
+  #define SECRET_OPTIONAL_IP ""
+  #define SECRET_OPTIONAL_DNS ""
+  #define SECRET_OPTIONAL_GATEWAY ""
+  #define SECRET_OPTIONAL_NETMASK ""
+#endif

--- a/examples/ArduinoIoTCloud-Callbacks/thingProperties.h
+++ b/examples/ArduinoIoTCloud-Callbacks/thingProperties.h
@@ -2,6 +2,7 @@
 #elif defined(BOARD_HAS_GSM)
 #elif defined(BOARD_HAS_LORA)
 #elif defined(BOARD_HAS_NB)
+#elif defined(BOARD_HAS_ETHERNET)
 #else
   #error "Please check Arduino IoT Cloud supported boards list: https://github.com/arduino-libraries/ArduinoIoTCloud/#what"
 #endif
@@ -25,4 +26,9 @@ void initProperties() {
   LoRaConnectionHandler ArduinoIoTPreferredConnection(SECRET_APP_EUI, SECRET_APP_KEY, _lora_band::EU868, NULL, _lora_class::CLASS_A);
 #elif defined(BOARD_HAS_NB)
   NBConnectionHandler ArduinoIoTPreferredConnection(SECRET_PIN, SECRET_APN, SECRET_LOGIN, SECRET_PASS);
+#elif defined(BOARD_HAS_ETHERNET)
+  /* DHCP mode */
+  //EthernetConnectionHandler ArduinoIoTPreferredConnection;
+  /* Manual mode. It will fallback in DHCP mode if SECRET_OPTIONAL_IP is invalid or equal to "0.0.0.0" */
+  EthernetConnectionHandler ArduinoIoTPreferredConnection(SECRET_OPTIONAL_IP, SECRET_OPTIONAL_DNS, SECRET_OPTIONAL_GATEWAY, SECRET_OPTIONAL_NETMASK);
 #endif

--- a/examples/ArduinoIoTCloud-DeferredOTA/ArduinoIoTCloud-DeferredOTA.ino
+++ b/examples/ArduinoIoTCloud-DeferredOTA/ArduinoIoTCloud-DeferredOTA.ino
@@ -9,7 +9,10 @@
   * always_allow callback will immediately apply the OTA update
   * ask_user_via_serial callback will read user input from serial to apply or postpone OTA update
 
-  This sketch is compatible with:
+  IMPORTANT:
+  This sketch works with WiFi and Ethernet enabled boards supported by Arduino IoT Cloud.
+
+  The full list of compatible boards can be found here:
    - https://github.com/arduino-libraries/ArduinoIoTCloud/#ota
 */
 

--- a/examples/ArduinoIoTCloud-DeferredOTA/arduino_secrets.h
+++ b/examples/ArduinoIoTCloud-DeferredOTA/arduino_secrets.h
@@ -35,3 +35,11 @@
   #define SECRET_LOGIN ""
   #define SECRET_PASS ""
 #endif
+
+/* Portenta H7 + Ethernet shield */
+#if defined(BOARD_HAS_ETHERNET)
+  #define SECRET_OPTIONAL_IP ""
+  #define SECRET_OPTIONAL_DNS ""
+  #define SECRET_OPTIONAL_GATEWAY ""
+  #define SECRET_OPTIONAL_NETMASK ""
+#endif

--- a/examples/ArduinoIoTCloud-DeferredOTA/thingProperties.h
+++ b/examples/ArduinoIoTCloud-DeferredOTA/thingProperties.h
@@ -2,6 +2,7 @@
 #elif defined(BOARD_HAS_GSM)
 #elif defined(BOARD_HAS_LORA)
 #elif defined(BOARD_HAS_NB)
+#elif defined(BOARD_HAS_ETHERNET)
 #else
   #error "Please check Arduino IoT Cloud supported boards list: https://github.com/arduino-libraries/ArduinoIoTCloud/#what"
 #endif
@@ -19,7 +20,7 @@ void initProperties() {
   ArduinoCloud.setBoardId(BOARD_ID);
   ArduinoCloud.setSecretDeviceKey(SECRET_DEVICE_KEY);
 #endif
-#if defined(BOARD_HAS_WIFI) || defined(BOARD_HAS_GSM) || defined(BOARD_HAS_NB)
+#if defined(BOARD_HAS_WIFI) || defined(BOARD_HAS_GSM) || defined(BOARD_HAS_NB) || defined(BOARD_HAS_ETHERNET)
   ArduinoCloud.addProperty(led, Permission::Write).onUpdate(onLedChange);
 #elif defined(BOARD_HAS_LORA)
   ArduinoCloud.addProperty(led, 1, READWRITE, ON_CHANGE, onLedChange);
@@ -34,4 +35,9 @@ void initProperties() {
   LoRaConnectionHandler ArduinoIoTPreferredConnection(SECRET_APP_EUI, SECRET_APP_KEY, _lora_band::EU868, NULL, _lora_class::CLASS_A);
 #elif defined(BOARD_HAS_NB)
   NBConnectionHandler ArduinoIoTPreferredConnection(SECRET_PIN, SECRET_APN, SECRET_LOGIN, SECRET_PASS);
+#elif defined(BOARD_HAS_ETHERNET)
+  /* DHCP mode */
+  //EthernetConnectionHandler ArduinoIoTPreferredConnection;
+  /* Manual mode. It will fallback in DHCP mode if SECRET_OPTIONAL_IP is invalid or equal to "0.0.0.0" */
+  EthernetConnectionHandler ArduinoIoTPreferredConnection(SECRET_OPTIONAL_IP, SECRET_OPTIONAL_DNS, SECRET_OPTIONAL_GATEWAY, SECRET_OPTIONAL_NETMASK);
 #endif

--- a/examples/ArduinoIoTCloud-Schedule/ArduinoIoTCloud-Schedule.ino
+++ b/examples/ArduinoIoTCloud-Schedule/ArduinoIoTCloud-Schedule.ino
@@ -1,8 +1,9 @@
 /*
   This sketch demonstrates how to use the cloud schedule variable type.
 
-  This sketch is compatible with the following boards:
-   - https://github.com/arduino-libraries/ArduinoIoTCloud#what
+  IMPORTANT:
+  This sketch works with WiFi, GSM, NB and Ethernet enabled boards supported by Arduino IoT Cloud.
+
 */
 
 #include "arduino_secrets.h"

--- a/examples/ArduinoIoTCloud-Schedule/arduino_secrets.h
+++ b/examples/ArduinoIoTCloud-Schedule/arduino_secrets.h
@@ -35,3 +35,11 @@
   #define SECRET_LOGIN ""
   #define SECRET_PASS ""
 #endif
+
+/* Portenta H7 + Ethernet shield */
+#if defined(BOARD_HAS_ETHERNET)
+  #define SECRET_OPTIONAL_IP ""
+  #define SECRET_OPTIONAL_DNS ""
+  #define SECRET_OPTIONAL_GATEWAY ""
+  #define SECRET_OPTIONAL_NETMASK ""
+#endif

--- a/examples/ArduinoIoTCloud-Schedule/thingProperties.h
+++ b/examples/ArduinoIoTCloud-Schedule/thingProperties.h
@@ -2,6 +2,7 @@
 #elif defined(BOARD_HAS_GSM)
 #elif defined(BOARD_HAS_LORA)
 #elif defined(BOARD_HAS_NB)
+#elif defined(BOARD_HAS_ETHERNET)
 #else
   #error "Please check Arduino IoT Cloud supported boards list: https://github.com/arduino-libraries/ArduinoIoTCloud/#what"
 #endif
@@ -26,7 +27,7 @@ void initProperties() {
   ArduinoCloud.setBoardId(BOARD_ID);
   ArduinoCloud.setSecretDeviceKey(SECRET_DEVICE_KEY);
 #endif
-#if defined(BOARD_HAS_WIFI) || defined(BOARD_HAS_GSM) || defined(BOARD_HAS_NB)
+#if defined(BOARD_HAS_WIFI) || defined(BOARD_HAS_GSM) || defined(BOARD_HAS_NB)  || defined(BOARD_HAS_ETHERNET)
   ArduinoCloud.addProperty(switchButton, WRITE, ON_CHANGE);
   ArduinoCloud.addProperty(oneShot, READWRITE, ON_CHANGE);
   ArduinoCloud.addProperty(minute, READWRITE, ON_CHANGE);
@@ -48,4 +49,9 @@ void initProperties() {
   LoRaConnectionHandler ArduinoIoTPreferredConnection(SECRET_APP_EUI, SECRET_APP_KEY, _lora_band::EU868, NULL, _lora_class::CLASS_A);
 #elif defined(BOARD_HAS_NB)
   NBConnectionHandler ArduinoIoTPreferredConnection(SECRET_PIN, SECRET_APN, SECRET_LOGIN, SECRET_PASS);
+#elif defined(BOARD_HAS_ETHERNET)
+  /* DHCP mode */
+  //EthernetConnectionHandler ArduinoIoTPreferredConnection;
+  /* Manual mode. It will fallback in DHCP mode if SECRET_OPTIONAL_IP is invalid or equal to "0.0.0.0" */
+  EthernetConnectionHandler ArduinoIoTPreferredConnection(SECRET_OPTIONAL_IP, SECRET_OPTIONAL_DNS, SECRET_OPTIONAL_GATEWAY, SECRET_OPTIONAL_NETMASK);
 #endif

--- a/examples/utility/ArduinoIoTCloud_Travis_CI/ArduinoIoTCloud_Travis_CI.ino
+++ b/examples/utility/ArduinoIoTCloud_Travis_CI/ArduinoIoTCloud_Travis_CI.ino
@@ -3,8 +3,13 @@
    unintentional breaking changes are made to the user facing
    Arduino IoT Cloud API.
 
-   This sketch is compatible with:
-     - https://github.com/arduino-libraries/ArduinoIoTCloud#what
+  IMPORTANT:
+  This sketch works with WiFi, GSM, NB, Ethernet and Lora enabled boards supported by Arduino IoT Cloud.
+  On a LoRa board, if it is configured as a class A device (default and preferred option), values from Cloud dashboard are received
+  only after a value is sent to Cloud.
+
+  The full list of compatible boards can be found here:
+   - https://github.com/arduino-libraries/ArduinoIoTCloud#what
 */
 
 #include "arduino_secrets.h"

--- a/examples/utility/ArduinoIoTCloud_Travis_CI/arduino_secrets.h
+++ b/examples/utility/ArduinoIoTCloud_Travis_CI/arduino_secrets.h
@@ -35,3 +35,11 @@
   #define SECRET_LOGIN ""
   #define SECRET_PASS ""
 #endif
+
+/* Portenta H7 + Ethernet shield */
+#if defined(BOARD_HAS_ETHERNET)
+  #define SECRET_OPTIONAL_IP ""
+  #define SECRET_OPTIONAL_DNS ""
+  #define SECRET_OPTIONAL_GATEWAY ""
+  #define SECRET_OPTIONAL_NETMASK ""
+#endif

--- a/examples/utility/ArduinoIoTCloud_Travis_CI/thingProperties.h
+++ b/examples/utility/ArduinoIoTCloud_Travis_CI/thingProperties.h
@@ -2,6 +2,7 @@
 #elif defined(BOARD_HAS_GSM)
 #elif defined(BOARD_HAS_LORA)
 #elif defined(BOARD_HAS_NB)
+#elif defined(BOARD_HAS_ETHERNET)
 #else
   #error "Please check Arduino IoT Cloud supported boards list: https://github.com/arduino-libraries/ArduinoIoTCloud/#what"
 #endif
@@ -57,6 +58,11 @@ String str_property_8;
   LoRaConnectionHandler ArduinoIoTPreferredConnection(SECRET_APP_EUI, SECRET_APP_KEY, EU868);
 #elif defined(BOARD_HAS_NB)
   NBConnectionHandler ArduinoIoTPreferredConnection(SECRET_PIN, SECRET_APN, SECRET_LOGIN, SECRET_PASS);
+#elif defined(BOARD_HAS_ETHERNET)
+  /* DHCP mode */
+  //EthernetConnectionHandler ArduinoIoTPreferredConnection;
+  /* Manual mode. It will fallback in DHCP mode if SECRET_OPTIONAL_IP is invalid or equal to "0.0.0.0" */
+  EthernetConnectionHandler ArduinoIoTPreferredConnection(SECRET_OPTIONAL_IP, SECRET_OPTIONAL_DNS, SECRET_OPTIONAL_GATEWAY, SECRET_OPTIONAL_NETMASK);
 #endif
 
 /******************************************************************************


### PR DESCRIPTION
Add EthernetConnectionHandler in library examples and the list of ethernet enabled boards in the readme.

Bonus: 
https://github.com/arduino-libraries/ArduinoIoTCloud/commit/0802445d458a84cebdb9ac306beae4cd0395544a Make Basic example build for all ESP32 boards

https://github.com/arduino-libraries/ArduinoIoTCloud/commit/7c4eb0938a463446974629938c3efc52bdfde5b9 Align header format of library examples