### PR TITLE
Avoid library to call deprecated functions itself

### DIFF
--- a/src/ArduinoIoTCloud.cpp
+++ b/src/ArduinoIoTCloud.cpp
@@ -126,56 +126,66 @@ Property& ArduinoIoTCloudClass::addPropertyReal(Property& property, String name,
 /* The following methods are deprecated but still used for non-LoRa boards */
 void ArduinoIoTCloudClass::addPropertyReal(bool& property, String name, permissionType permission_type, long seconds, void(*fn)(void), float minDelta, void(*synFn)(Property & property))
 {
-  addPropertyReal(property, name, -1, permission_type, seconds, fn, minDelta, synFn);
+  Property* p = new CloudWrapperBool(property);
+  addPropertyRealInternal(*p, name, -1, permission_type, seconds, fn, minDelta, synFn);
 }
 void ArduinoIoTCloudClass::addPropertyReal(float& property, String name, permissionType permission_type, long seconds, void(*fn)(void), float minDelta, void(*synFn)(Property & property))
 {
-  addPropertyReal(property, name, -1, permission_type, seconds, fn, minDelta, synFn);
+  Property* p = new CloudWrapperFloat(property);
+  addPropertyRealInternal(*p, name, -1, permission_type, seconds, fn, minDelta, synFn);
 }
 void ArduinoIoTCloudClass::addPropertyReal(int& property, String name, permissionType permission_type, long seconds, void(*fn)(void), float minDelta, void(*synFn)(Property & property))
 {
-  addPropertyReal(property, name, -1, permission_type, seconds, fn, minDelta, synFn);
+  Property* p = new CloudWrapperInt(property);
+  addPropertyRealInternal(*p, name, -1, permission_type, seconds, fn, minDelta, synFn);
 }
 void ArduinoIoTCloudClass::addPropertyReal(unsigned int& property, String name, permissionType permission_type, long seconds, void(*fn)(void), float minDelta, void(*synFn)(Property & property))
 {
-  addPropertyReal(property, name, -1, permission_type, seconds, fn, minDelta, synFn);
+  Property* p = new CloudWrapperUnsignedInt(property);
+  addPropertyRealInternal(*p, name, -1, permission_type, seconds, fn, minDelta, synFn);
 }
 void ArduinoIoTCloudClass::addPropertyReal(String& property, String name, permissionType permission_type, long seconds, void(*fn)(void), float minDelta, void(*synFn)(Property & property))
 {
-  addPropertyReal(property, name, -1, permission_type, seconds, fn, minDelta, synFn);
+  Property* p = new CloudWrapperString(property);
+  addPropertyRealInternal(*p, name, -1, permission_type, seconds, fn, minDelta, synFn);
 }
 void ArduinoIoTCloudClass::addPropertyReal(Property& property, String name, permissionType permission_type, long seconds, void(*fn)(void), float minDelta, void(*synFn)(Property & property))
 {
-  addPropertyReal(property, name, -1, permission_type, seconds, fn, minDelta, synFn);
+  addPropertyRealInternal(property, name, -1, permission_type, seconds, fn, minDelta, synFn);
 }
 
 /* The following methods are deprecated but still used for both LoRa and non-LoRa boards */
 void ArduinoIoTCloudClass::addPropertyReal(bool& property, String name, int tag, permissionType permission_type, long seconds, void(*fn)(void), float minDelta, void(*synFn)(Property & property))
 {
   Property* p = new CloudWrapperBool(property);
-  addPropertyReal(*p, name, tag, permission_type, seconds, fn, minDelta, synFn);
+  addPropertyRealInternal(*p, name, tag, permission_type, seconds, fn, minDelta, synFn);
 }
 void ArduinoIoTCloudClass::addPropertyReal(float& property, String name, int tag, permissionType permission_type, long seconds, void(*fn)(void), float minDelta, void(*synFn)(Property & property))
 {
   Property* p = new CloudWrapperFloat(property);
-  addPropertyReal(*p, name, tag, permission_type, seconds, fn, minDelta, synFn);
+  addPropertyRealInternal(*p, name, tag, permission_type, seconds, fn, minDelta, synFn);
 }
 void ArduinoIoTCloudClass::addPropertyReal(int& property, String name, int tag, permissionType permission_type, long seconds, void(*fn)(void), float minDelta, void(*synFn)(Property & property))
 {
   Property* p = new CloudWrapperInt(property);
-  addPropertyReal(*p, name, tag, permission_type, seconds, fn, minDelta, synFn);
+  addPropertyRealInternal(*p, name, tag, permission_type, seconds, fn, minDelta, synFn);
 }
 void ArduinoIoTCloudClass::addPropertyReal(unsigned int& property, String name, int tag, permissionType permission_type, long seconds, void(*fn)(void), float minDelta, void(*synFn)(Property & property))
 {
   Property* p = new CloudWrapperUnsignedInt(property);
-  addPropertyReal(*p, name, tag, permission_type, seconds, fn, minDelta, synFn);
+  addPropertyRealInternal(*p, name, tag, permission_type, seconds, fn, minDelta, synFn);
 }
 void ArduinoIoTCloudClass::addPropertyReal(String& property, String name, int tag, permissionType permission_type, long seconds, void(*fn)(void), float minDelta, void(*synFn)(Property & property))
 {
   Property* p = new CloudWrapperString(property);
-  addPropertyReal(*p, name, tag, permission_type, seconds, fn, minDelta, synFn);
+  addPropertyRealInternal(*p, name, tag, permission_type, seconds, fn, minDelta, synFn);
 }
 void ArduinoIoTCloudClass::addPropertyReal(Property& property, String name, int tag, permissionType permission_type, long seconds, void(*fn)(void), float minDelta, void(*synFn)(Property & property))
+{
+  addPropertyRealInternal(property, name, tag, permission_type, seconds, fn, minDelta, synFn);
+}
+
+void ArduinoIoTCloudClass::addPropertyRealInternal(Property& property, String name, int tag, permissionType permission_type, long seconds, void(*fn)(void), float minDelta, void(*synFn)(Property & property))
 {
   Permission permission = Permission::ReadWrite;
   if (permission_type == READ) {

--- a/src/ArduinoIoTCloud.h
+++ b/src/ArduinoIoTCloud.h
@@ -166,6 +166,8 @@ class ArduinoIoTCloudClass
 
   private:
 
+    void addPropertyRealInternal(Property& property, String name, int tag, permissionType permission_type = READWRITE, long seconds = ON_CHANGE, void(*fn)(void) = NULL, float minDelta = 0.0f, void(*synFn)(Property & property) = CLOUD_WINS);
+
     String _device_id;
     OnCloudEventCallback _cloud_event_callback[3];
     bool _thing_id_outdated;


### PR DESCRIPTION
Fixes #402

warning can still be triggered from thingProperties.h file if deprecated functions are called.