### PR TITLE
Add UNO R4 WiFi basic support

### DIFF
--- a/.github/workflows/compile-examples.yml
+++ b/.github/workflows/compile-examples.yml
@@ -64,6 +64,8 @@ jobs:
             type: mbed_giga
           - fqbn: arduino:renesas_portenta:portenta_c33
             type: renesas_portenta
+          - fqbn: arduino:renesas_uno:unor4wifi
+            type: renesas_uno
 
 
         # make board type-specific customizations to the matrix jobs
@@ -177,7 +179,7 @@ jobs:
               - name: Arduino_Portenta_OTA
             sketch-paths: |
               - examples/utility/Provisioning
-          # Portneta C33
+          # Portenta C33
           - board:
               type: renesas_portenta
             platforms: |
@@ -185,6 +187,12 @@ jobs:
               - name: arduino:renesas_portenta
             sketch-paths: |
               - examples/utility/Provisioning
+          # UNO R4 WiFi
+          - board:
+              type: renesas_uno
+            platforms: |
+              # Install renesas_uno platform via Boards Manager
+              - name: arduino:renesas_uno
           # ESP8266 boards
           - board:
               type: esp8266

--- a/library.properties
+++ b/library.properties
@@ -6,6 +6,6 @@ sentence=This library allows connecting to the Arduino IoT Cloud service.
 paragraph=It provides a ConnectionManager to handle connection/disconnection, property-change updates and events callbacks. The supported boards are MKR GSM, MKR1000 and WiFi101.
 category=Communication
 url=https://github.com/arduino-libraries/ArduinoIoTCloud
-architectures=mbed,samd,esp8266,mbed_nano,mbed_portenta,mbed_nicla,esp32,mbed_opta,mbed_giga,renesas_portenta
+architectures=mbed,samd,esp8266,mbed_nano,mbed_portenta,mbed_nicla,esp32,mbed_opta,mbed_giga,renesas_portenta,renesas_uno
 includes=ArduinoIoTCloud.h
 depends=Arduino_ConnectionHandler,Arduino_DebugUtils,ArduinoMqttClient,ArduinoECCX08,RTCZero,Adafruit SleepyDog Library,Arduino_ESP32_OTA,Arduino_Portenta_OTA

--- a/src/AIoTC_Config.h
+++ b/src/AIoTC_Config.h
@@ -151,6 +151,11 @@
   #define BOARD_STM32H7
 #endif
 
+#if defined(ARDUINO_UNOR4_WIFI)
+  #define BOARD_HAS_SECRET_KEY
+  #define HAS_TCP
+#endif
+
 /******************************************************************************
  * CONSTANTS
  ******************************************************************************/

--- a/src/ArduinoIoTCloudTCP.cpp
+++ b/src/ArduinoIoTCloudTCP.cpp
@@ -329,7 +329,7 @@ ArduinoIoTCloudTCP::State ArduinoIoTCloudTCP::handle_ConnectMqttBroker()
 
 #if defined(ARDUINO_UNOWIFIR4)
     if (String(WiFi.firmwareVersion()) < String("0.2.0")) {
-      DEBUG_ERROR("ArduinoIoTCloudTCP::%s In order to connect to Arduino IoT Cloud, WiFI firmware needs to be >= 0.2.0, current %s", __FUNCTION__, WiFi.firmwareVersion());
+      DEBUG_ERROR("ArduinoIoTCloudTCP::%s In order to connect to Arduino IoT Cloud, WiFi firmware needs to be >= 0.2.0, current %s", __FUNCTION__, WiFi.firmwareVersion());
     }
 #endif
 

--- a/src/ArduinoIoTCloudTCP.cpp
+++ b/src/ArduinoIoTCloudTCP.cpp
@@ -327,6 +327,12 @@ ArduinoIoTCloudTCP::State ArduinoIoTCloudTCP::handle_ConnectMqttBroker()
   reconnection_retry_delay = min(reconnection_retry_delay, static_cast<unsigned long>(AIOT_CONFIG_MAX_RECONNECTION_RETRY_DELAY_ms));
   _next_connection_attempt_tick = millis() + reconnection_retry_delay;
 
+#if defined(ARDUINO_UNOWIFIR4)
+    if (String(WiFi.firmwareVersion()) < String("0.2.0")) {
+      DEBUG_ERROR("ArduinoIoTCloudTCP::%s In order to connect to Arduino IoT Cloud, WiFI firmware needs to be >= 0.2.0, current %s", __FUNCTION__, WiFi.firmwareVersion());
+    }
+#endif
+
   DEBUG_ERROR("ArduinoIoTCloudTCP::%s could not connect to %s:%d", __FUNCTION__, _brokerAddress.c_str(), _brokerPort);
   DEBUG_ERROR("ArduinoIoTCloudTCP::%s %d connection attempt at tick time %d", __FUNCTION__, _last_connection_attempt_cnt, _next_connection_attempt_tick);
   return State::ConnectPhy;

