### PR TITLE
Remove internal global functions and unwanted public functions

### DIFF
--- a/src/ArduinoIoTCloud.h
+++ b/src/ArduinoIoTCloud.h
@@ -151,8 +151,8 @@ class ArduinoIoTCloudClass
     PropertyContainer _thing_property_container;
     unsigned int _last_checked_property_index;
     TimeServiceClass & _time_service;
-    int _tz_offset;
-    unsigned int _tz_dst_until;
+    CloudInt _tz_offset;
+    CloudUnsignedInt _tz_dst_until;
     CloudString _thing_id;
     String _lib_version;
 

--- a/src/ArduinoIoTCloud.h
+++ b/src/ArduinoIoTCloud.h
@@ -92,15 +92,9 @@ class ArduinoIoTCloudClass
             bool setTimestamp(String const & prop_name, unsigned long const timestamp);
 
     inline void     setThingId (String const thing_id)  { _thing_id = thing_id; };
-    inline String & getThingId ()                       { return _thing_id; };
+    inline String & getThingId ()                       { return _thing_id.getValue(); };
     inline void     setDeviceId(String const device_id) { _device_id = device_id; };
     inline String & getDeviceId()                       { return _device_id; };
-
-    inline void     setThingIdOutdatedFlag()            { _thing_id_outdated = true ; }
-    inline void     clrThingIdOutdatedFlag()            { _thing_id_outdated = false ; }
-    inline bool     getThingIdOutdatedFlag()            { return _thing_id_outdated; }
-
-    inline bool     deviceNotAttached()                 { return _thing_id == ""; }
 
     inline ConnectionHandler * getConnection()          { return _connection; }
 
@@ -159,7 +153,7 @@ class ArduinoIoTCloudClass
     TimeServiceClass & _time_service;
     int _tz_offset;
     unsigned int _tz_dst_until;
-    String _thing_id;
+    CloudString _thing_id;
     String _lib_version;
 
     void execCloudEventCallback(ArduinoIoTCloudEvent const event);

--- a/src/property/PropertyContainer.cpp
+++ b/src/property/PropertyContainer.cpp
@@ -114,16 +114,22 @@ void updateProperty(PropertyContainer & prop_cont, String propertyName, unsigned
 {
   Property * property = getProperty(prop_cont, propertyName);
 
-  if (property && property->isWriteableByCloud())
+  if (property )
   {
+    /* Update _cloud_value */
     property->setLastCloudChangeTimestamp(cloudChangeEventTime);
     property->setAttributesFromCloud(map_data_list);
-    if (is_sync_message) {
-      property->execCallbackOnSync();
-    } else {
-      property->fromCloudToLocal();
-      property->execCallbackOnChange();
-      property->provideEcho();
+
+    /* Update _value */
+    if (property->isWriteableByCloud())
+    {
+      if (is_sync_message) {
+        property->execCallbackOnSync();
+      } else {
+        property->fromCloudToLocal();
+        property->execCallbackOnChange();
+        property->provideEcho();
+      }
     }
   }
 }

--- a/src/property/types/CloudString.h
+++ b/src/property/types/CloudString.h
@@ -52,6 +52,9 @@ class CloudString : public Property {
     virtual bool isDifferentFromCloud() {
       return _value != _cloud_value;
     }
+    virtual String & getValue() {
+      return _value;
+    }
     virtual void fromCloudToLocal() {
       _value = _cloud_value;
     }


### PR DESCRIPTION
### Issue
To handle `timezone` and `thing-id` changes from the cloud UI the following global functions were added:
* https://github.com/arduino-libraries/ArduinoIoTCloud/blob/6a9acc20ae4c07311ab11c46464901a9fd70dbd1/src/ArduinoIoTCloudTCP.cpp#L63
* https://github.com/arduino-libraries/ArduinoIoTCloud/blob/6a9acc20ae4c07311ab11c46464901a9fd70dbd1/src/ArduinoIoTCloudTCP.cpp#L68

Together with other public functions that should be only used for internal purposes:
* https://github.com/arduino-libraries/ArduinoIoTCloud/blob/6a9acc20ae4c07311ab11c46464901a9fd70dbd1/src/ArduinoIoTCloud.h#L99
* https://github.com/arduino-libraries/ArduinoIoTCloud/blob/6a9acc20ae4c07311ab11c46464901a9fd70dbd1/src/ArduinoIoTCloud.h#L100
* https://github.com/arduino-libraries/ArduinoIoTCloud/blob/6a9acc20ae4c07311ab11c46464901a9fd70dbd1/src/ArduinoIoTCloud.h#L101
* https://github.com/arduino-libraries/ArduinoIoTCloud/blob/6a9acc20ae4c07311ab11c46464901a9fd70dbd1/src/ArduinoIoTCloud.h#L103

### Changes
This PR removes the global functions and unwanted public methods  to handle `thing-id` and `timezone` changes.

### Other Info
Regarding commit https://github.com/arduino-libraries/ArduinoIoTCloud/commit/19176392365e72c653c2292c6e3f2ce08bb84453 I'm not sure if this behaviour was intended or not, but I've found out that for `read-only` property the `cloud_value` is never updated. This change allows to update the cloud_value of a `read-only` property allowing also the possibility to manually change the local value calling the `fromCloudTiLocal()` function. This is a bit hacky and not 100% correct. To fix this we should add a local update policy [`manual`/`auto`] to add the possibility to handle the property `local_value` update manually.
