### PR TITLE
ESP: Remove redundant arch defines

### DIFF
--- a/src/AIoTC_Config.h
+++ b/src/AIoTC_Config.h
@@ -141,7 +141,7 @@
   #define HAS_LORA
 #endif
 
-#if defined(ARDUINO_ESP8266_ESP12) || defined(ARDUINO_ARCH_ESP32) || defined(ESP8266) || defined(ESP32)
+#if defined(ARDUINO_ARCH_ESP8266) || defined(ARDUINO_ARCH_ESP32)
   #define BOARD_ESP
   #define HAS_TCP
 #endif


### PR DESCRIPTION
`ARDUINO_ARCH_ESP8266` and `ESP8266` are both defined when building a sketch for ESP 8266/8285 platform.

Same thing for `ARDUINO_ARCH_ESP32` and `ESP32`.

`ARDUINO_ESP8266_ESP12` is a board configuration define and is not needed. 