### PR TITLE
OTA: chunked download

### DIFF
--- a/src/ArduinoIoTCloudTCP.cpp
+++ b/src/ArduinoIoTCloudTCP.cpp
@@ -168,9 +168,6 @@ int ArduinoIoTCloudTCP::begin(bool const enable_watchdog, String brokerAddress, 
 
 #if OTA_ENABLED && !defined(OFFLOADED_DOWNLOAD)
   _ota.setClient(&_otaClient);
-  if (_connection->getInterface() == NetworkAdapter::ETHERNET) {
-    _ota.setFetchMode(OTADefaultCloudProcessInterface::OtaFetchChunk);
-  }
 #endif // OTA_ENABLED && !defined(OFFLOADED_DOWNLOAD)
 
 #if OTA_ENABLED && defined(OTA_BASIC_AUTH)

--- a/src/ArduinoIoTCloudTCP.cpp
+++ b/src/ArduinoIoTCloudTCP.cpp
@@ -168,6 +168,9 @@ int ArduinoIoTCloudTCP::begin(bool const enable_watchdog, String brokerAddress, 
 
 #if OTA_ENABLED && !defined(OFFLOADED_DOWNLOAD)
   _ota.setClient(&_otaClient);
+  if (_connection->getInterface() == NetworkAdapter::ETHERNET) {
+    _ota.setFetchMode(OTADefaultCloudProcessInterface::OtaFetchChunk);
+  }
 #endif // OTA_ENABLED && !defined(OFFLOADED_DOWNLOAD)
 
 #if OTA_ENABLED && defined(OTA_BASIC_AUTH)

--- a/src/ArduinoIoTCloudTCP.h
+++ b/src/ArduinoIoTCloudTCP.h
@@ -105,9 +105,9 @@ class ArduinoIoTCloudTCP: public ArduinoIoTCloudClass
     /* Slower but more reliable in some corner cases */
     void setOTAChunkMode(bool enable = true) {
       if(enable) {
-        _ota.enableOtaPolicy(OTADefaultCloudProcessInterface::ChunkDownload);
+        _ota.enableOtaPolicy(OTACloudProcessInterface::ChunkDownload);
       } else {
-        _ota.disableOtaPolicy(OTADefaultCloudProcessInterface::ChunkDownload);
+        _ota.disableOtaPolicy(OTACloudProcessInterface::ChunkDownload);
       }
     }
 #endif

--- a/src/ArduinoIoTCloudTCP.h
+++ b/src/ArduinoIoTCloudTCP.h
@@ -101,6 +101,15 @@ class ArduinoIoTCloudTCP: public ArduinoIoTCloudClass
         _ota.setOtaPolicies(OTACloudProcessInterface::None);
       }
     }
+
+    /* Slower but more reliable in some corner cases */
+    void setOTAChunkMode(bool enable = true) {
+      if(enable) {
+        _ota.setFetchMode(OTADefaultCloudProcessInterface::OtaFetchChunk);
+      } else {
+        _ota.setFetchMode(OTADefaultCloudProcessInterface::OtaFetchTime);
+      }
+    }
 #endif
 
   private:

--- a/src/ArduinoIoTCloudTCP.h
+++ b/src/ArduinoIoTCloudTCP.h
@@ -96,9 +96,9 @@ class ArduinoIoTCloudTCP: public ArduinoIoTCloudClass
       _get_ota_confirmation = cb;
 
       if(_get_ota_confirmation) {
-        _ota.setOtaPolicies(OTACloudProcessInterface::ApprovalRequired);
+        _ota.enableOtaPolicy(OTACloudProcessInterface::ApprovalRequired);
       } else {
-        _ota.setOtaPolicies(OTACloudProcessInterface::None);
+        _ota.disableOtaPolicy(OTACloudProcessInterface::ApprovalRequired);
       }
     }
 

