### PR TITLE
Reorder and simplify addPropertyReal methods 

### DIFF
--- a/src/ArduinoIoTCloud.cpp
+++ b/src/ArduinoIoTCloud.cpp
@@ -205,32 +205,6 @@ __attribute__((weak)) void setDebugMessageLevel(int const /* level */)
   /* do nothing */
 }
 
-/* The following methods are used internally to handle hidden thing and device properties */
-Property& ArduinoIoTCloudClass::addPropertyReal(bool& property, PropertyContainer &prop_cont, String name, Permission const permission)
-{
-  return addPropertyReal(property, prop_cont, name, -1, permission);
-}
-Property& ArduinoIoTCloudClass::addPropertyReal(float& property, PropertyContainer &prop_cont, String name, Permission const permission)
-{
-  return addPropertyReal(property, prop_cont, name, -1, permission);
-}
-Property& ArduinoIoTCloudClass::addPropertyReal(int& property, PropertyContainer &prop_cont, String name, Permission const permission)
-{
-  return addPropertyReal(property, prop_cont, name, -1, permission);
-}
-Property& ArduinoIoTCloudClass::addPropertyReal(unsigned int& property, PropertyContainer &prop_cont, String name, Permission const permission)
-{
-  return addPropertyReal(property, prop_cont, name, -1, permission);
-}
-Property& ArduinoIoTCloudClass::addPropertyReal(String& property, PropertyContainer &prop_cont, String name, Permission const permission)
-{
-  return addPropertyReal(property, prop_cont, name, -1, permission);
-}
-Property& ArduinoIoTCloudClass::addPropertyReal(Property& property, PropertyContainer &prop_cont, String name, Permission const permission)
-{
-  return addPropertyReal(property, prop_cont, name, -1, permission);
-}
-
 /******************************************************************************
  * PRIVATE MEMBER FUNCTIONS
  ******************************************************************************/

--- a/src/ArduinoIoTCloud.cpp
+++ b/src/ArduinoIoTCloud.cpp
@@ -69,53 +69,58 @@ void ArduinoIoTCloudClass::addCallback(ArduinoIoTCloudEvent const event, OnCloud
 /* The following methods are used for non-LoRa boards */
 Property& ArduinoIoTCloudClass::addPropertyReal(bool& property, String name, Permission const permission)
 {
-  return addPropertyReal(property, _thing_property_container, name, -1, permission);
+  return addPropertyReal(property, name, -1, permission);
 }
 Property& ArduinoIoTCloudClass::addPropertyReal(float& property, String name, Permission const permission)
 {
-  return addPropertyReal(property, _thing_property_container, name, -1, permission);
+  return addPropertyReal(property, name, -1, permission);
 }
 Property& ArduinoIoTCloudClass::addPropertyReal(int& property, String name, Permission const permission)
 {
-  return addPropertyReal(property, _thing_property_container, name, -1, permission);
+  return addPropertyReal(property, name, -1, permission);
 }
 Property& ArduinoIoTCloudClass::addPropertyReal(unsigned int& property, String name, Permission const permission)
 {
-  return addPropertyReal(property, _thing_property_container, name, -1, permission);
+  return addPropertyReal(property, name, -1, permission);
 }
 Property& ArduinoIoTCloudClass::addPropertyReal(String& property, String name, Permission const permission)
 {
-  return addPropertyReal(property, _thing_property_container, name, -1, permission);
+  return addPropertyReal(property, name, -1, permission);
 }
 Property& ArduinoIoTCloudClass::addPropertyReal(Property& property, String name, Permission const permission)
 {
-  return addPropertyReal(property, _thing_property_container, name, -1, permission);
+  return addPropertyReal(property, name, -1, permission);
 }
 
-/* The following methods are used for LoRa boards */
+/* The following methods are used for both LoRa and non-Lora boards */
 Property& ArduinoIoTCloudClass::addPropertyReal(bool& property, String name, int tag, Permission const permission)
 {
-  return addPropertyReal(property, _thing_property_container, name, tag, permission);
+  Property* p = new CloudWrapperBool(property);
+  return addPropertyReal(*p, name, tag, permission);
 }
 Property& ArduinoIoTCloudClass::addPropertyReal(float& property, String name, int tag, Permission const permission)
 {
-  return addPropertyReal(property, _thing_property_container, name, tag, permission);
+  Property* p = new CloudWrapperFloat(property);
+  return addPropertyReal(*p, name, tag, permission);
 }
 Property& ArduinoIoTCloudClass::addPropertyReal(int& property, String name, int tag, Permission const permission)
 {
-  return addPropertyReal(property, _thing_property_container, name, tag, permission);
+  Property* p = new CloudWrapperInt(property);
+  return addPropertyReal(*p, name, tag, permission);
 }
 Property& ArduinoIoTCloudClass::addPropertyReal(unsigned int& property, String name, int tag, Permission const permission)
 {
-  return addPropertyReal(property, _thing_property_container, name, tag, permission);
+  Property* p = new CloudWrapperUnsignedInt(property);
+  return addPropertyReal(*p, name, tag, permission);
 }
 Property& ArduinoIoTCloudClass::addPropertyReal(String& property, String name, int tag, Permission const permission)
 {
-  return addPropertyReal(property, _thing_property_container, name, tag, permission);
+  Property* p = new CloudWrapperString(property);
+  return addPropertyReal(*p, name, tag, permission);
 }
 Property& ArduinoIoTCloudClass::addPropertyReal(Property& property, String name, int tag, Permission const permission)
 {
-  return addPropertyReal(property, _thing_property_container, name, tag, permission);
+  return addPropertyToContainer(_thing_property_container, property, name, permission, tag);
 }
 
 /* The following methods are deprecated but still used for non-LoRa boards */
@@ -205,37 +210,3 @@ __attribute__((weak)) void setDebugMessageLevel(int const /* level */)
   /* do nothing */
 }
 
