### PR TITLE
Add Arduino_ESP32_OTA to library dependencies

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -8,4 +8,4 @@ category=Communication
 url=https://github.com/arduino-libraries/ArduinoIoTCloud
 architectures=mbed,samd,esp8266,mbed_nano,mbed_portenta,mbed_nicla,esp32,mbed_opta
 includes=ArduinoIoTCloud.h
-depends=Arduino_ConnectionHandler,Arduino_DebugUtils,ArduinoMqttClient,ArduinoECCX08,RTCZero,Adafruit SleepyDog Library
+depends=Arduino_ConnectionHandler,Arduino_DebugUtils,ArduinoMqttClient,ArduinoECCX08,RTCZero,Adafruit SleepyDog Library,Arduino_ESP32_OTA


### PR DESCRIPTION
This is probably a regression: compilation fails on ESP32 when the new Arduino_ESP32_OTA is not installed. This PR adds it to dependencies so that it's automatically installed.