### PR TITLE
ArduinoIoTCloudDevice: add missing initializers

### DIFF
--- a/src/ArduinoIoTCloudDevice.cpp
+++ b/src/ArduinoIoTCloudDevice.cpp
@@ -26,6 +26,8 @@ ArduinoCloudDevice::ArduinoCloudDevice(MessageStream *ms)
 : CloudProcess(ms),
 _state{State::Init},
 _attachAttempt(0, 0),
+_propertyContainer(),
+_propertyContainerIndex(0),
 _attached(false),
 _registered(false) {
 }

--- a/src/ArduinoIoTCloudThing.cpp
+++ b/src/ArduinoIoTCloudThing.cpp
@@ -29,7 +29,7 @@ ArduinoCloudThing::ArduinoCloudThing(MessageStream* ms)
 : CloudProcess(ms),
 _state{State::Init},
 _syncAttempt(0, 0),
-_propertyContainer(0),
+_propertyContainer(),
 _propertyContainerIndex(0),
 _utcOffset(0),
 _utcOffsetProperty(nullptr),


### PR DESCRIPTION
Working on #457 i noticed two missing initializers in device class