-/******************************************************************************
- * PRIVATE MEMBER FUNCTIONS
- ******************************************************************************/
-
-/* The following methods are used for both LoRa and non-LoRa boards */
-Property& ArduinoIoTCloudClass::addPropertyReal(bool& property, PropertyContainer &prop_cont, String name, int tag, Permission const permission)
-{
-  Property* p = new CloudWrapperBool(property);
-  return addPropertyReal(*p, prop_cont, name, tag, permission);
-}
-Property& ArduinoIoTCloudClass::addPropertyReal(float& property, PropertyContainer &prop_cont, String name, int tag, Permission const permission)
-{
-  Property* p = new CloudWrapperFloat(property);
-  return addPropertyReal(*p, prop_cont, name, tag, permission);
-}
-Property& ArduinoIoTCloudClass::addPropertyReal(int& property, PropertyContainer &prop_cont, String name, int tag, Permission const permission)
-{
-  Property* p = new CloudWrapperInt(property);
-  return addPropertyReal(*p, prop_cont, name, tag, permission);
-}
-Property& ArduinoIoTCloudClass::addPropertyReal(unsigned int& property, PropertyContainer &prop_cont, String name, int tag, Permission const permission)
-{
-  Property* p = new CloudWrapperUnsignedInt(property);
-  return addPropertyReal(*p, prop_cont, name, tag, permission);
-}
-Property& ArduinoIoTCloudClass::addPropertyReal(String& property, PropertyContainer &prop_cont, String name, int tag, Permission const permission)
-{
-  Property* p = new CloudWrapperString(property);
-  return addPropertyReal(*p, prop_cont, name, tag, permission);
-}
-Property& ArduinoIoTCloudClass::addPropertyReal(Property& property, PropertyContainer &prop_cont, String name, int tag, Permission const permission)
-{
-  return addPropertyToContainer(prop_cont, property, name, permission, tag);
-}

--- a/src/ArduinoIoTCloud.cpp
+++ b/src/ArduinoIoTCloud.cpp
@@ -66,11 +66,110 @@ void ArduinoIoTCloudClass::addCallback(ArduinoIoTCloudEvent const event, OnCloud
   _cloud_event_callback[static_cast<size_t>(event)] = callback;
 }
 
