### PR TITLE
examples: remova LoRa from schedule example

### DIFF
--- a/.github/workflows/compile-examples.yml
+++ b/.github/workflows/compile-examples.yml
@@ -31,7 +31,6 @@ jobs:
         - examples/ArduinoIoTCloud-Advanced
         - examples/ArduinoIoTCloud-Basic
         - examples/ArduinoIoTCloud-Callbacks
-        - examples/ArduinoIoTCloud-Schedule
         - examples/utility/ArduinoIoTCloud_Travis_CI
       SKETCHES_REPORTS_PATH: sketches-reports
 
@@ -109,6 +108,7 @@ jobs:
               - source-url: https://github.com/adafruit/Adafruit_SleepyDog.git
             sketch-paths: |
               - examples/ArduinoIoTCloud-Notecard
+              - examples/ArduinoIoTCloud-Schedule
               - examples/utility/Provisioning
           # MKR WiFi 1010, Nano 33 IoT, Nano RP2040 Connect
           - board:
@@ -127,6 +127,7 @@ jobs:
             sketch-paths: |
               - examples/ArduinoIoTCloud-DeferredOTA
               - examples/ArduinoIoTCloud-Notecard
+              - examples/ArduinoIoTCloud-Schedule
               - examples/utility/Provisioning
               - examples/utility/SelfProvisioning
           - board:
@@ -156,6 +157,7 @@ jobs:
               - source-url: https://github.com/adafruit/Adafruit_SleepyDog.git
             sketch-paths: |
               - examples/ArduinoIoTCloud-Notecard
+              - examples/ArduinoIoTCloud-Schedule
               - examples/utility/Provisioning
           # NB boards
           - board:
@@ -171,6 +173,7 @@ jobs:
               - source-url: https://github.com/adafruit/Adafruit_SleepyDog.git
             sketch-paths: |
               - examples/ArduinoIoTCloud-Notecard
+              - examples/ArduinoIoTCloud-Schedule
               - examples/utility/Provisioning
           # Portenta
           - board:
@@ -185,6 +188,7 @@ jobs:
             sketch-paths: |
               - examples/ArduinoIoTCloud-DeferredOTA
               - examples/ArduinoIoTCloud-Notecard
+              - examples/ArduinoIoTCloud-Schedule
               - examples/utility/Provisioning
           # Nicla Vision
           - board:
@@ -197,6 +201,7 @@ jobs:
             sketch-paths: |
               - examples/ArduinoIoTCloud-DeferredOTA
               - examples/ArduinoIoTCloud-Notecard
+              - examples/ArduinoIoTCloud-Schedule
               - examples/utility/Provisioning
           # Opta
           - board:
@@ -210,6 +215,7 @@ jobs:
             sketch-paths: |
               - examples/ArduinoIoTCloud-DeferredOTA
               - examples/ArduinoIoTCloud-Notecard
+              - examples/ArduinoIoTCloud-Schedule
               - examples/utility/Provisioning
           # GIGA
           - board:
@@ -223,6 +229,7 @@ jobs:
             sketch-paths: |
               - examples/ArduinoIoTCloud-DeferredOTA
               - examples/ArduinoIoTCloud-Notecard
+              - examples/ArduinoIoTCloud-Schedule
               - examples/utility/Provisioning
           # Portenta C33
           - board:
@@ -235,6 +242,7 @@ jobs:
               - name: Blues Wireless Notecard
             sketch-paths: |
               - examples/ArduinoIoTCloud-Notecard
+              - examples/ArduinoIoTCloud-Schedule
               - examples/utility/Provisioning
           # UNO R4 WiFi
           - board:
@@ -246,6 +254,7 @@ jobs:
               - name: Blues Wireless Notecard
             sketch-paths: |
               - examples/ArduinoIoTCloud-Notecard
+              - examples/ArduinoIoTCloud-Schedule
           # Nano ESP32
           - board:
               type: arduino_esp32
@@ -257,6 +266,7 @@ jobs:
             sketch-paths: |
               - examples/ArduinoIoTCloud-DeferredOTA
               - examples/ArduinoIoTCloud-Notecard
+              - examples/ArduinoIoTCloud-Schedule
           # Edge Control
           - board:
               type: mbed_edge
