### PR TITLE
Fix size deltas report infrastructure configuration

### DIFF
--- a/.github/workflows/compile-examples.yml
+++ b/.github/workflows/compile-examples.yml
@@ -12,12 +12,8 @@ on:
       - "examples/**"
       - "src/**"
 
-env:
-  # It's convenient to set variables for values used multiple times in the workflow.
-  SKETCHES_REPORTS_PATH: sketches-reports
-
 jobs:
-  compile:
+  build:
     runs-on: ubuntu-latest
 
     env:
@@ -35,6 +31,7 @@ jobs:
         - examples/ArduinoIoTCloud-Callbacks
         - examples/ArduinoIoTCloud-Schedule
         - examples/utility/ArduinoIoTCloud_Travis_CI
+      SKETCHES_REPORTS_PATH: sketches-reports
 
     strategy:
       fail-fast: false
@@ -295,28 +292,9 @@ jobs:
           google-key-file: ${{ secrets.GOOGLE_KEY_FILE }}
           spreadsheet-id: 1I6NZkpZpf8KugBkE92adB1Z3_b7ZepOpCdYTOigJpN4
 
-      # This step is needed to pass the size data to the report job.
       - name: Save memory usage change report as artifact
         if: github.event_name == 'pull_request'
         uses: actions/upload-artifact@v4
         with:
           name: sketches-report-${{ matrix.board.artifact-name-suffix }}
           path: ${{ env.SKETCHES_REPORTS_PATH }}
-
-  # When using a matrix to compile for multiple boards, it's necessary to use a separate job for the deltas report
-  report:
-    needs: compile # Wait for the compile job to finish to get the data for the report
-    if: github.event_name == 'pull_request' # Only run the job when the workflow is triggered by a pull request
-    runs-on: ubuntu-latest
-
-    steps:
-      # This step is needed to get the size data produced by the compile jobs
-      - name: Download sketches reports artifacts
-        uses: actions/download-artifact@v4
-        with:
-          # All workflow artifacts will be downloaded to this location.
-          path: ${{ env.SKETCHES_REPORTS_PATH }}
-
-      - uses: arduino/report-size-deltas@v1
-        with:
-          sketches-reports-source: ${{ env.SKETCHES_REPORTS_PATH }}

--- a/.github/workflows/report-size-deltas.yml
+++ b/.github/workflows/report-size-deltas.yml
@@ -1,0 +1,14 @@
+on:
+  schedule:
+    - cron:  '*/5 * * * *'
+
+jobs:
+  report:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Comment size deltas reports to PRs
+        uses: arduino/report-size-deltas@v1
+        with:
+          # The name of the workflow artifact created by the "Compile Examples" workflow
+          sketches-reports-source: sketches-reports

--- a/.github/workflows/report-size-deltas.yml
+++ b/.github/workflows/report-size-deltas.yml
@@ -10,5 +10,5 @@ jobs:
       - name: Comment size deltas reports to PRs
         uses: arduino/report-size-deltas@v1
         with:
-          # The name of the workflow artifact created by the "Compile Examples" workflow
-          sketches-reports-source: sketches-reports
+          # Regex matching the names of the workflow artifacts created by the "Compile Examples" workflow
+          sketches-reports-source: ^sketches-report-.+


### PR DESCRIPTION
## Revert Size Deltas Report Infrastructure Back to Public Repository-Appropriate Configuration

The repository infrastructure uses the [**arduino/report-size-deltas**](https://github.com/arduino/report-size-deltas) GitHub Actions action to generate a report of the changes in memory usage of the example sketches that would result from merging a pull request.

There are two use patterns for the **arduino/report-size-deltas** action:

- [Run from a workflow triggered by a `schedule` event](https://github.com/arduino/report-size-deltas#run-from-a-scheduled-workflow)
- [Run from the same workflow as the "arduino/compile-sketches" action when triggered by a `pull_request` event](https://github.com/arduino/report-size-deltas#run-from-the-same-workflow-as-the-arduinocompile-sketches-action)

The latter use pattern is only suitable for private repositories. The reason is that, when a pull request is submitted from a fork, the permissions of [the access token](https://docs.github.com/actions/security-guides/automatic-token-authentication) used by the **arduino/report-size-deltas** action are [downgraded to read-only in workflows triggered by a `pull_request` event](https://docs.github.com/actions/security-guides/automatic-token-authentication#permissions-for-the-github_token), which means it is unable to make the report comment.

The reverted commit migrated the size deltas report infrastructure from the first use pattern to the second, which caused the ["**Compile Examples**" workflow](https://github.com/arduino-libraries/ArduinoIoTCloud/blob/master/.github/workflows/compile-examples.yml) runs to fail on pull requests submitted from forks:

https://github.com/arduino-libraries/ArduinoIoTCloud/actions/runs/7985568163/job/21816272872?pr=427#step:4:18

```text
Error: HTTPError: HTTP Error 403: Forbidden
```

For this reason, the infrastructure must be reverted back to using the first use pattern.

## Fix Regression in Size Deltas Report Infrastructure Configuration

The [`sketches-reports-source` input](https://github.com/arduino/report-size-deltas#sketches-reports-source) of the **arduino/report-size-deltas** action defines the regular expression that matches the names of the sketches report workflow artifacts produced by the "**Compile Examples**" workflow.

The key string in the names of these artifacts was set to "sketches-report" when the "Compile Examples" workflow was adjusted for compatibility (https://github.com/arduino-libraries/ArduinoIoTCloud/pull/423) with the breaking changes introduced by updating to version 4.x of the workflow's **actions/upload-artifact** GitHub Actions action dependency (https://github.com/arduino-libraries/ArduinoIoTCloud/pull/419):

https://github.com/arduino-libraries/ArduinoIoTCloud/blob/836771a7a4a2d49758bf7e977f68fa2b124a5941/.github/workflows/compile-examples.yml#L303

The pattern set in the size deltas report workflow was "sketches-reports":

https://github.com/arduino-libraries/ArduinoIoTCloud/blob/c2a9992591cc2071e4a6221934aa73f4cc503404/.github/workflows/report-size-deltas.yml#L14

The `s` at the end of that pattern caused it to no longer match against the key string in the artifact names after that adjustment of the "**Compile Examples**" workflow, resulting in size deltas reports no longer being generated by the workflow.

Although a minimal fix would be to simply remove the `s` from the end of the pattern, the decision was made to use a more strict regular expression. This will make it easier for maintainers and contributors to understand that this value is a regular expression and the exact nature of how that regular expression functions (which is less clear when relying on the **arduino/report-size-deltas** action's [partial pattern matching behavior](https://docs.python.org/3.11/library/re.html#re.match)).