+/* The following methods are used for non-LoRa boards */
+Property& ArduinoIoTCloudClass::addPropertyReal(bool& property, String name, Permission const permission)
+{
+  return addPropertyReal(property, _thing_property_container, name, -1, permission);
+}
+Property& ArduinoIoTCloudClass::addPropertyReal(float& property, String name, Permission const permission)
+{
+  return addPropertyReal(property, _thing_property_container, name, -1, permission);
+}
+Property& ArduinoIoTCloudClass::addPropertyReal(int& property, String name, Permission const permission)
+{
+  return addPropertyReal(property, _thing_property_container, name, -1, permission);
+}
+Property& ArduinoIoTCloudClass::addPropertyReal(unsigned int& property, String name, Permission const permission)
+{
+  return addPropertyReal(property, _thing_property_container, name, -1, permission);
+}
+Property& ArduinoIoTCloudClass::addPropertyReal(String& property, String name, Permission const permission)
+{
+  return addPropertyReal(property, _thing_property_container, name, -1, permission);
+}
+Property& ArduinoIoTCloudClass::addPropertyReal(Property& property, String name, Permission const permission)
+{
+  return addPropertyReal(property, _thing_property_container, name, -1, permission);
+}
+
+/* The following methods are used for LoRa boards */
+Property& ArduinoIoTCloudClass::addPropertyReal(bool& property, String name, int tag, Permission const permission)
+{
+  return addPropertyReal(property, _thing_property_container, name, tag, permission);
+}
+Property& ArduinoIoTCloudClass::addPropertyReal(float& property, String name, int tag, Permission const permission)
+{
+  return addPropertyReal(property, _thing_property_container, name, tag, permission);
+}
+Property& ArduinoIoTCloudClass::addPropertyReal(int& property, String name, int tag, Permission const permission)
+{
+  return addPropertyReal(property, _thing_property_container, name, tag, permission);
+}
+Property& ArduinoIoTCloudClass::addPropertyReal(unsigned int& property, String name, int tag, Permission const permission)
+{
+  return addPropertyReal(property, _thing_property_container, name, tag, permission);
+}
+Property& ArduinoIoTCloudClass::addPropertyReal(String& property, String name, int tag, Permission const permission)
+{
+  return addPropertyReal(property, _thing_property_container, name, tag, permission);
+}
+Property& ArduinoIoTCloudClass::addPropertyReal(Property& property, String name, int tag, Permission const permission)
+{
+  return addPropertyReal(property, _thing_property_container, name, tag, permission);
+}
+
+/* The following methods are deprecated but still used for non-LoRa boards */
+void ArduinoIoTCloudClass::addPropertyReal(bool& property, String name, permissionType permission_type, long seconds, void(*fn)(void), float minDelta, void(*synFn)(Property & property))
+{
+  addPropertyReal(property, name, -1, permission_type, seconds, fn, minDelta, synFn);
+}
+void ArduinoIoTCloudClass::addPropertyReal(float& property, String name, permissionType permission_type, long seconds, void(*fn)(void), float minDelta, void(*synFn)(Property & property))
+{
+  addPropertyReal(property, name, -1, permission_type, seconds, fn, minDelta, synFn);
+}
+void ArduinoIoTCloudClass::addPropertyReal(int& property, String name, permissionType permission_type, long seconds, void(*fn)(void), float minDelta, void(*synFn)(Property & property))
+{
+  addPropertyReal(property, name, -1, permission_type, seconds, fn, minDelta, synFn);
+}
+void ArduinoIoTCloudClass::addPropertyReal(unsigned int& property, String name, permissionType permission_type, long seconds, void(*fn)(void), float minDelta, void(*synFn)(Property & property))
+{
+  addPropertyReal(property, name, -1, permission_type, seconds, fn, minDelta, synFn);
+}
+void ArduinoIoTCloudClass::addPropertyReal(String& property, String name, permissionType permission_type, long seconds, void(*fn)(void), float minDelta, void(*synFn)(Property & property))
+{
+  addPropertyReal(property, name, -1, permission_type, seconds, fn, minDelta, synFn);
+}
 void ArduinoIoTCloudClass::addPropertyReal(Property& property, String name, permissionType permission_type, long seconds, void(*fn)(void), float minDelta, void(*synFn)(Property & property))
 {
   addPropertyReal(property, name, -1, permission_type, seconds, fn, minDelta, synFn);
 }
 
+/* The following methods are deprecated but still used for both LoRa and non-LoRa boards */
+void ArduinoIoTCloudClass::addPropertyReal(bool& property, String name, int tag, permissionType permission_type, long seconds, void(*fn)(void), float minDelta, void(*synFn)(Property & property))
+{
+  Property* p = new CloudWrapperBool(property);
+  addPropertyReal(*p, name, tag, permission_type, seconds, fn, minDelta, synFn);
+}
+void ArduinoIoTCloudClass::addPropertyReal(float& property, String name, int tag, permissionType permission_type, long seconds, void(*fn)(void), float minDelta, void(*synFn)(Property & property))
+{
+  Property* p = new CloudWrapperFloat(property);
+  addPropertyReal(*p, name, tag, permission_type, seconds, fn, minDelta, synFn);
+}
+void ArduinoIoTCloudClass::addPropertyReal(int& property, String name, int tag, permissionType permission_type, long seconds, void(*fn)(void), float minDelta, void(*synFn)(Property & property))
+{
+  Property* p = new CloudWrapperInt(property);
+  addPropertyReal(*p, name, tag, permission_type, seconds, fn, minDelta, synFn);
+}
+void ArduinoIoTCloudClass::addPropertyReal(unsigned int& property, String name, int tag, permissionType permission_type, long seconds, void(*fn)(void), float minDelta, void(*synFn)(Property & property))
+{
+  Property* p = new CloudWrapperUnsignedInt(property);
+  addPropertyReal(*p, name, tag, permission_type, seconds, fn, minDelta, synFn);
+}
+void ArduinoIoTCloudClass::addPropertyReal(String& property, String name, int tag, permissionType permission_type, long seconds, void(*fn)(void), float minDelta, void(*synFn)(Property & property))
+{
+  Property* p = new CloudWrapperString(property);
+  addPropertyReal(*p, name, tag, permission_type, seconds, fn, minDelta, synFn);
+}
 void ArduinoIoTCloudClass::addPropertyReal(Property& property, String name, int tag, permissionType permission_type, long seconds, void(*fn)(void), float minDelta, void(*synFn)(Property & property))
 {
   Permission permission = Permission::ReadWrite;
@@ -89,186 +188,6 @@ void ArduinoIoTCloudClass::addPropertyReal(Property& property, String name, int 
   }
 }
 
