### PR TITLE
fix: Await Serial

### DIFF
--- a/examples/ArduinoIoTCloud-Advanced/ArduinoIoTCloud-Advanced.ino
+++ b/examples/ArduinoIoTCloud-Advanced/ArduinoIoTCloud-Advanced.ino
@@ -15,7 +15,7 @@
 void setup() {
   /* Initialize serial and wait up to 5 seconds for port to open */
   Serial.begin(9600);
-  for(unsigned long const serialBeginTime = millis(); !Serial && (millis() - serialBeginTime > 5000); ) { }
+  for(unsigned long const serialBeginTime = millis(); !Serial && (millis() - serialBeginTime <= 5000); ) { }
 
   /* This function takes care of connecting your sketch variables to the ArduinoIoTCloud object */
   initProperties();

--- a/examples/ArduinoIoTCloud-Basic/ArduinoIoTCloud-Basic.ino
+++ b/examples/ArduinoIoTCloud-Basic/ArduinoIoTCloud-Basic.ino
@@ -23,7 +23,7 @@ static int const LED_BUILTIN = 2;
 void setup() {
   /* Initialize serial and wait up to 5 seconds for port to open */
   Serial.begin(9600);
-  for(unsigned long const serialBeginTime = millis(); !Serial && (millis() - serialBeginTime > 5000); ) { }
+  for(unsigned long const serialBeginTime = millis(); !Serial && (millis() - serialBeginTime <= 5000); ) { }
 
   /* Configure LED pin as an output */
   pinMode(LED_BUILTIN, OUTPUT);

--- a/examples/ArduinoIoTCloud-Callbacks/ArduinoIoTCloud-Callbacks.ino
+++ b/examples/ArduinoIoTCloud-Callbacks/ArduinoIoTCloud-Callbacks.ino
@@ -8,7 +8,7 @@
 
   You don't need any specific Properties to be created in order to demonstrate these functionalities.
   Simply create a new Thing and give it 1 arbitrary Property.
-  Remember that the Thing ID needs to be configured in thingProperties.h 
+  Remember that the Thing ID needs to be configured in thingProperties.h
   These events can be very useful in particular cases, for instance to disable a peripheral
   or a connected sensor/actuator when no data connection is available, as well as to perform
   specific operations on connection or right after properties values are synchronised.
@@ -31,7 +31,7 @@
 void setup() {
   /* Initialize serial and wait up to 5 seconds for port to open */
   Serial.begin(9600);
-  for(unsigned long const serialBeginTime = millis(); !Serial && (millis() - serialBeginTime > 5000); ) { }
+  for(unsigned long const serialBeginTime = millis(); !Serial && (millis() - serialBeginTime <= 5000); ) { }
 
   /* This function takes care of connecting your sketch variables to the ArduinoIoTCloud object */
   initProperties();

--- a/examples/ArduinoIoTCloud-DeferredOTA/ArduinoIoTCloud-DeferredOTA.ino
+++ b/examples/ArduinoIoTCloud-DeferredOTA/ArduinoIoTCloud-DeferredOTA.ino
@@ -39,7 +39,7 @@ bool ask_user_via_serial() {
   if (Serial.available()) {
     char c = Serial.read();
     if (c == 'y' || c == 'Y') {
-      return true;  
+      return true;
     }
   }
   return false;
@@ -56,7 +56,7 @@ bool onOTARequestCallback()
 void setup() {
   /* Initialize serial and wait up to 5 seconds for port to open */
   Serial.begin(9600);
-  for(unsigned long const serialBeginTime = millis(); !Serial && (millis() - serialBeginTime > 5000); ) { }
+  for(unsigned long const serialBeginTime = millis(); !Serial && (millis() - serialBeginTime <= 5000); ) { }
 
   /* Configure LED pin as an output */
   pinMode(LED_BUILTIN, OUTPUT);

--- a/examples/ArduinoIoTCloud-Schedule/ArduinoIoTCloud-Schedule.ino
+++ b/examples/ArduinoIoTCloud-Schedule/ArduinoIoTCloud-Schedule.ino
@@ -15,7 +15,7 @@ static int const LED_BUILTIN = 2;
 void setup() {
   /* Initialize the serial port and wait up to 5 seconds for a connection */
   Serial.begin(9600);
-  for(unsigned long const serialBeginTime = millis(); !Serial && (millis() - serialBeginTime > 5000); ) { }
+  for(unsigned long const serialBeginTime = millis(); !Serial && (millis() - serialBeginTime <= 5000); ) { }
 
   /* Configure LED pin as an output */
   pinMode(LED_BUILTIN, OUTPUT);
@@ -206,7 +206,7 @@ void loop() {
   if(daily.isActive()) {
     Serial.println("Daily schedule is active");
   }
-  
+
   /* Activate LED when the weekly schedule is active */
   digitalWrite(LED_BUILTIN, weekly.isActive());
 

--- a/examples/utility/ArduinoIoTCloud_Travis_CI/ArduinoIoTCloud_Travis_CI.ino
+++ b/examples/utility/ArduinoIoTCloud_Travis_CI/ArduinoIoTCloud_Travis_CI.ino
@@ -18,7 +18,7 @@ void setup() {
 
   Serial.begin(9600);
   unsigned long serialBeginTime = millis();
-  while (!Serial && (millis() - serialBeginTime > 5000));
+  while (!Serial && (millis() - serialBeginTime <= 5000));
 
   Serial.println("Starting Arduino IoT Cloud Example");
 


### PR DESCRIPTION
Previous implementation was attempting to wait while "Serial was NOT ready" AND "time passed is GREATER than 5 seconds".

This can NEVER be true. Early logs were being missed and Serial had difficulty connecting during debugging.

It should have instead been waiting while "Serial was NOT ready" AND "time passed is LESS THAN OR EQUAL TO 5 seconds".