### PR TITLE
Fix the crash of Portenta H7 with cellular connectivity

### DIFF
--- a/src/ArduinoIoTCloudTCP.cpp
+++ b/src/ArduinoIoTCloudTCP.cpp
@@ -244,7 +244,7 @@ void ArduinoIoTCloudTCP::update()
    * the mqttClient. The state can be reached only after the mqttClient is connected to
    * the broker.
    */
-  if(_state <= State::Init){
+  if(_state <= State::ConnectPhy){
     return;
   }
 
@@ -264,7 +264,7 @@ void ArduinoIoTCloudTCP::update()
 
 int ArduinoIoTCloudTCP::connected()
 {
-  if (_state <= State::Init) {
+  if (_state <= State::ConnectPhy) {
     return 0;
   }
   return _mqttClient.connected();
@@ -281,7 +281,7 @@ void ArduinoIoTCloudTCP::printDebugInfo()
 }
 
 void ArduinoIoTCloudTCP::disconnect() {
-  if (_state == State::ConfigPhy || _state == State::Init) {
+  if (_state <= State::ConnectPhy) {
     return;
   }
 


### PR DESCRIPTION
Fix the bug introduced with version 2.6.0 that crashes the Portenta H7 if used with the Cellular 4G connectivity