-Property& ArduinoIoTCloudClass::addPropertyReal(Property& property, String name, Permission const permission)
-{
-  return addPropertyToContainer(_thing_property_container, property, name, permission);
-}
-
-Property& ArduinoIoTCloudClass::addPropertyReal(Property& property, String name, int tag, Permission const permission)
-{
-  return addPropertyToContainer(_thing_property_container, property, name, permission, tag);
-}
-
-Property& ArduinoIoTCloudClass::addPropertyReal(Property& property, PropertyContainer &prop_cont, String name, Permission const permission)
-{
-  return addPropertyToContainer(prop_cont, property, name, permission, -1);
-}
-
-Property& ArduinoIoTCloudClass::addPropertyReal(Property& property, PropertyContainer &prop_cont, String name, int tag, Permission const permission)
-{
-  return addPropertyToContainer(prop_cont, property, name, permission, tag);
-}
-
-void ArduinoIoTCloudClass::addPropertyReal(bool& property, String name, permissionType permission_type, long seconds, void(*fn)(void), float minDelta, void(*synFn)(Property & property))
-{
-  addPropertyReal(property, name, -1, permission_type, seconds, fn, minDelta, synFn);
-}
-
-void ArduinoIoTCloudClass::addPropertyReal(bool& property, String name, int tag, permissionType permission_type, long seconds, void(*fn)(void), float minDelta, void(*synFn)(Property & property))
-{
-  Property* p = new CloudWrapperBool(property);
-  addPropertyReal(*p, name, tag, permission_type, seconds, fn, minDelta, synFn);
-}
-
-Property& ArduinoIoTCloudClass::addPropertyReal(bool& property, String name, Permission const permission)
-{
-  return addPropertyReal(property, _thing_property_container, name, -1, permission);
-}
-
-Property& ArduinoIoTCloudClass::addPropertyReal(bool& property, String name, int tag, Permission const permission)
-{
-  return addPropertyReal(property, _thing_property_container, name, tag, permission);
-}
-
-Property& ArduinoIoTCloudClass::addPropertyReal(bool& property, PropertyContainer &prop_cont, String name, Permission const permission)
-{
-  return addPropertyReal(property, prop_cont, name, -1, permission);
-}
-
-Property& ArduinoIoTCloudClass::addPropertyReal(bool& property, PropertyContainer &prop_cont, String name, int tag, Permission const permission)
-{
-  Property* p = new CloudWrapperBool(property);
-  return addPropertyToContainer(prop_cont, *p, name, permission, tag);
-}
-
-void ArduinoIoTCloudClass::addPropertyReal(float& property, String name, permissionType permission_type, long seconds, void(*fn)(void), float minDelta, void(*synFn)(Property & property))
-{
-  addPropertyReal(property, name, -1, permission_type, seconds, fn, minDelta, synFn);
-}
-
-void ArduinoIoTCloudClass::addPropertyReal(float& property, String name, int tag, permissionType permission_type, long seconds, void(*fn)(void), float minDelta, void(*synFn)(Property & property))
-{
-  Property* p = new CloudWrapperFloat(property);
-  addPropertyReal(*p, name, tag, permission_type, seconds, fn, minDelta, synFn);
-}
-
-Property& ArduinoIoTCloudClass::addPropertyReal(float& property, String name, Permission const permission)
-{
-  return addPropertyReal(property, _thing_property_container, name, -1, permission);
-}
-
-Property& ArduinoIoTCloudClass::addPropertyReal(float& property, String name, int tag, Permission const permission)
-{
-  return addPropertyReal(property, _thing_property_container, name, tag, permission);
-}
-
-Property& ArduinoIoTCloudClass::addPropertyReal(float& property, PropertyContainer &prop_cont, String name, Permission const permission)
-{
-  return addPropertyReal(property, prop_cont, name, -1, permission);
-}
-
-Property& ArduinoIoTCloudClass::addPropertyReal(float& property, PropertyContainer &prop_cont, String name, int tag, Permission const permission)
-{
-  Property* p = new CloudWrapperFloat(property);
-  return addPropertyToContainer(prop_cont, *p, name, permission, tag);
-}
-
-void ArduinoIoTCloudClass::addPropertyReal(int& property, String name, permissionType permission_type, long seconds, void(*fn)(void), float minDelta, void(*synFn)(Property & property))
-{
-  addPropertyReal(property, name, -1, permission_type, seconds, fn, minDelta, synFn);
-}
-
-void ArduinoIoTCloudClass::addPropertyReal(int& property, String name, int tag, permissionType permission_type, long seconds, void(*fn)(void), float minDelta, void(*synFn)(Property & property))
-{
-  Property* p = new CloudWrapperInt(property);
-  addPropertyReal(*p, name, tag, permission_type, seconds, fn, minDelta, synFn);
-}
-
-Property& ArduinoIoTCloudClass::addPropertyReal(int& property, String name, Permission const permission)
-{
-  return addPropertyReal(property, _thing_property_container, name, -1, permission);
-}
-
-Property& ArduinoIoTCloudClass::addPropertyReal(int& property, String name, int tag, Permission const permission)
-{
-  return addPropertyReal(property, _thing_property_container, name, tag, permission);
-}
-
-Property& ArduinoIoTCloudClass::addPropertyReal(int& property, PropertyContainer &prop_cont, String name, Permission const permission)
-{
-  return addPropertyReal(property, prop_cont, name, -1, permission);
-}
-
-Property& ArduinoIoTCloudClass::addPropertyReal(int& property, PropertyContainer &prop_cont, String name, int tag, Permission const permission)
-{
-  Property* p = new CloudWrapperInt(property);
-  return addPropertyToContainer(prop_cont, *p, name, permission, tag);
-}
-
-void ArduinoIoTCloudClass::addPropertyReal(unsigned int& property, String name, permissionType permission_type, long seconds, void(*fn)(void), float minDelta, void(*synFn)(Property & property))
-{
-  addPropertyReal(property, name, -1, permission_type, seconds, fn, minDelta, synFn);
-}
-
-void ArduinoIoTCloudClass::addPropertyReal(unsigned int& property, String name, int tag, permissionType permission_type, long seconds, void(*fn)(void), float minDelta, void(*synFn)(Property & property))
-{
-  Property* p = new CloudWrapperUnsignedInt(property);
-  addPropertyReal(*p, name, tag, permission_type, seconds, fn, minDelta, synFn);
-}
-
-Property& ArduinoIoTCloudClass::addPropertyReal(unsigned int& property, String name, Permission const permission)
-{
-  return addPropertyReal(property, _thing_property_container, name, -1, permission);
-}
-
-Property& ArduinoIoTCloudClass::addPropertyReal(unsigned int& property, String name, int tag, Permission const permission)
-{
-  return addPropertyReal(property, _thing_property_container, name, tag, permission);
-}
-
-Property& ArduinoIoTCloudClass::addPropertyReal(unsigned int& property, PropertyContainer &prop_cont, String name, Permission const permission)
-{
-  return addPropertyReal(property, prop_cont, name, -1, permission);
-}
-
-Property& ArduinoIoTCloudClass::addPropertyReal(unsigned int& property, PropertyContainer &prop_cont, String name, int tag, Permission const permission)
-{
-  Property* p = new CloudWrapperUnsignedInt(property);
-  return addPropertyToContainer(prop_cont, *p, name, permission, tag);
-}
-
-void ArduinoIoTCloudClass::addPropertyReal(String& property, String name, permissionType permission_type, long seconds, void(*fn)(void), float minDelta, void(*synFn)(Property & property))
-{
-  addPropertyReal(property, name, -1, permission_type, seconds, fn, minDelta, synFn);
-}
-
-void ArduinoIoTCloudClass::addPropertyReal(String& property, String name, int tag, permissionType permission_type, long seconds, void(*fn)(void), float minDelta, void(*synFn)(Property & property))
-{
-  Property* p = new CloudWrapperString(property);
-  addPropertyReal(*p, name, tag, permission_type, seconds, fn, minDelta, synFn);
-}
-
-Property& ArduinoIoTCloudClass::addPropertyReal(String& property, String name, Permission const permission)
-{
-  return addPropertyReal(property, _thing_property_container, name, -1, permission);
-}
-
-Property& ArduinoIoTCloudClass::addPropertyReal(String& property, String name, int tag, Permission const permission)
-{
-  return addPropertyReal(property, _thing_property_container, name, tag, permission);
-}
-
-Property& ArduinoIoTCloudClass::addPropertyReal(String& property, PropertyContainer &prop_cont, String name, Permission const permission)
-{
-  return addPropertyReal(property, prop_cont, name, -1, permission);
-}
-
-Property& ArduinoIoTCloudClass::addPropertyReal(String& property, PropertyContainer &prop_cont, String name, int tag, Permission const permission)
-{
-  Property* p = new CloudWrapperString(property);
-  return addPropertyToContainer(prop_cont, *p, name, permission, tag);
-}
-
 /******************************************************************************
  * PROTECTED MEMBER FUNCTIONS
  ******************************************************************************/
