### PR TITLE
Watchdog: use mbed API

### DIFF
--- a/src/ota/implementation/OTANanoRP2040.cpp
+++ b/src/ota/implementation/OTANanoRP2040.cpp
@@ -83,8 +83,6 @@ OTACloudProcessInterface::State NANO_RP2040OTACloudProcess::flashOTA() {
 }
 
 OTACloudProcessInterface::State NANO_RP2040OTACloudProcess::reboot() {
-  mbed_watchdog_trigger_reset();
-  /* If watchdog is enabled we should not reach this point */
   NVIC_SystemReset();
 
   return Resume; // This won't ever be reached

--- a/src/utility/watchdog/Watchdog.cpp
+++ b/src/utility/watchdog/Watchdog.cpp
@@ -131,21 +131,6 @@ static void mbed_watchdog_enable_network_feed(NetworkAdapter ni)
 #endif
   }
 }
-
-void mbed_watchdog_trigger_reset()
-{
-  watchdog_config_t cfg;
-  cfg.timeout_ms = 1;
-
-  if (hal_watchdog_init(&cfg) == WATCHDOG_STATUS_OK) {
-    is_watchdog_enabled = true;
-    while(1){}
-  }
-  else {
-    DEBUG_WARNING("%s: watchdog could not be reconfigured", __FUNCTION__);
-  }
-
-}
 #endif /* ARDUINO_ARCH_MBED */
 
 #if defined (ARDUINO_ARCH_SAMD) || defined (ARDUINO_ARCH_MBED)

--- a/src/utility/watchdog/Watchdog.cpp
+++ b/src/utility/watchdog/Watchdog.cpp
@@ -33,7 +33,7 @@
 #endif /* ARDUINO_ARCH_SAMD */
 
 #ifdef ARDUINO_ARCH_MBED
-#  include <watchdog_api.h>
+#  include <drivers/Watchdog.h>
 #  define PORTENTA_H7_WATCHDOG_MAX_TIMEOUT_ms  (32760)
 #  define NANO_RP2040_WATCHDOG_MAX_TIMEOUT_ms  (8389)
 #  define EDGE_CONTROL_WATCHDOG_MAX_TIMEOUT_ms (65536)
@@ -42,7 +42,7 @@
 /******************************************************************************
  * GLOBAL VARIABLES
  ******************************************************************************/
-#if defined(ARDUINO_ARCH_SAMD) || defined(ARDUINO_ARCH_MBED)
+#if defined(ARDUINO_ARCH_SAMD)
 static bool is_watchdog_enabled = false;
 #endif
 
@@ -96,18 +96,15 @@ static void mbed_watchdog_enable()
 # error "You need to define the maximum possible timeout for this architecture."
 #endif
 
-  if (hal_watchdog_init(&cfg) == WATCHDOG_STATUS_OK) {
-    is_watchdog_enabled = true;
-  }
-  else {
+  if (!mbed::Watchdog::get_instance().start(cfg.timeout_ms)) {
     DEBUG_WARNING("%s: watchdog could not be enabled", __FUNCTION__);
   }
 }
 
 static void mbed_watchdog_reset()
 {
-  if (is_watchdog_enabled) {
-    hal_watchdog_kick();
+  if (mbed::Watchdog::get_instance().is_running()) {
+    mbed::Watchdog::get_instance().kick();
   }
 }
 

--- a/src/utility/watchdog/Watchdog.h
+++ b/src/utility/watchdog/Watchdog.h
@@ -34,8 +34,4 @@ void watchdog_reset();
 void watchdog_enable_network_feed(NetworkAdapter ni);
 #endif /* (ARDUINO_ARCH_SAMD) || (ARDUINO_ARCH_MBED) */
 
-#ifdef ARDUINO_ARCH_MBED
-void mbed_watchdog_trigger_reset();
-#endif /* ARDUINO_ARCH_MBED */
-
 #endif /* ARDUINO_AIOTC_UTILITY_WATCHDOG_H_ */


### PR DESCRIPTION
This is needed to allow ArduinoCellular library to kick the watchdog without using callback 