### PR TITLE
examples: fix username/password secure element logic

### DIFF
--- a/examples/ArduinoIoTCloud-Advanced/arduino_secrets.h
+++ b/examples/ArduinoIoTCloud-Advanced/arduino_secrets.h
@@ -9,7 +9,7 @@
 #endif
 
 /* ESP8266 ESP32 */
-#if defined(BOARD_HAS_SECRET_KEY)
+#if !defined(BOARD_HAS_SECURE_ELEMENT)
   #define SECRET_DEVICE_KEY "my-device-password"
 #endif
 

--- a/examples/ArduinoIoTCloud-Advanced/thingProperties.h
+++ b/examples/ArduinoIoTCloud-Advanced/thingProperties.h
@@ -6,7 +6,7 @@
   #error  "Please check Arduino IoT Cloud supported boards list: https://github.com/arduino-libraries/ArduinoIoTCloud/#what"
 #endif
 
-#if defined(BOARD_HAS_SECRET_KEY)
+#if !defined(BOARD_HAS_SECURE_ELEMENT)
   #define BOARD_ID "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
 #endif
 
@@ -22,14 +22,15 @@ CloudLocation location;
 CloudColor color;
 
 void initProperties() {
-#if defined(BOARD_HAS_SECRET_KEY)
-  ArduinoCloud.setBoardId(BOARD_ID);
-  ArduinoCloud.setSecretDeviceKey(SECRET_DEVICE_KEY);
-#endif
 #if defined(HAS_TCP)
   ArduinoCloud.addProperty(switchButton, Permission::Write).onUpdate(onSwitchButtonChange);
   ArduinoCloud.addProperty(location, Permission::Read).publishOnChange(0.0f);
   ArduinoCloud.addProperty(color, Permission::ReadWrite).onUpdate(onColorChange);
+
+#if !defined(BOARD_HAS_SECURE_ELEMENT)
+  ArduinoCloud.setBoardId(BOARD_ID);
+  ArduinoCloud.setSecretDeviceKey(SECRET_DEVICE_KEY);
+#endif
 #elif defined(HAS_LORA)
   ArduinoCloud.addProperty(switchButton, 1, Permission::Write).onUpdate(onSwitchButtonChange);
   ArduinoCloud.addProperty(location, 2, Permission::Read).publishOnChange(0.0f);

--- a/examples/ArduinoIoTCloud-Basic/arduino_secrets.h
+++ b/examples/ArduinoIoTCloud-Basic/arduino_secrets.h
@@ -9,7 +9,7 @@
 #endif
 
 /* ESP8266 ESP32 */
-#if defined(BOARD_HAS_SECRET_KEY)
+#if !defined(BOARD_HAS_SECURE_ELEMENT)
   #define SECRET_DEVICE_KEY "my-device-password"
 #endif
 

--- a/examples/ArduinoIoTCloud-Basic/thingProperties.h
+++ b/examples/ArduinoIoTCloud-Basic/thingProperties.h
@@ -6,7 +6,7 @@
   #error  "Please check Arduino IoT Cloud supported boards list: https://github.com/arduino-libraries/ArduinoIoTCloud/#what"
 #endif
 
-#if defined(BOARD_HAS_SECRET_KEY)
+#if !defined(BOARD_HAS_SECURE_ELEMENT)
   #define BOARD_ID "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
 #endif
 
@@ -21,14 +21,15 @@ int potentiometer;
 int seconds;
 
 void initProperties() {
-#if defined(BOARD_HAS_SECRET_KEY)
-  ArduinoCloud.setBoardId(BOARD_ID);
-  ArduinoCloud.setSecretDeviceKey(SECRET_DEVICE_KEY);
-#endif
 #if defined(HAS_TCP)
   ArduinoCloud.addProperty(led, Permission::Write).onUpdate(onLedChange);
   ArduinoCloud.addProperty(potentiometer, Permission::Read).publishOnChange(10);
   ArduinoCloud.addProperty(seconds, Permission::Read).publishOnChange(1);
+
+#if !defined(BOARD_HAS_SECURE_ELEMENT)
+  ArduinoCloud.setBoardId(BOARD_ID);
+  ArduinoCloud.setSecretDeviceKey(SECRET_DEVICE_KEY);
+#endif
 #elif defined(HAS_LORA)
   ArduinoCloud.addProperty(led, 1, Permission::ReadWrite).onUpdate(onLedChange);
   ArduinoCloud.addProperty(potentiometer, 2, Permission::Read).publishOnChange(10);

--- a/examples/ArduinoIoTCloud-BlockForOTA/arduino_secrets.h
+++ b/examples/ArduinoIoTCloud-BlockForOTA/arduino_secrets.h
@@ -9,7 +9,7 @@
 #endif
 
 /* ESP8266 ESP32 */
-#if defined(BOARD_HAS_SECRET_KEY)
+#if !defined(BOARD_HAS_SECURE_ELEMENT)
   #define SECRET_DEVICE_KEY "my-device-password"
 #endif
 

--- a/examples/ArduinoIoTCloud-BlockForOTA/thingProperties.h
+++ b/examples/ArduinoIoTCloud-BlockForOTA/thingProperties.h
@@ -6,7 +6,7 @@
   #error  "Please check Arduino IoT Cloud supported boards list: https://github.com/arduino-libraries/ArduinoIoTCloud/#what"
 #endif
 
-#if defined(BOARD_HAS_SECRET_KEY)
+#if !defined(BOARD_HAS_SECURE_ELEMENT)
   #define BOARD_ID "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
 #endif
 
@@ -21,14 +21,15 @@ int potentiometer;
 int seconds;
 
 void initProperties() {
-#if defined(BOARD_HAS_SECRET_KEY)
-  ArduinoCloud.setBoardId(BOARD_ID);
-  ArduinoCloud.setSecretDeviceKey(SECRET_DEVICE_KEY);
-#endif
 #if defined(HAS_TCP)
   ArduinoCloud.addProperty(led, Permission::Write).onUpdate(onLedChange);
   ArduinoCloud.addProperty(potentiometer, Permission::Read).publishOnChange(10);
   ArduinoCloud.addProperty(seconds, Permission::Read).publishOnChange(1);
+
+#if !defined(BOARD_HAS_SECURE_ELEMENT)
+  ArduinoCloud.setBoardId(BOARD_ID);
+  ArduinoCloud.setSecretDeviceKey(SECRET_DEVICE_KEY);
+#endif
 #elif defined(HAS_LORA)
   ArduinoCloud.addProperty(led, 1, Permission::ReadWrite).onUpdate(onLedChange);
   ArduinoCloud.addProperty(potentiometer, 2, Permission::Read).publishOnChange(10);

--- a/examples/ArduinoIoTCloud-Callbacks/arduino_secrets.h
+++ b/examples/ArduinoIoTCloud-Callbacks/arduino_secrets.h
@@ -9,7 +9,7 @@
 #endif
 
 /* ESP8266 ESP32 */
-#if defined(BOARD_HAS_SECRET_KEY)
+#if !defined(BOARD_HAS_SECURE_ELEMENT)
   #define SECRET_DEVICE_KEY "my-device-password"
 #endif
 

--- a/examples/ArduinoIoTCloud-Callbacks/thingProperties.h
+++ b/examples/ArduinoIoTCloud-Callbacks/thingProperties.h
@@ -6,7 +6,7 @@
   #error  "Please check Arduino IoT Cloud supported boards list: https://github.com/arduino-libraries/ArduinoIoTCloud/#what"
 #endif
 
-#if defined(BOARD_HAS_SECRET_KEY)
+#if !defined(BOARD_HAS_SECURE_ELEMENT)
   #define BOARD_ID "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
 #endif
 
@@ -15,11 +15,12 @@
 #endif
 
 void initProperties() {
-#if defined(BOARD_HAS_SECRET_KEY)
+#if defined(HAS_TCP)
+#if !defined(BOARD_HAS_SECURE_ELEMENT)
   ArduinoCloud.setBoardId(BOARD_ID);
   ArduinoCloud.setSecretDeviceKey(SECRET_DEVICE_KEY);
 #endif
-#if defined(BOARD_HAS_LORA)
+#elif defined(HAS_LORA)
   ArduinoCloud.setThingId(THING_ID);
 #endif
 }

--- a/examples/ArduinoIoTCloud-DeferredOTA/arduino_secrets.h
+++ b/examples/ArduinoIoTCloud-DeferredOTA/arduino_secrets.h
@@ -9,7 +9,7 @@
 #endif
 
 /* ESP8266 ESP32 */
-#if defined(BOARD_HAS_SECRET_KEY)
+#if !defined(BOARD_HAS_SECURE_ELEMENT)
   #define SECRET_DEVICE_KEY "my-device-password"
 #endif
 

--- a/examples/ArduinoIoTCloud-DeferredOTA/thingProperties.h
+++ b/examples/ArduinoIoTCloud-DeferredOTA/thingProperties.h
@@ -6,7 +6,7 @@
   #error "Please check Arduino IoT Cloud supported boards list: https://github.com/arduino-libraries/ArduinoIoTCloud/#what"
 #endif
 
-#if defined(BOARD_HAS_SECRET_KEY)
+#if !defined(BOARD_HAS_SECURE_ELEMENT)
   #define BOARD_ID "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
 #endif
 
@@ -15,11 +15,12 @@ void onLedChange();
 bool led;
 
 void initProperties() {
-#if defined(BOARD_HAS_SECRET_KEY)
+#if defined(HAS_TCP)
+#if !defined(BOARD_HAS_SECURE_ELEMENT)
   ArduinoCloud.setBoardId(BOARD_ID);
   ArduinoCloud.setSecretDeviceKey(SECRET_DEVICE_KEY);
 #endif
-
+#endif
   ArduinoCloud.addProperty(led, Permission::Write).onUpdate(onLedChange);
 }
 

--- a/examples/ArduinoIoTCloud-Schedule/arduino_secrets.h
+++ b/examples/ArduinoIoTCloud-Schedule/arduino_secrets.h
@@ -9,7 +9,7 @@
 #endif
 
 /* ESP8266 ESP32 */
-#if defined(BOARD_HAS_SECRET_KEY)
+#if !defined(BOARD_HAS_SECURE_ELEMENT)
   #define SECRET_DEVICE_KEY "my-device-password"
 #endif
 

--- a/examples/ArduinoIoTCloud-Schedule/thingProperties.h
+++ b/examples/ArduinoIoTCloud-Schedule/thingProperties.h
@@ -6,7 +6,7 @@
   #error  "Please check Arduino IoT Cloud supported boards list: https://github.com/arduino-libraries/ArduinoIoTCloud/#what"
 #endif
 
-#if defined(BOARD_HAS_SECRET_KEY)
+#if !defined(BOARD_HAS_SECURE_ELEMENT)
   #define BOARD_ID "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
 #endif
 
@@ -26,10 +26,6 @@ CloudSchedule monthly;
 CloudSchedule yearly;
 
 void initProperties() {
-#if defined(BOARD_HAS_SECRET_KEY)
-  ArduinoCloud.setBoardId(BOARD_ID);
-  ArduinoCloud.setSecretDeviceKey(SECRET_DEVICE_KEY);
-#endif
 #if defined(HAS_TCP)
   ArduinoCloud.addProperty(switchButton, Permission::Write);
   ArduinoCloud.addProperty(oneShot, Permission::ReadWrite);
@@ -39,6 +35,11 @@ void initProperties() {
   ArduinoCloud.addProperty(weekly, Permission::ReadWrite);
   ArduinoCloud.addProperty(monthly, Permission::ReadWrite);
   ArduinoCloud.addProperty(yearly, Permission::ReadWrite);
+
+#if !defined(BOARD_HAS_SECURE_ELEMENT)
+  ArduinoCloud.setBoardId(BOARD_ID);
+  ArduinoCloud.setSecretDeviceKey(SECRET_DEVICE_KEY);
+#endif
 #elif defined(HAS_LORA)
   ArduinoCloud.addProperty(switchButton, 1, Permission::Write);
 

--- a/examples/utility/ArduinoIoTCloud_Travis_CI/arduino_secrets.h
+++ b/examples/utility/ArduinoIoTCloud_Travis_CI/arduino_secrets.h
@@ -9,7 +9,7 @@
 #endif
 
 /* ESP8266 ESP32*/
-#if defined(BOARD_HAS_SECRET_KEY)
+#if !defined(BOARD_HAS_SECURE_ELEMENT)
   #define SECRET_DEVICE_KEY "my-device-password"
 #endif
 

--- a/examples/utility/ArduinoIoTCloud_Travis_CI/thingProperties.h
+++ b/examples/utility/ArduinoIoTCloud_Travis_CI/thingProperties.h
@@ -10,7 +10,7 @@
    DEFINES
  ******************************************************************************/
 
-#if defined(BOARD_HAS_SECRET_KEY)
+#if !defined(BOARD_HAS_SECURE_ELEMENT)
   #define BOARD_ID "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
 #endif
 
@@ -86,7 +86,7 @@ void onStringPropertyChange();
  ******************************************************************************/
 #if defined(HAS_TCP)
 void initProperties() {
-#if defined(BOARD_HAS_SECRET_KEY)
+#if !defined(BOARD_HAS_SECURE_ELEMENT)
   ArduinoCloud.setBoardId(BOARD_ID);
   ArduinoCloud.setSecretDeviceKey(SECRET_DEVICE_KEY);
 #endif


### PR DESCRIPTION
Otherwise username and password authentication is used by default for UNO R4 WiFi