### PR TITLE
Use token when uploading unit test code coverage data to Codecov from workflow

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -36,7 +36,7 @@ jobs:
           coverage-data-path: ${{ env.COVERAGE_DATA_PATH }}
 
       - name: Upload coverage report to Codecov
-        uses: codecov/codecov-action@v1
+        uses: codecov/codecov-action@v3
         with:
           file: "${{ env.COVERAGE_DATA_PATH }}"
           fail_ci_if_error: true

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -35,8 +35,23 @@ jobs:
             - '*/src/cbor/lib/*'
           coverage-data-path: ${{ env.COVERAGE_DATA_PATH }}
 
+      # A token is used to avoid intermittent spurious job failures caused by rate limiting.
+      - name: Set up Codecov upload token
+        run: |
+          if [[ "${{ github.repository }}" == "arduino-libraries/ArduinoIoTCloud" ]]; then
+            # In order to avoid uploads of data from forks, only use the token for runs in the parent repo.
+            # Token is intentionally exposed.
+            # See: https://community.codecov.com/t/upload-issues-unable-to-locate-build-via-github-actions-api/3954
+            CODECOV_TOKEN="47827969-3fda-4ba1-9506-e8d0834ed88c"
+          else
+            # codecov/codecov-action does unauthenticated upload if empty string is passed via the `token` input.
+            CODECOV_TOKEN=""
+          fi
+          echo "CODECOV_TOKEN=$CODECOV_TOKEN" >> "$GITHUB_ENV"
+
       - name: Upload coverage report to Codecov
         uses: codecov/codecov-action@v3
         with:
           file: "${{ env.COVERAGE_DATA_PATH }}"
           fail_ci_if_error: true
+          token: ${{ env.CODECOV_TOKEN }}


### PR DESCRIPTION
[Codecov](https://codecov.io) claims a token is not needed when using the [`codecov/codecov-action`](https://github.com/codecov/codecov-action) GitHub Actions action in workflows of a public repository:

https://github.com/codecov/codecov-action#usage

> For public repositories, no token is needed

However, experience shows that that step of the workflow is subject to intermittent spurious failures caused by a 404 error during the upload attempt:

https://github.com/arduino-libraries/ArduinoIoTCloud/actions/runs/5403452364/jobs/9816277077#step:4:32

```
[2023-06-28T16:21:33.805Z] ['error'] There was an error running the uploader: Error uploading to [https://codecov.io:](https://codecov.io/) Error: There was an error fetching the storage URL during POST: 404 - {'detail': ErrorDetail(string='Unable to locate build via Github Actions API. Please upload with the Codecov repository upload token to resolve issue.', code='not_found')}
```

It is suggested that this can be avoided by using the Codecov upload token for the repository (which can be passed to the `codecov/codecov-action` action via the `token` input):

https://community.codecov.com/t/upload-issues-unable-to-locate-build-via-github-actions-api/3954

It should be noted that [PRs from forks do not have access to repository secrets](https://docs.github.com/en/actions/security-guides/encrypted-secrets#using-encrypted-secrets-in-a-workflow), so the approach suggested there of using an [encrypted repository secret](https://docs.github.com/en/actions/security-guides/encrypted-secrets) for the token would mean that PRs from forks (the workflow runs for which don't have access to secrets) would still be subject to the same intermittent spurious workflow run failures.

The alternative approach is to add the token in plaintext directly in the workflow. The security implications of that
approach are described here:

https://community.codecov.com/t/upload-issues-unable-to-locate-build-via-github-actions-api/3954

> Public repositories that rely on PRs via forks will find that they cannot effectively use Codecov if the token is stored as a GitHub secret. The scope of the Codecov token is only to confirm that the coverage uploaded comes from a specific repository, not to pull down source code or make any code changes.
>
> For this reason, we recommend that teams with public repositories that rely on PRs via forks consider the security ramifications of making the Codecov token available as opposed to being in a secret.
>
> A malicious actor would be able to upload incorrect or misleading coverage reports to a specific repository if they have access to your upload token, but would not be able to pull down source code or make any code changes.

I have evaluated the risks of exposing the token and am intentionally choosing to accept the possibility of it being used by a malicious actor to upload incorrect coverage data for this project to Codecov.