--- a/src/ArduinoIoTCloudTCP.h
+++ b/src/ArduinoIoTCloudTCP.h
@@ -31,6 +31,8 @@
   #include "tls/utility/CryptoUtil.h"
 #elif defined(BOARD_ESP)
   #include <WiFiClientSecure.h>
+#elif defined(ARDUINO_UNOR4_WIFI)
+  #include <WiFiSSLClient.h>
 #elif defined(ARDUINO_PORTENTA_C33)
   #include "tls/utility/CryptoUtil.h"
   #include <SSLClient.h>
@@ -148,6 +150,8 @@ class ArduinoIoTCloudTCP: public ArduinoIoTCloudClass
     CryptoUtil _crypto;
     #elif defined(BOARD_ESP)
     WiFiClientSecure _sslClient;
+    #elif defined(ARDUINO_UNOR4_WIFI)
+    WiFiSSLClient _sslClient;
     #elif defined(ARDUINO_PORTENTA_C33)
     ArduinoIoTCloudCertClass _cert;
     SSLClient _sslClient;

--- a/src/utility/time/TimeService.cpp
+++ b/src/utility/time/TimeService.cpp
@@ -97,12 +97,17 @@ unsigned long renesas_getRTC();
 #endif
 
 /**************************************************************************************
+ * DEFINES
+ **************************************************************************************/
+
+#define EPOCH_AT_COMPILE_TIME cvt_time(__DATE__)
+
+/**************************************************************************************
  * CONSTANTS
  **************************************************************************************/
 
 /* Default NTP synch is scheduled each 24 hours from startup */
 static time_t const TIMESERVICE_NTP_SYNC_TIMEOUT_ms = DAYS * 1000;
-static time_t const EPOCH_AT_COMPILE_TIME = cvt_time(__DATE__);
 static time_t const EPOCH = 0;
 
 /**************************************************************************************

--- a/src/utility/time/TimeService.cpp
+++ b/src/utility/time/TimeService.cpp
@@ -398,32 +398,38 @@ unsigned long TimeServiceClass::getRTC()
 
 time_t cvt_time(char const * time)
 {
-  char s_month[5];
-  int month, day, year;
-  struct tm t =
-  {
-    0 /* tm_sec   */,
-    0 /* tm_min   */,
-    0 /* tm_hour  */,
-    0 /* tm_mday  */,
-    0 /* tm_mon   */,
-    0 /* tm_year  */,
-    0 /* tm_wday  */,
-    0 /* tm_yday  */,
-    0 /* tm_isdst */
-  };
-  static const char month_names[] = "JanFebMarAprMayJunJulAugSepOctNovDec";
+  static time_t build_time = 0;
 
-  sscanf(time, "%s %d %d", s_month, &day, &year);
+  if (!build_time) {
+    char s_month[5];
+    int month, day, year;
+    struct tm t =
+    {
+      0 /* tm_sec   */,
+      0 /* tm_min   */,
+      0 /* tm_hour  */,
+      0 /* tm_mday  */,
+      0 /* tm_mon   */,
+      0 /* tm_year  */,
+      0 /* tm_wday  */,
+      0 /* tm_yday  */,
+      0 /* tm_isdst */
+    };
+    static const char month_names[] = "JanFebMarAprMayJunJulAugSepOctNovDec";
 
-  month = (strstr(month_names, s_month) - month_names) / 3;
+    sscanf(time, "%s %d %d", s_month, &day, &year);
 
-  t.tm_mon = month;
-  t.tm_mday = day;
-  t.tm_year = year - 1900;
-  t.tm_isdst = -1;
+    month = (strstr(month_names, s_month) - month_names) / 3;
 
-  return mktime(&t);
+    t.tm_mon = month;
+    t.tm_mday = day;
+    t.tm_year = year - 1900;
+    t.tm_isdst = -1;
+
+    build_time = mktime(&t);
+  }
+
+  return build_time;
 }
 
 #ifdef ARDUINO_ARCH_SAMD


### PR DESCRIPTION
To connect to ArduinoIoTCloud WiFi firmware need to be updated. The minimum required version is `0.2.0`.

Pre release of the firmware is available here: https://github.com/bcmi-labs/uno-r4-wifi-usb-bridge/releases
Updater tool for [linux](https://github.com/bcmi-labs/uno-r4-wifi-usb-bridge/releases/download/0.2.0/unor4wifi-update-linux.zip), [win](https://github.com/bcmi-labs/uno-r4-wifi-usb-bridge/releases/download/0.2.0/unor4wifi-update-windows.zip), [macos](https://github.com/bcmi-labs/uno-r4-wifi-usb-bridge/releases/download/0.2.0/unor4wifi-update-macos.zip).

Instructions for flashing the new firmware available [here](https://github.com/bcmi-labs/uno-r4-wifi-usb-bridge/blob/b1ddb36decd16f348e4e5796b2040c4b94b7e821/unor4wifi-updater/README.md)