### PR TITLE
Increase MQTT buffer size on STM32H7

### DIFF
--- a/src/ArduinoIoTCloudTCP.h
+++ b/src/ArduinoIoTCloudTCP.h
@@ -106,7 +106,11 @@ class ArduinoIoTCloudTCP: public ArduinoIoTCloudClass
 #endif
 
   private:
+#if defined(ARDUINO_PORTENTA_H7_M7) || defined(ARDUINO_OPTA) || defined(ARDUINO_GIGA)
+    static const int MQTT_TRANSMIT_BUFFER_SIZE = 1024;
+#else
     static const int MQTT_TRANSMIT_BUFFER_SIZE = 256;
+#endif
 
     enum class State
     {


### PR DESCRIPTION
Increasing MQTT buffer size on STM32H7-based board allows use cases such as using large `String` values to carry payloads to 3rd platforms.