@@ -284,4 +203,65 @@ void ArduinoIoTCloudClass::execCloudEventCallback(ArduinoIoTCloudEvent const eve
 __attribute__((weak)) void setDebugMessageLevel(int const /* level */)
 {
   /* do nothing */
+}
+
+/* The following methods are used internally to handle hidden thing and device properties */
+Property& ArduinoIoTCloudClass::addPropertyReal(bool& property, PropertyContainer &prop_cont, String name, Permission const permission)
+{
+  return addPropertyReal(property, prop_cont, name, -1, permission);
+}
+Property& ArduinoIoTCloudClass::addPropertyReal(float& property, PropertyContainer &prop_cont, String name, Permission const permission)
+{
+  return addPropertyReal(property, prop_cont, name, -1, permission);
+}
+Property& ArduinoIoTCloudClass::addPropertyReal(int& property, PropertyContainer &prop_cont, String name, Permission const permission)
+{
+  return addPropertyReal(property, prop_cont, name, -1, permission);
+}
+Property& ArduinoIoTCloudClass::addPropertyReal(unsigned int& property, PropertyContainer &prop_cont, String name, Permission const permission)
+{
+  return addPropertyReal(property, prop_cont, name, -1, permission);
+}
+Property& ArduinoIoTCloudClass::addPropertyReal(String& property, PropertyContainer &prop_cont, String name, Permission const permission)
+{
+  return addPropertyReal(property, prop_cont, name, -1, permission);
+}
+Property& ArduinoIoTCloudClass::addPropertyReal(Property& property, PropertyContainer &prop_cont, String name, Permission const permission)
+{
+  return addPropertyReal(property, prop_cont, name, -1, permission);
+}
+
+/******************************************************************************
+ * PRIVATE MEMBER FUNCTIONS
+ ******************************************************************************/
+
+/* The following methods are used for both LoRa and non-LoRa boards */
+Property& ArduinoIoTCloudClass::addPropertyReal(bool& property, PropertyContainer &prop_cont, String name, int tag, Permission const permission)
+{
+  Property* p = new CloudWrapperBool(property);
+  return addPropertyReal(*p, prop_cont, name, tag, permission);
+}
+Property& ArduinoIoTCloudClass::addPropertyReal(float& property, PropertyContainer &prop_cont, String name, int tag, Permission const permission)
+{
+  Property* p = new CloudWrapperFloat(property);
+  return addPropertyReal(*p, prop_cont, name, tag, permission);
+}
+Property& ArduinoIoTCloudClass::addPropertyReal(int& property, PropertyContainer &prop_cont, String name, int tag, Permission const permission)
+{
+  Property* p = new CloudWrapperInt(property);
+  return addPropertyReal(*p, prop_cont, name, tag, permission);
+}
+Property& ArduinoIoTCloudClass::addPropertyReal(unsigned int& property, PropertyContainer &prop_cont, String name, int tag, Permission const permission)
+{
+  Property* p = new CloudWrapperUnsignedInt(property);
+  return addPropertyReal(*p, prop_cont, name, tag, permission);
+}
+Property& ArduinoIoTCloudClass::addPropertyReal(String& property, PropertyContainer &prop_cont, String name, int tag, Permission const permission)
+{
+  Property* p = new CloudWrapperString(property);
+  return addPropertyReal(*p, prop_cont, name, tag, permission);
+}
+Property& ArduinoIoTCloudClass::addPropertyReal(Property& property, PropertyContainer &prop_cont, String name, int tag, Permission const permission)
+{
+  return addPropertyToContainer(prop_cont, property, name, permission, tag);
 }

--- a/src/ArduinoIoTCloud.h
+++ b/src/ArduinoIoTCloud.h
@@ -164,14 +164,6 @@ class ArduinoIoTCloudClass
 
     void execCloudEventCallback(ArduinoIoTCloudEvent const event);
 
-    /* The following methods are used to handle hidden thing and device properties */
-    Property& addPropertyReal(Property& property, PropertyContainer &prop_cont, String name, Permission const permission);
-    Property& addPropertyReal(bool& property, PropertyContainer &prop_cont, String name, Permission const permission);
-    Property& addPropertyReal(float& property, PropertyContainer &prop_cont, String name, Permission const permission);
-    Property& addPropertyReal(int& property, PropertyContainer &prop_cont, String name, Permission const permission);
-    Property& addPropertyReal(unsigned int& property, PropertyContainer &prop_cont, String name, Permission const permission);
-    Property& addPropertyReal(String& property, PropertyContainer &prop_cont, String name, Permission const permission);
-
   private:
 
     String _device_id;

--- a/src/ArduinoIoTCloud.h
+++ b/src/ArduinoIoTCloud.h
@@ -130,20 +130,6 @@ class ArduinoIoTCloudClass
     Property& addPropertyReal(unsigned int& property, String name, Permission const permission);
     Property& addPropertyReal(String& property, String name, Permission const permission);
 
-    Property& addPropertyReal(Property& property, PropertyContainer &prop_cont, String name, int tag, Permission const permission);
-    Property& addPropertyReal(bool& property, PropertyContainer &prop_cont, String name, int tag, Permission const permission);
-    Property& addPropertyReal(float& property, PropertyContainer &prop_cont, String name, int tag, Permission const permission);
-    Property& addPropertyReal(int& property, PropertyContainer &prop_cont, String name, int tag, Permission const permission);
-    Property& addPropertyReal(unsigned int& property, PropertyContainer &prop_cont, String name, int tag, Permission const permission);
-    Property& addPropertyReal(String& property, PropertyContainer &prop_cont, String name, int tag, Permission const permission);
-
-    Property& addPropertyReal(Property& property, PropertyContainer &prop_cont, String name, Permission const permission);
-    Property& addPropertyReal(bool& property, PropertyContainer &prop_cont, String name, Permission const permission);
-    Property& addPropertyReal(float& property, PropertyContainer &prop_cont, String name, Permission const permission);
-    Property& addPropertyReal(int& property, PropertyContainer &prop_cont, String name, Permission const permission);
-    Property& addPropertyReal(unsigned int& property, PropertyContainer &prop_cont, String name, Permission const permission);
-    Property& addPropertyReal(String& property, PropertyContainer &prop_cont, String name, Permission const permission);
-
     /* The following methods are for MKR WAN 1300/1310 LoRa boards since
      * they use a number to identify a given property within a CBOR message.
      * This approach reduces the required amount of data which is of great
@@ -178,11 +164,26 @@ class ArduinoIoTCloudClass
 
     void execCloudEventCallback(ArduinoIoTCloudEvent const event);
 
+    /* The following methods are used to handle hidden thing and device properties */
+    Property& addPropertyReal(Property& property, PropertyContainer &prop_cont, String name, Permission const permission);
+    Property& addPropertyReal(bool& property, PropertyContainer &prop_cont, String name, Permission const permission);
+    Property& addPropertyReal(float& property, PropertyContainer &prop_cont, String name, Permission const permission);
+    Property& addPropertyReal(int& property, PropertyContainer &prop_cont, String name, Permission const permission);
+    Property& addPropertyReal(unsigned int& property, PropertyContainer &prop_cont, String name, Permission const permission);
+    Property& addPropertyReal(String& property, PropertyContainer &prop_cont, String name, Permission const permission);
+
   private:
 
     String _device_id;
     OnCloudEventCallback _cloud_event_callback[3];
     bool _thing_id_outdated;
+
+    Property& addPropertyReal(Property& property, PropertyContainer &prop_cont, String name, int tag, Permission const permission);
+    Property& addPropertyReal(bool& property, PropertyContainer &prop_cont, String name, int tag, Permission const permission);
+    Property& addPropertyReal(float& property, PropertyContainer &prop_cont, String name, int tag, Permission const permission);
+    Property& addPropertyReal(int& property, PropertyContainer &prop_cont, String name, int tag, Permission const permission);
+    Property& addPropertyReal(unsigned int& property, PropertyContainer &prop_cont, String name, int tag, Permission const permission);
+    Property& addPropertyReal(String& property, PropertyContainer &prop_cont, String name, int tag, Permission const permission);
 };
 
 #ifdef HAS_TCP