@@ -267,6 +277,7 @@ jobs:
               - name: Blues Wireless Notecard
             sketch-paths: |
               - examples/ArduinoIoTCloud-Notecard
+              - examples/ArduinoIoTCloud-Schedule
           # ESP8266 boards
           - board:
               type: esp8266
@@ -277,7 +288,8 @@ jobs:
                 # Use the version currently installed in Arduino Cloud
                 version: 2.5.0
             libraries:
-            sketch-paths:
+            sketch-paths: |
+              - examples/ArduinoIoTCloud-Schedule
           # ESP32 boards
           - board:
               type: esp32
@@ -290,6 +302,7 @@ jobs:
             sketch-paths: |
               - examples/ArduinoIoTCloud-DeferredOTA
               - examples/ArduinoIoTCloud-Notecard
+              - examples/ArduinoIoTCloud-Schedule
 
     steps:
       - name: Checkout

--- a/examples/ArduinoIoTCloud-Schedule/arduino_secrets.h
+++ b/examples/ArduinoIoTCloud-Schedule/arduino_secrets.h
@@ -23,12 +23,6 @@
   #define SECRET_PASS ""
 #endif
 
-/* MKR WAN 1300/1310 */
-#if defined(BOARD_HAS_LORA)
-  #define SECRET_APP_EUI ""
-  #define SECRET_APP_KEY ""
-#endif
-
 /* Portenta H7 + Ethernet shield */
 #if defined(BOARD_HAS_ETHERNET)
   #define SECRET_OPTIONAL_IP ""

--- a/examples/ArduinoIoTCloud-Schedule/thingProperties.h
+++ b/examples/ArduinoIoTCloud-Schedule/thingProperties.h
@@ -2,16 +2,12 @@
 #include <Arduino_ConnectionHandler.h>
 #include "arduino_secrets.h"
 
-#if !(defined(HAS_TCP) || defined(HAS_LORA))
+#if !defined(HAS_TCP)
   #error  "Please check Arduino IoT Cloud supported boards list: https://github.com/arduino-libraries/ArduinoIoTCloud/#what"
 #endif
 
 #if !defined(BOARD_HAS_SECURE_ELEMENT)
   #define BOARD_ID "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
-#endif
-
-#if defined(HAS_LORA)
-  #define THING_ID "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
 #endif
 
 void onSwitchButtonChange();
@@ -40,10 +36,6 @@ void initProperties() {
   ArduinoCloud.setBoardId(BOARD_ID);
   ArduinoCloud.setSecretDeviceKey(SECRET_DEVICE_KEY);
 #endif
-#elif defined(HAS_LORA)
-  ArduinoCloud.addProperty(switchButton, 1, Permission::Write);
-
-  ArduinoCloud.setThingId(THING_ID);
 #endif
 }
 
@@ -51,8 +43,6 @@ void initProperties() {
   WiFiConnectionHandler ArduinoIoTPreferredConnection(SECRET_WIFI_SSID, SECRET_WIFI_PASS);
 #elif defined(BOARD_HAS_GSM)
   GSMConnectionHandler ArduinoIoTPreferredConnection(SECRET_PIN, SECRET_APN, SECRET_LOGIN, SECRET_PASS);
-#elif defined(BOARD_HAS_LORA)
-  LoRaConnectionHandler ArduinoIoTPreferredConnection(SECRET_APP_EUI, SECRET_APP_KEY, _lora_band::EU868, NULL, _lora_class::CLASS_A);
 #elif defined(BOARD_HAS_NB)
   NBConnectionHandler ArduinoIoTPreferredConnection(SECRET_PIN, SECRET_APN, SECRET_LOGIN, SECRET_PASS);
 #elif defined(BOARD_HAS_CATM1_NBIOT)


### PR DESCRIPTION
Schedule property cannot work with TTN LoRa network unless board time is configured with `TimeService` [setSyncFunction](https://github.com/arduino-libraries/ArduinoIoTCloud/blob/8b7fbf4fc216f970a5af8d321deb02807e669da4/src/utility/time/TimeService.h#L52)

In the past there was an [attempt](https://github.com/arduino-libraries/ArduinoIoTCloud/commit/0cfc02f6d13ea347fc9b542b8a83d53b466e0e9b) to remove LoRa support from the example, but only the sketch comment was changed.

Fixes #495