### PR TITLE
Changes for migration from Provisioning 1.0 to Provisioning 2.0 

### DIFF
--- a/examples/utility/Provisioning_2.0/ClaimingHandler.cpp
+++ b/examples/utility/Provisioning_2.0/ClaimingHandler.cpp
@@ -100,7 +100,7 @@ void ClaimingHandlerClass::getIdReqHandler() {
     idMsg.m.uhwid = _uhwidBytes;
     _agentManager.sendMsg(idMsg);
 
-    String token = getAIoTCloudJWT(*_secureElement, *_uhwid, _ts, 1);
+    String token = generateToken();
     if (token == "") {
       DEBUG_ERROR("CH::%s Error: token not created", __FUNCTION__);
       sendStatus(StatusMessage::ERROR);
@@ -112,6 +112,19 @@ void ClaimingHandlerClass::getIdReqHandler() {
     jwtMsg.m.jwt = token.c_str();
     _agentManager.sendMsg(jwtMsg);
     _ts = 0;
+
+    SElementJWS sejws;
+    String publicKey =  sejws.publicKey(*_secureElement, 1, false);
+    if (publicKey == "") {
+      DEBUG_ERROR("CH::%s Error: public key not created", __FUNCTION__);
+      sendStatus(StatusMessage::ERROR);
+      return;
+    }
+
+    //Send public key
+    ProvisioningOutputMessage publicKeyMsg = {MessageOutputType::PROV_PUBLIC_KEY};
+    publicKeyMsg.m.provPublicKey = publicKey.c_str();
+    _agentManager.sendMsg(publicKeyMsg);
   } else {
     DEBUG_ERROR("CH::%s Error: timestamp not provided" , __FUNCTION__);
     sendStatus(StatusMessage::PARAMS_NOT_FOUND);
@@ -186,7 +199,24 @@ void ClaimingHandlerClass::getProvSketchVersionRequestCb() {
   _receivedEvent = ClaimingReqEvents::GET_PROV_SKETCH_VERSION;
 }
 
-bool ClaimingHandlerClass::sendStatus(StatusMessage msg) {
-  ProvisioningOutputMessage statusMsg = { MessageOutputType::STATUS, { msg } };
-  return _agentManager.sendMsg(statusMsg);
+String ClaimingHandlerClass::generateToken()
+{
+  String token = getAIoTCloudJWT(*_secureElement, *_uhwid, _ts, 1);
+  if(token == "") {
+    byte publicKey[64];
+    DEBUG_INFO("Generating private key");
+    if(!_secureElement->generatePrivateKey(1, publicKey)){
+      DEBUG_ERROR("CH::%s Error: private key generation failed", __FUNCTION__);
+      return "";
+    }
+    token = getAIoTCloudJWT(*_secureElement, *_uhwid, _ts, 1);
+  }
+
+  return token;
+}
+
+bool ClaimingHandlerClass::sendStatus(StatusMessage msg)
+{
+    ProvisioningOutputMessage statusMsg = {MessageOutputType::STATUS, {msg}};
+    return _agentManager.sendMsg(statusMsg);
 }

--- a/examples/utility/Provisioning_2.0/ClaimingHandler.cpp
+++ b/examples/utility/Provisioning_2.0/ClaimingHandler.cpp
@@ -92,43 +92,47 @@ void ClaimingHandlerClass::poll() {
 }
 
 void ClaimingHandlerClass::getIdReqHandler() {
-  if (_ts != 0) {
-    byte _uhwidBytes[32];
-    hex::decode(_uhwid->c_str(), _uhwidBytes, _uhwid->length());
-    //Send UHWID
-    ProvisioningOutputMessage idMsg = {MessageOutputType::UHWID};
-    idMsg.m.uhwid = _uhwidBytes;
-    _agentManager.sendMsg(idMsg);
-
-    String token = generateToken();
-    if (token == "") {
-      DEBUG_ERROR("CH::%s Error: token not created", __FUNCTION__);
-      sendStatus(StatusMessage::ERROR);
-      return;
-    }
-
-    //Send JWT
-    ProvisioningOutputMessage jwtMsg = {MessageOutputType::JWT};
-    jwtMsg.m.jwt = token.c_str();
-    _agentManager.sendMsg(jwtMsg);
-    _ts = 0;
-
-    SElementJWS sejws;
-    String publicKey =  sejws.publicKey(*_secureElement, 1, false);
-    if (publicKey == "") {
-      DEBUG_ERROR("CH::%s Error: public key not created", __FUNCTION__);
-      sendStatus(StatusMessage::ERROR);
-      return;
-    }
-
-    //Send public key
-    ProvisioningOutputMessage publicKeyMsg = {MessageOutputType::PROV_PUBLIC_KEY};
-    publicKeyMsg.m.provPublicKey = publicKey.c_str();
-    _agentManager.sendMsg(publicKeyMsg);
-  } else {
+  if (_ts == 0) {
     DEBUG_ERROR("CH::%s Error: timestamp not provided" , __FUNCTION__);
     sendStatus(StatusMessage::PARAMS_NOT_FOUND);
+    return;
   }
+
+  byte _uhwidBytes[32];
+  hex::decode(_uhwid->c_str(), _uhwidBytes, _uhwid->length());
+
+  String token = generateToken();
+  if (token == "") {
+    DEBUG_ERROR("CH::%s Error: token not created", __FUNCTION__);
+    sendStatus(StatusMessage::ERROR);
+    return;
+  }
+
+  SElementJWS sejws;
+  String publicKey =  sejws.publicKey(*_secureElement, 1, false);
+  if (publicKey == "") {
+    DEBUG_ERROR("CH::%s Error: public key not created", __FUNCTION__);
+    sendStatus(StatusMessage::ERROR);
+    return;
+  }
+
+  //Send public key
+  ProvisioningOutputMessage publicKeyMsg = {MessageOutputType::PROV_PUBLIC_KEY};
+  publicKeyMsg.m.provPublicKey = publicKey.c_str();
+  _agentManager.sendMsg(publicKeyMsg);
+
+
+  //Send UHWID
+  ProvisioningOutputMessage idMsg = {MessageOutputType::UHWID};
+  idMsg.m.uhwid = _uhwidBytes;
+  _agentManager.sendMsg(idMsg);
+
+  //Send JWT
+  ProvisioningOutputMessage jwtMsg = {MessageOutputType::JWT};
+  jwtMsg.m.jwt = token.c_str();
+  _agentManager.sendMsg(jwtMsg);
+  _ts = 0;
+
 }
 
 void ClaimingHandlerClass::resetStoredCredReqHandler() {

--- a/examples/utility/Provisioning_2.0/ClaimingHandler.cpp
+++ b/examples/utility/Provisioning_2.0/ClaimingHandler.cpp
@@ -13,6 +13,8 @@
 #include "utility/HCI.h"
 #include <Arduino_HEX.h>
 
+#define SLOT_BOARD_PRIVATE_KEY 1
+
 extern const char *SKETCH_VERSION;
 
 ClaimingHandlerClass::ClaimingHandlerClass():
@@ -109,7 +111,7 @@ void ClaimingHandlerClass::getIdReqHandler() {
   }
 
   SElementJWS sejws;
-  String publicKey =  sejws.publicKey(*_secureElement, 1, false);
+  String publicKey =  sejws.publicKey(*_secureElement, SLOT_BOARD_PRIVATE_KEY, false);
   if (publicKey == "") {
     DEBUG_ERROR("CH::%s Error: public key not created", __FUNCTION__);
     sendStatus(StatusMessage::ERROR);
@@ -203,24 +205,22 @@ void ClaimingHandlerClass::getProvSketchVersionRequestCb() {
   _receivedEvent = ClaimingReqEvents::GET_PROV_SKETCH_VERSION;
 }
 
-String ClaimingHandlerClass::generateToken()
-{
-  String token = getAIoTCloudJWT(*_secureElement, *_uhwid, _ts, 1);
+String ClaimingHandlerClass::generateToken() {
+  String token = getAIoTCloudJWT(*_secureElement, *_uhwid, _ts, SLOT_BOARD_PRIVATE_KEY);
   if(token == "") {
     byte publicKey[64];
     DEBUG_INFO("Generating private key");
-    if(!_secureElement->generatePrivateKey(1, publicKey)){
+    if(!_secureElement->generatePrivateKey(SLOT_BOARD_PRIVATE_KEY, publicKey)){
       DEBUG_ERROR("CH::%s Error: private key generation failed", __FUNCTION__);
       return "";
     }
-    token = getAIoTCloudJWT(*_secureElement, *_uhwid, _ts, 1);
+    token = getAIoTCloudJWT(*_secureElement, *_uhwid, _ts, SLOT_BOARD_PRIVATE_KEY);
   }
 
   return token;
 }
 
-bool ClaimingHandlerClass::sendStatus(StatusMessage msg)
-{
+bool ClaimingHandlerClass::sendStatus(StatusMessage msg) {
     ProvisioningOutputMessage statusMsg = {MessageOutputType::STATUS, {msg}};
     return _agentManager.sendMsg(statusMsg);
 }

--- a/examples/utility/Provisioning_2.0/ClaimingHandler.h
+++ b/examples/utility/Provisioning_2.0/ClaimingHandler.h
@@ -36,6 +36,7 @@ private:
   LEDFeedbackClass &_ledFeedback;
   static inline uint64_t _ts;
   SecureElement *_secureElement;
+  String generateToken();
 
   bool sendStatus(StatusMessage msg);
   /* Commands handlers */

--- a/examples/utility/Provisioning_2.0/Provisioning_2.0.ino
+++ b/examples/utility/Provisioning_2.0/Provisioning_2.0.ino
@@ -15,7 +15,7 @@
 #include <utility/SElementArduinoCloudCertificate.h>
 #include "utility/LEDFeedback.h"
 
-const char *SKETCH_VERSION = "0.1.0";
+const char *SKETCH_VERSION = "0.3.0";
 
 enum class DeviceState {
     HARDWARE_CHECK,

--- a/examples/utility/Provisioning_2.0/Provisioning_2.0.ino
+++ b/examples/utility/Provisioning_2.0/Provisioning_2.0.ino
@@ -59,7 +59,7 @@ void setup() {
   initProperties();
   AgentsManagerClass::getInstance().begin();
   LEDFeedbackClass::getInstance().begin();
-  DEBUG_INFO("Starting Provisioning");
+  DEBUG_INFO("Starting Provisioning version %s", SKETCH_VERSION);
 }
 
 void sendStatus(StatusMessage msg) {


### PR DESCRIPTION
### Changes:

- generate private key if fails in generating the token
- send the public key on request