--- a/src/ArduinoIoTCloud.h
+++ b/src/ArduinoIoTCloud.h
@@ -169,13 +169,6 @@ class ArduinoIoTCloudClass
     String _device_id;
     OnCloudEventCallback _cloud_event_callback[3];
     bool _thing_id_outdated;
-
-    Property& addPropertyReal(Property& property, PropertyContainer &prop_cont, String name, int tag, Permission const permission);
-    Property& addPropertyReal(bool& property, PropertyContainer &prop_cont, String name, int tag, Permission const permission);
-    Property& addPropertyReal(float& property, PropertyContainer &prop_cont, String name, int tag, Permission const permission);
-    Property& addPropertyReal(int& property, PropertyContainer &prop_cont, String name, int tag, Permission const permission);
-    Property& addPropertyReal(unsigned int& property, PropertyContainer &prop_cont, String name, int tag, Permission const permission);
-    Property& addPropertyReal(String& property, PropertyContainer &prop_cont, String name, int tag, Permission const permission);
 };
 
 #ifdef HAS_TCP

--- a/src/ArduinoIoTCloudTCP.cpp
+++ b/src/ArduinoIoTCloudTCP.cpp
@@ -250,18 +250,26 @@ int ArduinoIoTCloudTCP::begin(bool const enable_watchdog, String brokerAddress, 
   _deviceTopicOut = getTopic_deviceout();
   _deviceTopicIn  = getTopic_devicein();
 
-  addPropertyReal(_lib_version, _device_property_container, "LIB_VERSION", Permission::Read);
+  Property* p;
+  p = new CloudWrapperString(_lib_version);
+  addPropertyToContainer(_device_property_container, *p, "LIB_VERSION", Permission::Read, -1);
 #if OTA_ENABLED
-  addPropertyReal(_ota_cap, _device_property_container, "OTA_CAP", Permission::Read);
-  addPropertyReal(_ota_error, _device_property_container, "OTA_ERROR", Permission::Read);
-  addPropertyReal(_ota_img_sha256, _device_property_container, "OTA_SHA256", Permission::Read);
-  addPropertyReal(_ota_url, _device_property_container, "OTA_URL", Permission::ReadWrite);
-  addPropertyReal(_ota_req, _device_property_container, "OTA_REQ", Permission::ReadWrite);
+  p = new CloudWrapperBool(_ota_cap);
+  addPropertyToContainer(_device_property_container, *p, "OTA_CAP", Permission::Read, -1);
+  p = new CloudWrapperInt(_ota_error);
+  addPropertyToContainer(_device_property_container, *p, "OTA_ERROR", Permission::Read, -1);
+  p = new CloudWrapperString(_ota_img_sha256);
+  addPropertyToContainer(_device_property_container, *p, "OTA_SHA256", Permission::Read, -1);
+  p = new CloudWrapperString(_ota_url);
+  addPropertyToContainer(_device_property_container, *p, "OTA_URL", Permission::ReadWrite, -1);
+  p = new CloudWrapperBool(_ota_req);
+  addPropertyToContainer(_device_property_container, *p, "OTA_REQ", Permission::ReadWrite, -1);
 #endif /* OTA_ENABLED */
+  p = new CloudWrapperString(_thing_id);
+  addPropertyToContainer(_device_property_container, *p, "thing_id", Permission::ReadWrite, -1).onUpdate(setThingIdOutdated);
 
-  addPropertyReal(_tz_offset, _thing_property_container, "tz_offset", Permission::ReadWrite).onSync(CLOUD_WINS).onUpdate(updateTimezoneInfo);
-  addPropertyReal(_tz_dst_until, _thing_property_container, "tz_dst_until", Permission::ReadWrite).onSync(CLOUD_WINS).onUpdate(updateTimezoneInfo);
-  addPropertyReal(_thing_id, _device_property_container, "thing_id", Permission::ReadWrite).onUpdate(setThingIdOutdated);
+  addPropertyReal(_tz_offset, "tz_offset", Permission::ReadWrite).onSync(CLOUD_WINS).onUpdate(updateTimezoneInfo);
+  addPropertyReal(_tz_dst_until, "tz_dst_until", Permission::ReadWrite).onSync(CLOUD_WINS).onUpdate(updateTimezoneInfo);
 
 #if OTA_STORAGE_PORTENTA_QSPI
   #define BOOTLOADER_ADDR   (0x8000000)


### PR DESCRIPTION
During the `thing_id` discovery work https://github.com/arduino-libraries/ArduinoIoTCloud/pull/297 i've added unnecessary methods to the public space.

The goal of this pr is to:
reorder `addPropertyReal` methods in ArduinoIoTCloud.cpp to make more clear who is calling who
remove unnecessary `addPropertyReal` methods from public space: the user should not be able to select the property container because all user properties have to be added to the `_thing_property_container`.