--- a/src/ArduinoIoTCloudTCP.h
+++ b/src/ArduinoIoTCloudTCP.h
@@ -105,9 +105,9 @@ class ArduinoIoTCloudTCP: public ArduinoIoTCloudClass
     /* Slower but more reliable in some corner cases */
     void setOTAChunkMode(bool enable = true) {
       if(enable) {
-        _ota.setFetchMode(OTADefaultCloudProcessInterface::OtaFetchChunk);
+        _ota.enableOtaPolicy(OTADefaultCloudProcessInterface::ChunkDownload);
       } else {
-        _ota.setFetchMode(OTADefaultCloudProcessInterface::OtaFetchTime);
+        _ota.disableOtaPolicy(OTADefaultCloudProcessInterface::ChunkDownload);
       }
     }
 #endif

--- a/src/ota/interface/OTAInterface.cpp
+++ b/src/ota/interface/OTAInterface.cpp
@@ -167,10 +167,10 @@ OTACloudProcessInterface::State OTACloudProcessInterface::idle(Message* msg) {
 OTACloudProcessInterface::State OTACloudProcessInterface::otaAvailable() {
   // depending on the policy decided on this device the ota process can start immediately
   // or wait for confirmation from the user
-  if((policies & (ApprovalRequired | Approved)) == ApprovalRequired ) {
+  if(getOtaPolicy(ApprovalRequired) && !getOtaPolicy(Approved)) {
     return OtaAvailable;
   } else {
-    policies &= ~Approved;
+    disableOtaPolicy(Approved);
     return StartOTA;
   } // TODO add an abortOTA command? in this case delete the context
 }

--- a/src/ota/interface/OTAInterface.h
+++ b/src/ota/interface/OTAInterface.h
@@ -80,7 +80,8 @@ public:
   enum OtaFlags: uint16_t {
     None              = 0,
     ApprovalRequired  = 1,
-    Approved          = 1<<1
+    Approved          = 1<<1,
+    ChunkDownload     = 1<<2
   };
 
   virtual void handleMessage(Message*);

--- a/src/ota/interface/OTAInterface.h
+++ b/src/ota/interface/OTAInterface.h
@@ -88,8 +88,12 @@ public:
   // virtual void hook(State s, void* action);
   virtual void update() { handleMessage(nullptr); }
 
-  inline void approveOta()                      { policies |= Approved; }
+  inline void approveOta()                      { this->policies |= Approved; }
   inline void setOtaPolicies(uint16_t policies) { this->policies = policies; }
+
+  inline void enableOtaPolicy(OtaFlags policyFlag)  { this->policies |= policyFlag; }
+  inline void disableOtaPolicy(OtaFlags policyFlag) { this->policies &= ~policyFlag; }
+  inline bool getOtaPolicy(OtaFlags policyFlag)     { return (this->policies & policyFlag) != 0;}
 
   inline State getState() { return state; }
 

--- a/src/ota/interface/OTAInterfaceDefault.cpp
+++ b/src/ota/interface/OTAInterfaceDefault.cpp
@@ -161,7 +161,7 @@ OTACloudProcessInterface::State OTADefaultCloudProcessInterface::requestOta(OtaF
   if((mode & ChunkDownload) == ChunkDownload) {
     char range[128] = {0};
     size_t rangeSize = context->downloadedSize + maxChunkSize > context->contentLength ? context->contentLength - context->downloadedSize : maxChunkSize;
-    sprintf(range, "bytes=%lu-%lu", context->downloadedSize, context->downloadedSize + rangeSize);
+    sprintf(range, "bytes=%" PRIu32 "-%" PRIu32, context->downloadedSize, context->downloadedSize + rangeSize);
     DEBUG_VERBOSE("OTA downloading range: %s", range);
     http_client->sendHeader("Range", range);
   }

--- a/src/ota/interface/OTAInterfaceDefault.cpp
+++ b/src/ota/interface/OTAInterfaceDefault.cpp
@@ -90,6 +90,18 @@ OTACloudProcessInterface::State OTADefaultCloudProcessInterface::startOTA() {
 }
 
 OTACloudProcessInterface::State OTADefaultCloudProcessInterface::fetch() {
+  if(downloadTime > 0) {
+    return fetchTime();
+  } else {
+    return fetchChunk();
+  }
+}
+
+OTACloudProcessInterface::State OTADefaultCloudProcessInterface::fetchChunk() {
+  return OtaDownloadFail;
+}
+
+OTACloudProcessInterface::State OTADefaultCloudProcessInterface::fetchTime() {
   OTACloudProcessInterface::State res = Fetch;
   int http_res = 0;
   uint32_t start = millis();

--- a/src/ota/interface/OTAInterfaceDefault.cpp
+++ b/src/ota/interface/OTAInterfaceDefault.cpp
@@ -55,12 +55,12 @@ OTACloudProcessInterface::State OTADefaultCloudProcessInterface::startOTA() {
   }
 
   // The following call is required to save the header value , keep it
-  context->contentLength = http_client->contentLength();
-  if(context->contentLength == HttpClient::kNoContentLengthHeader) {
+  if(http_client->contentLength() == HttpClient::kNoContentLengthHeader) {
     DEBUG_VERBOSE("OTA ERROR: the response header doesn't contain \"ContentLength\" field");
     return HttpHeaderErrorFail;
   }
 
+  context->contentLength = http_client->contentLength();
   context->lastReportTime = millis();
   DEBUG_VERBOSE("OTA file length: %d", context->contentLength);
   return Fetch;

--- a/src/ota/interface/OTAInterfaceDefault.cpp
+++ b/src/ota/interface/OTAInterfaceDefault.cpp
@@ -20,6 +20,7 @@ OTADefaultCloudProcessInterface::OTADefaultCloudProcessInterface(MessageStream *
 , client(client)
 , http_client(nullptr)
 , username(nullptr), password(nullptr)
+, fetchMode(OtaFetchTime)
 , context(nullptr) {
 }
 
@@ -85,12 +86,13 @@ OTACloudProcessInterface::State OTADefaultCloudProcessInterface::startOTA() {
   }
 
   context->lastReportTime = millis();
+  DEBUG_VERBOSE("OTA file length: %d", context->contentLength);
 
   return Fetch;
 }
 
 OTACloudProcessInterface::State OTADefaultCloudProcessInterface::fetch() {
-  if(downloadTime > 0) {
+  if(fetchMode == OtaFetchTime) {
     return fetchTime();
   } else {
     return fetchChunk();

--- a/src/ota/interface/OTAInterfaceDefault.cpp
+++ b/src/ota/interface/OTAInterfaceDefault.cpp
@@ -92,59 +92,20 @@ OTACloudProcessInterface::State OTADefaultCloudProcessInterface::startOTA() {
 }
 
 OTACloudProcessInterface::State OTADefaultCloudProcessInterface::fetch() {
-  if(fetchMode == OtaFetchTime) {
-    return fetchTime();
-  } else {
-    return fetchChunk();
-  }
-}
-
-OTACloudProcessInterface::State OTADefaultCloudProcessInterface::fetchChunk() {
   OTACloudProcessInterface::State res = Fetch;
-  int http_res = 0;
-  uint32_t start = millis();
-  char range[128] = {0};
 
-  /* stop connected client */
-  http_client->stop();
-
-  /* request chunk */
-  http_client->beginRequest();
-  http_res = http_client->get(context->parsed_url.path());
-
-  if(username != nullptr && password != nullptr) {
-    http_client->sendBasicAuth(username, password);
+  if(fetchMode == OtaFetchChunk) {
+    res = requestChunk();
   }
 
-  size_t rangeSize = context->downloadedSize + context->maxChunkSize > context->contentLength ? context->contentLength - context->downloadedSize : context->maxChunkSize;
-  sprintf(range, "bytes=%d-%d", context->downloadedSize, context->downloadedSize + rangeSize);
-  DEBUG_VERBOSE("OTA downloading range: %s", range);
-  http_client->sendHeader("Range", range);
-  http_client->endRequest();
-
-  if(http_res == HTTP_ERROR_CONNECTION_FAILED) {
-    DEBUG_VERBOSE("OTA ERROR: http client error connecting to server \"%s:%d\"",
-      context->parsed_url.host(), context->parsed_url.port());
-    return ServerConnectErrorFail;
-  } else if(http_res == HTTP_ERROR_TIMED_OUT) {
-    DEBUG_VERBOSE("OTA ERROR: http client timeout \"%s\"", OTACloudProcessInterface::context->url);
-    return OtaHeaderTimeoutFail;
-  } else if(http_res != HTTP_SUCCESS) {
-    DEBUG_VERBOSE("OTA ERROR: http client returned %d on  get \"%s\"", res, OTACloudProcessInterface::context->url);
-    return OtaDownloadFail;
-  }
-
-  int statusCode = http_client->responseStatusCode();
-
-  if(statusCode != 206) {
-    DEBUG_VERBOSE("OTA ERROR: get response on \"%s\" returned status %d", OTACloudProcessInterface::context->url, statusCode);
-    return HttpResponseFail;
-  }
-
-  http_client->skipResponseHeaders();
-
-  /* download chunk */
   context->downloadedChunkSize = 0;
+  context->downloadedChunkStartTime = millis();
+
+  if(res != Fetch) {
+    goto exit;
+  }
+
+  /* download chunked or timed  */
   do {
     if(!http_client->connected()) {
       res = OtaDownloadFail;
@@ -157,7 +118,7 @@ OTACloudProcessInterface::State OTADefaultCloudProcessInterface::fetchChunk() {
       continue;
     }
 
-    http_res = http_client->read(context->buffer, context->bufLen);
+    int http_res = http_client->read(context->buffer, context->bufLen);
 
     if(http_res < 0) {
       DEBUG_VERBOSE("OTA ERROR: Download read error %d", http_res);
@@ -175,8 +136,7 @@ OTACloudProcessInterface::State OTADefaultCloudProcessInterface::fetchChunk() {
 
     context->downloadedChunkSize += http_res;
 
-  } while((context->downloadState == OtaDownloadFile || context->downloadState == OtaDownloadHeader) &&
-          (context->downloadedChunkSize < rangeSize));
+  } while(context->downloadState < OtaDownloadCompleted && fetchMore());
 
   // TODO verify that the information present in the ota header match the info in context
   if(context->downloadState == OtaDownloadCompleted) {
@@ -209,70 +169,58 @@ exit:
   return res;
 }
 
-OTACloudProcessInterface::State OTADefaultCloudProcessInterface::fetchTime() {
-  OTACloudProcessInterface::State res = Fetch;
+OTACloudProcessInterface::State OTADefaultCloudProcessInterface::requestChunk() {
   int http_res = 0;
   uint32_t start = millis();
+  char range[128] = {0};
 
-  do {
-    if(!http_client->connected()) {
-      res = OtaDownloadFail;
-      goto exit;
-    }
+  /* stop connected client */
+  http_client->stop();
 
-    if(http_client->available() == 0) {
-      /* Avoid tight loop and allow yield */
-      delay(1);
-      continue;
-    }
+  /* request chunk */
+  http_client->beginRequest();
+  http_res = http_client->get(context->parsed_url.path());
 
-    http_res = http_client->read(context->buffer, context->bufLen);
-
-    if(http_res < 0) {
-      DEBUG_VERBOSE("OTA ERROR: Download read error %d", http_res);
-      res = OtaDownloadFail;
-      goto exit;
-    }
-
-    parseOta(context->buffer, http_res);
-
-    if(context->writeError) {
-      DEBUG_VERBOSE("OTA ERROR: File write error");
-      res = ErrorWriteUpdateFileFail;
-      goto exit;
-    }
-  } while((context->downloadState == OtaDownloadFile || context->downloadState == OtaDownloadHeader) &&
-    millis() - start < downloadTime);
-
-  // TODO verify that the information present in the ota header match the info in context
-  if(context->downloadState == OtaDownloadCompleted) {
-    // Verify that the downloaded file size is matching the expected size ??
-    // this could distinguish between consistency of the downloaded bytes and filesize
-
-    // validate CRC
-    context->calculatedCrc32 ^= 0xFFFFFFFF; // finalize CRC
-    if(context->header.header.crc32 == context->calculatedCrc32) {
-      DEBUG_VERBOSE("Ota download completed successfully");
-      res = FlashOTA;
-    } else {
-      res = OtaHeaderCrcFail;
-    }
-  } else if(context->downloadState == OtaDownloadError) {
-    DEBUG_VERBOSE("OTA ERROR: OtaDownloadError");
-
-    res = OtaDownloadFail;
-  } else if(context->downloadState == OtaDownloadMagicNumberMismatch) {
-    DEBUG_VERBOSE("OTA ERROR: Magic number mismatch");
-    res = OtaHeaderMagicNumberFail;
+  if(username != nullptr && password != nullptr) {
+    http_client->sendBasicAuth(username, password);
   }
 
-exit:
-  if(res != Fetch) {
-    http_client->stop(); // close the connection
-    delete http_client;
-    http_client = nullptr;
+  size_t rangeSize = context->downloadedSize + maxChunkSize > context->contentLength ? context->contentLength - context->downloadedSize : maxChunkSize;
+  sprintf(range, "bytes=%d-%d", context->downloadedSize, context->downloadedSize + rangeSize);
+  DEBUG_VERBOSE("OTA downloading range: %s", range);
+  http_client->sendHeader("Range", range);
+  http_client->endRequest();
+
+  if(http_res == HTTP_ERROR_CONNECTION_FAILED) {
+    DEBUG_VERBOSE("OTA ERROR: http client error connecting to server \"%s:%d\"",
+      context->parsed_url.host(), context->parsed_url.port());
+    return ServerConnectErrorFail;
+  } else if(http_res == HTTP_ERROR_TIMED_OUT) {
+    DEBUG_VERBOSE("OTA ERROR: http client timeout \"%s\"", OTACloudProcessInterface::context->url);
+    return OtaHeaderTimeoutFail;
+  } else if(http_res != HTTP_SUCCESS) {
+    DEBUG_VERBOSE("OTA ERROR: http client returned %d on  get \"%s\"", http_res, OTACloudProcessInterface::context->url);
+    return OtaDownloadFail;
   }
-  return res;
+
+  int statusCode = http_client->responseStatusCode();
+
+  if(statusCode != 206) {
+    DEBUG_VERBOSE("OTA ERROR: get response on \"%s\" returned status %d", OTACloudProcessInterface::context->url, statusCode);
+    return HttpResponseFail;
+  }
+
+  http_client->skipResponseHeaders();
+
+  return Fetch;
+}
+
+bool OTADefaultCloudProcessInterface::fetchMore() {
+  if (fetchMode == OtaFetchChunk) {
+    return context->downloadedChunkSize < maxChunkSize;
+  } else {
+    return (millis() - context->downloadedChunkStartTime) < downloadTime;
+  }
 }
 
 void OTADefaultCloudProcessInterface::parseOta(uint8_t* buffer, size_t bufLen) {

--- a/src/ota/interface/OTAInterfaceDefault.cpp
+++ b/src/ota/interface/OTAInterfaceDefault.cpp
@@ -104,7 +104,7 @@ OTACloudProcessInterface::State OTADefaultCloudProcessInterface::fetch() {
       continue;
     }
 
-    http_res = http_client->read(context->buffer, context->buf_len);
+    http_res = http_client->read(context->buffer, context->bufLen);
 
     if(http_res < 0) {
       DEBUG_VERBOSE("OTA ERROR: Download read error %d", http_res);
@@ -153,13 +153,13 @@ exit:
   return res;
 }
 
-void OTADefaultCloudProcessInterface::parseOta(uint8_t* buffer, size_t buf_len) {
+void OTADefaultCloudProcessInterface::parseOta(uint8_t* buffer, size_t bufLen) {
   assert(context != nullptr); // This should never fail
 
-  for(uint8_t* cursor=(uint8_t*)buffer; cursor<buffer+buf_len; ) {
+  for(uint8_t* cursor=(uint8_t*)buffer; cursor<buffer+bufLen; ) {
     switch(context->downloadState) {
     case OtaDownloadHeader: {
-      const uint32_t headerLeft = context->headerCopiedBytes + buf_len <= sizeof(context->header.buf) ? buf_len : sizeof(context->header.buf) - context->headerCopiedBytes;
+      const uint32_t headerLeft = context->headerCopiedBytes + bufLen <= sizeof(context->header.buf) ? bufLen : sizeof(context->header.buf) - context->headerCopiedBytes;
       memcpy(context->header.buf+context->headerCopiedBytes, buffer, headerLeft);
       cursor += headerLeft;
       context->headerCopiedBytes += headerLeft;
@@ -185,7 +185,7 @@ void OTADefaultCloudProcessInterface::parseOta(uint8_t* buffer, size_t buf_len) 
     }
     case OtaDownloadFile: {
       const uint32_t contentLength = http_client->contentLength();
-      const uint32_t dataLeft = buf_len - (cursor-buffer);
+      const uint32_t dataLeft = bufLen - (cursor-buffer);
       context->decoder.decompress(cursor, dataLeft); // TODO verify return value
 
       context->calculatedCrc32 = crc_update(

--- a/src/ota/interface/OTAInterfaceDefault.cpp
+++ b/src/ota/interface/OTAInterfaceDefault.cpp
@@ -50,7 +50,10 @@ OTACloudProcessInterface::State OTADefaultCloudProcessInterface::startOTA() {
   }
 
   // make the http get request
-  requestOta(OtaFetchTime);
+  OTACloudProcessInterface::State res = requestOta(OtaFetchTime);
+  if(res != Fetch) {
+    return res;
+  }
 
   // The following call is required to save the header value , keep it
   context->contentLength = http_client->contentLength();

--- a/src/ota/interface/OTAInterfaceDefault.cpp
+++ b/src/ota/interface/OTAInterfaceDefault.cpp
@@ -161,7 +161,7 @@ OTACloudProcessInterface::State OTADefaultCloudProcessInterface::requestOta(OtaF
   if((mode & ChunkDownload) == ChunkDownload) {
     char range[128] = {0};
     size_t rangeSize = context->downloadedSize + maxChunkSize > context->contentLength ? context->contentLength - context->downloadedSize : maxChunkSize;
-    sprintf(range, "bytes=%d-%d", context->downloadedSize, context->downloadedSize + rangeSize);
+    sprintf(range, "bytes=%lu-%lu", context->downloadedSize, context->downloadedSize + rangeSize);
     DEBUG_VERBOSE("OTA downloading range: %s", range);
     http_client->sendHeader("Range", range);
   }

--- a/src/ota/interface/OTAInterfaceDefault.h
+++ b/src/ota/interface/OTAInterfaceDefault.h
@@ -35,13 +35,6 @@ public:
     this->password = password;
   }
 
-  enum OTAFetchMode: uint8_t {
-    OtaFetchTime,
-    OtaFetchChunk
-  };
-
-  inline virtual void setFetchMode(OTAFetchMode mode) { this->fetchMode = mode; }
-
 protected:
   State startOTA();
   State fetch();
@@ -50,19 +43,20 @@ protected:
 
 private:
   void parseOta(uint8_t* buffer, size_t bufLen);
-  State requestOta(OTAFetchMode mode);
+  State requestOta(OtaFlags mode = None);
   bool fetchMore();
 
   Client*     client;
   HttpClient* http_client;
 
   const char *username, *password;
-  OTAFetchMode fetchMode;
 
   // The amount of time that each iteration of Fetch has to take at least
   // This mitigate the issues arising from tasks run in main loop that are using all the computing time
   static constexpr uint32_t downloadTime = 2000;
 
+  // The amount of data that each iteration of Fetch has to take at least
+  // This should be enabled setting ChunkDownload OtaFlag to 1 and mitigate some Ota corner cases
   static constexpr size_t maxChunkSize = 1024 * 10;
 
   enum OTADownloadState: uint8_t {

--- a/src/ota/interface/OTAInterfaceDefault.h
+++ b/src/ota/interface/OTAInterfaceDefault.h
@@ -50,7 +50,7 @@ protected:
 
 private:
   void parseOta(uint8_t* buffer, size_t bufLen);
-  State requestChunk();
+  State requestOta(OTAFetchMode mode);
   bool fetchMore();
 
   Client*     client;

--- a/src/ota/interface/OTAInterfaceDefault.h
+++ b/src/ota/interface/OTAInterfaceDefault.h
@@ -35,6 +35,13 @@ public:
     this->password = password;
   }
 
+  enum OTAFetchMode: uint8_t {
+    OtaFetchTime,
+    OtaFetchChunk
+  };
+
+  inline virtual void setFetchMode(OTAFetchMode mode) { this->fetchMode = mode; }
+
 protected:
   State startOTA();
   State fetch();
@@ -50,6 +57,7 @@ private:
   HttpClient* http_client;
 
   const char *username, *password;
+  OTAFetchMode fetchMode;
 
   // The amount of time that each iteration of Fetch has to take at least
   // This mitigate the issues arising from tasks run in main loop that are using all the computing time

--- a/src/ota/interface/OTAInterfaceDefault.h
+++ b/src/ota/interface/OTAInterfaceDefault.h
@@ -43,6 +43,8 @@ protected:
 
 private:
   void parseOta(uint8_t* buffer, size_t bufLen);
+  State fetchTime();
+  State fetchChunk();
 
   Client*     client;
   HttpClient* http_client;

--- a/src/ota/interface/OTAInterfaceDefault.h
+++ b/src/ota/interface/OTAInterfaceDefault.h
@@ -50,8 +50,8 @@ protected:
 
 private:
   void parseOta(uint8_t* buffer, size_t bufLen);
-  State fetchTime();
-  State fetchChunk();
+  State requestChunk();
+  bool fetchMore();
 
   Client*     client;
   HttpClient* http_client;
@@ -62,6 +62,8 @@ private:
   // The amount of time that each iteration of Fetch has to take at least
   // This mitigate the issues arising from tasks run in main loop that are using all the computing time
   static constexpr uint32_t downloadTime = 2000;
+
+  static constexpr size_t maxChunkSize = 1024 * 10;
 
   enum OTADownloadState: uint8_t {
     OtaDownloadHeader,
@@ -87,8 +89,8 @@ protected:
     uint32_t          contentLength;
     bool              writeError;
 
+    uint32_t          downloadedChunkStartTime;
     uint32_t          downloadedChunkSize;
-    static constexpr size_t maxChunkSize = 1024 * 10;
 
     // LZSS decoder
     LZSSDecoder       decoder;

--- a/src/ota/interface/OTAInterfaceDefault.h
+++ b/src/ota/interface/OTAInterfaceDefault.h
@@ -79,6 +79,9 @@ protected:
     uint32_t          contentLength;
     bool              writeError;
 
+    uint32_t          downloadedChunkSize;
+    static constexpr size_t maxChunkSize = 1024 * 10;
+
     // LZSS decoder
     LZSSDecoder       decoder;
 

--- a/src/ota/interface/OTAInterfaceDefault.h
+++ b/src/ota/interface/OTAInterfaceDefault.h
@@ -42,7 +42,7 @@ protected:
   virtual int writeFlash(uint8_t* const buffer, size_t len) = 0;
 
 private:
-  void parseOta(uint8_t* buffer, size_t buf_len);
+  void parseOta(uint8_t* buffer, size_t bufLen);
 
   Client*     client;
   HttpClient* http_client;
@@ -79,7 +79,7 @@ protected:
     // LZSS decoder
     LZSSDecoder       decoder;
 
-    const size_t buf_len = 64;
+    const size_t bufLen = 64;
     uint8_t buffer[64];
   } *context;
 };

--- a/src/ota/interface/OTAInterfaceDefault.h
+++ b/src/ota/interface/OTAInterfaceDefault.h
@@ -74,6 +74,7 @@ protected:
     uint32_t          headerCopiedBytes;
     uint32_t          downloadedSize;
     uint32_t          lastReportTime;
+    uint32_t          contentLength;
     bool              writeError;
 
     // LZSS decoder

--- a/src/ota/interface/OTAInterfaceDefault.h
+++ b/src/ota/interface/OTAInterfaceDefault.h
@@ -89,8 +89,8 @@ protected:
     // LZSS decoder
     LZSSDecoder       decoder;
 
-    const size_t bufLen = 64;
-    uint8_t buffer[64];
+    static constexpr size_t bufLen = 64;
+    uint8_t buffer[bufLen];
   } *context;
 };
 


### PR DESCRIPTION
This pull request introduces several changes to the OTA update process in the Arduino IoT Cloud library. The key changes focus on improving the reliability of OTA updates by adding support for chunked downloads and refining OTA policy management.

Improvements to OTA policy management:

* [`src/ArduinoIoTCloudTCP.h`](diffhunk://#diff-a1314de94eb0792cf8632064de47dae933ca9243976b03715c1083d1faba2389L99-R110): Replaced `setOtaPolicies` with `enableOtaPolicy` and `disableOtaPolicy` methods to manage OTA policies more flexibly. Added a new method `setOTAChunkMode` to enable or disable chunked downloads.
* [`src/ota/interface/OTAInterface.cpp`](diffhunk://#diff-6e3e6582c41e8451a16dae10757ac9278c9c91a65567aab491f8f0eee40f33c9L170-R173): Updated the `otaAvailable` method to use the new `getOtaPolicy` method for checking OTA policies.
* [`src/ota/interface/OTAInterface.h`](diffhunk://#diff-48a6e883d40d54b216295e81650bd93c9289d2671e2b5f0868eade4d0178c86cL83-R98): Added new methods `enableOtaPolicy`, `disableOtaPolicy`, and `getOtaPolicy` to manage OTA policies. Introduced a new `ChunkDownload` flag for chunked downloads.

Enhancements to OTA download process:

* [`src/ota/interface/OTAInterfaceDefault.cpp`](diffhunk://#diff-15f356c4407a55f1b72470304917cb77c9ade194e19c26e83731e93337047efcL44-R54): Refactored the `startOTA` and `fetch` methods to support chunked downloads. Added a new method `requestOta` to handle HTTP requests for OTA updates, including chunked requests. 
* [`src/ota/interface/OTAInterfaceDefault.h`](diffhunk://#diff-df4de9e6398b7f343066d7316cf57f994490a81c0b8e8b7adc02ff84d1d5d885L45-R47): Added new constants and methods to support chunked downloads, including `maxChunkSize`, `requestOta`, and `fetchMore`. Updated the `Context` struct to include new fields for managing chunked downloads. 