### PR TITLE
fix: infinite disconnect loop

### DIFF
--- a/src/ArduinoIoTCloudTCP.cpp
+++ b/src/ArduinoIoTCloudTCP.cpp
@@ -346,9 +346,14 @@ ArduinoIoTCloudTCP::State ArduinoIoTCloudTCP::handle_Disconnect()
     _mqttClient.stop();
   }
 
+  // Reset the Thing property container
   Message message = { ResetCmdId };
   _thing.handleMessage(&message);
+  _thing.update();
+
+  // Reset the Device property container
   _device.handleMessage(&message);
+  _device.update();
 
   DEBUG_INFO("Disconnected from Arduino IoT Cloud");
   execCloudEventCallback(ArduinoIoTCloudEvent::DISCONNECT);


### PR DESCRIPTION
When a disconnect occurs, a reset message is provided to both the `_thing` and `_device` containers, but there is no subsequent call to `_thing.update()` or `_device.update()` to process the message and actually reset the state.

This results in an infinite loop, because `!_device.connected()` (i.e. not not disconnected) will ALWAYS remain `true`.

This seems like the appropriate place for the call to `update()`, because `ResetCmdId` puts the `_device` and `_thing` containers into their disconnected state then `update()` processes the disconnect and restores them to their initialization state (same state that results from `begin()` just before we enter the state machine).