### PR TITLE
Avoid using memcpy to store timezone data

### DIFF
--- a/src/ArduinoIoTCloudThing.h
+++ b/src/ArduinoIoTCloudThing.h
@@ -51,7 +51,7 @@ private:
   };
 
   State _state;
-  CommandDown _command;
+  CommandId _command;
   TimedAttempt _syncAttempt;
   PropertyContainer _propertyContainer;
   unsigned int _propertyContainerIndex;


### PR DESCRIPTION
Fix bug introduced in #451 causing a board reset when `ResetCmdId` is sent to thing process handling a disconnection.