### PR TITLE
Time Service: merge STM42H7 and NANO RP2040 RTC functions

### DIFF
--- a/src/utility/time/TimeService.cpp
+++ b/src/utility/time/TimeService.cpp
@@ -72,10 +72,10 @@ void rp2040_connect_setRTC(unsigned long time);
 unsigned long rp2040_connect_getRTC();
 #endif
 
-#ifdef BOARD_STM32H7
-void stm32h7_initRTC();
-void stm32h7_setRTC(unsigned long time);
-unsigned long stm32h7_getRTC();
+#ifdef ARDUINO_ARCH_MBED
+void mbed_initRTC();
+void mbed_setRTC(unsigned long time);
+unsigned long mbed_getRTC();
 #endif
 
 #ifdef ARDUINO_ARCH_ESP32
@@ -339,8 +339,8 @@ void TimeServiceClass::initRTC()
   samd_initRTC();
 #elif defined (ARDUINO_NANO_RP2040_CONNECT)
   rp2040_connect_initRTC();
-#elif defined (BOARD_STM32H7)
-  stm32h7_initRTC();
+#elif defined (ARDUINO_ARCH_MBED)
+  mbed_initRTC();
 #elif defined (ARDUINO_ARCH_ESP32)
   esp32_initRTC();
 #elif defined (ARDUINO_ARCH_ESP8266)
@@ -358,8 +358,8 @@ void TimeServiceClass::setRTC(unsigned long time)
   samd_setRTC(time);
 #elif defined (ARDUINO_NANO_RP2040_CONNECT)
   rp2040_connect_setRTC(time);
-#elif defined (BOARD_STM32H7)
-  stm32h7_setRTC(time);
+#elif defined (ARDUINO_ARCH_MBED)
+  mbed_setRTC(time);
 #elif defined (ARDUINO_ARCH_ESP32)
   esp32_setRTC(time);
 #elif defined (ARDUINO_ARCH_ESP8266)
@@ -377,8 +377,8 @@ unsigned long TimeServiceClass::getRTC()
   return samd_getRTC();
 #elif defined (ARDUINO_NANO_RP2040_CONNECT)
   return rp2040_connect_getRTC();
-#elif defined (BOARD_STM32H7)
-  return stm32h7_getRTC();
+#elif defined (ARDUINO_ARCH_MBED)
+  return mbed_getRTC();
 #elif defined (ARDUINO_ARCH_ESP32)
   return esp32_getRTC();
 #elif defined (ARDUINO_ARCH_ESP8266)
@@ -464,18 +464,18 @@ unsigned long rp2040_connect_getRTC()
 }
 #endif
 
-#ifdef BOARD_STM32H7
-void stm32h7_initRTC()
+#ifdef ARDUINO_ARCH_MBED
+void mbed_initRTC()
 {
   /* Nothing to do */
 }
 
-void stm32h7_setRTC(unsigned long time)
+void mbed_setRTC(unsigned long time)
 {
   set_time(time);
 }
 
-unsigned long stm32h7_getRTC()
+unsigned long mbed_getRTC()
 {
   return time(NULL);
 }

--- a/src/utility/time/TimeService.cpp
+++ b/src/utility/time/TimeService.cpp
@@ -66,12 +66,6 @@ void samd_setRTC(unsigned long time);
 unsigned long samd_getRTC();
 #endif
 
-#ifdef ARDUINO_NANO_RP2040_CONNECT
-void rp2040_connect_initRTC();
-void rp2040_connect_setRTC(unsigned long time);
-unsigned long rp2040_connect_getRTC();
-#endif
-
 #ifdef ARDUINO_ARCH_MBED
 void mbed_initRTC();
 void mbed_setRTC(unsigned long time);
@@ -337,8 +331,6 @@ void TimeServiceClass::initRTC()
 {
 #if defined (ARDUINO_ARCH_SAMD)
   samd_initRTC();
-#elif defined (ARDUINO_NANO_RP2040_CONNECT)
-  rp2040_connect_initRTC();
 #elif defined (ARDUINO_ARCH_MBED)
   mbed_initRTC();
 #elif defined (ARDUINO_ARCH_ESP32)
@@ -356,8 +348,6 @@ void TimeServiceClass::setRTC(unsigned long time)
 {
 #if defined (ARDUINO_ARCH_SAMD)
   samd_setRTC(time);
-#elif defined (ARDUINO_NANO_RP2040_CONNECT)
-  rp2040_connect_setRTC(time);
 #elif defined (ARDUINO_ARCH_MBED)
   mbed_setRTC(time);
 #elif defined (ARDUINO_ARCH_ESP32)
@@ -375,8 +365,6 @@ unsigned long TimeServiceClass::getRTC()
 {
 #if defined (ARDUINO_ARCH_SAMD)
   return samd_getRTC();
-#elif defined (ARDUINO_NANO_RP2040_CONNECT)
-  return rp2040_connect_getRTC();
 #elif defined (ARDUINO_ARCH_MBED)
   return mbed_getRTC();
 #elif defined (ARDUINO_ARCH_ESP32)
@@ -444,23 +432,6 @@ void samd_setRTC(unsigned long time)
 unsigned long samd_getRTC()
 {
   return rtc.getEpoch();
-}
-#endif
-
-#ifdef ARDUINO_NANO_RP2040_CONNECT
-void rp2040_connect_initRTC()
-{
-  /* Nothing to do */
-}
-
-void rp2040_connect_setRTC(unsigned long time)
-{
-  set_time(time);
-}
-
-unsigned long rp2040_connect_getRTC()
-{
-  return time(NULL);
 }
 #endif
 


### PR DESCRIPTION
ST32H7 based boards and NANO RP2040 Connect shares the same mbed interface to configure and use the real time clock peripheral.