### PR TITLE
LPWAN: fix property container initialization

### DIFF
--- a/src/ArduinoIoTCloudLPWAN.cpp
+++ b/src/ArduinoIoTCloudLPWAN.cpp
@@ -51,7 +51,7 @@ ArduinoIoTCloudLPWAN::ArduinoIoTCloudLPWAN()
 , _retryEnable{false}
 , _maxNumRetry{5}
 , _intervalRetry{AIOT_CONFIG_INTERVAL_RETRY_DELAY_ms}
-, _thing_property_container{0}
+, _thing_property_container()
 , _last_checked_property_index{0}
 {
 


### PR DESCRIPTION
This PR fixes a bug introduced in https://github.com/arduino-libraries/ArduinoIoTCloud/pull/442

For TCP implementation the bug was already unintentionally fixed with https://github.com/arduino-libraries/ArduinoIoTCloud/pull/445 and https://github.com/arduino-libraries/ArduinoIoTCloud/pull/444