### PR TITLE
ci: align esp32 core to the one installed on Arduino cloud web editor

### DIFF
--- a/.github/workflows/compile-examples.yml
+++ b/.github/workflows/compile-examples.yml
@@ -254,6 +254,7 @@ jobs:
               # Install ESP32 platform via Boards Manager
               - name: esp32:esp32
                 source-url: https://raw.githubusercontent.com/espressif/arduino-esp32/gh-pages/package_esp32_index.json
+                version: 2.0.17
             sketch-paths: |
               - examples/ArduinoIoTCloud-DeferredOTA
 


### PR DESCRIPTION
Latest esp32 core release [3.0.4](https://github.com/espressif/arduino-esp32/releases/tag/3.0.4) has introduced a breking change about certificate bundle loading https://github.com/espressif/arduino-esp32/pull/10101

Using 2.0.17 will fix the ci issue and aligns with the core installed on the Arduino web editor