### PR TITLE
Addressing Issue #552

### DIFF
--- a/src/ArduinoIoTCloudTCP.cpp
+++ b/src/ArduinoIoTCloudTCP.cpp
@@ -72,7 +72,8 @@ ArduinoIoTCloudTCP::ArduinoIoTCloudTCP()
 , _get_ota_confirmation{nullptr}
 #endif /* OTA_ENABLED */
 {
-
+  cbor::encoder::iotcloud::commandEncoders();
+  cbor::decoder::iotcloud::commandDecoders();
 }
 
 /******************************************************************************

--- a/src/cbor/IoTCloudMessageDecoder.cpp
+++ b/src/cbor/IoTCloudMessageDecoder.cpp
@@ -176,3 +176,13 @@ static ThingUpdateCommandDecoder      thingUpdateCommandDecoder;
 static ThingDetachCommandDecoder      thingDetachCommandDecoder;
 static LastValuesUpdateCommandDecoder lastValuesUpdateCommandDecoder;
 static TimezoneCommandDownDecoder     timezoneCommandDownDecoder;
+
+namespace cbor { namespace decoder { namespace iotcloud {
+  void commandDecoders() {
+    (void) otaUpdateCommandDecoder;
+    (void) thingUpdateCommandDecoder;
+    (void) thingDetachCommandDecoder;
+    (void) lastValuesUpdateCommandDecoder;
+    (void) timezoneCommandDownDecoder;
+  }
+}}}

--- a/src/cbor/IoTCloudMessageDecoder.h
+++ b/src/cbor/IoTCloudMessageDecoder.h
@@ -63,4 +63,12 @@ protected:
   MessageDecoder::Status decode(CborValue* iter, Message *msg) override;
 };
 
+namespace cbor { namespace decoder { namespace iotcloud {
+  /**
+   * Some link time optimization may exclude these classes to be instantiated
+   * thus it may be required to reference them from outside of this file
+   */
+  void commandDecoders();
+}}}
+
 #endif /* ARDUINO_CBOR_MESSAGE_DECODER_H_ */

--- a/src/cbor/IoTCloudMessageEncoder.cpp
+++ b/src/cbor/IoTCloudMessageEncoder.cpp
@@ -159,3 +159,14 @@ static LastValuesBeginCommandEncoder  lastValuesBeginCommandEncoder;
 static DeviceBeginCommandEncoder      deviceBeginCommandEncoder;
 static OtaProgressCommandUpEncoder    otaProgressCommandUpEncoder;
 static TimezoneCommandUpEncoder       timezoneCommandUpEncoder;
+
+namespace cbor { namespace encoder { namespace iotcloud {
+  void commandEncoders() {
+    (void) otaBeginCommandEncoder;
+    (void) thingBeginCommandEncoder;
+    (void) lastValuesBeginCommandEncoder;
+    (void) deviceBeginCommandEncoder;
+    (void) otaProgressCommandUpEncoder;
+    (void) timezoneCommandUpEncoder;
+  }
+}}}

--- a/src/cbor/IoTCloudMessageEncoder.h
+++ b/src/cbor/IoTCloudMessageEncoder.h
@@ -71,5 +71,12 @@ protected:
   MessageEncoder::Status encode(CborEncoder* encoder, Message *msg) override;
 };
 
+namespace cbor { namespace encoder { namespace iotcloud {
+  /**
+   * Some link time optimization may exclude these classes to be instantiated
+   * thus it may be required to reference them from outside of this file
+   */
+  void commandEncoders();
+}}}
 
 #endif /* ARDUINO_CBOR_MESSAGE_ENCODER_H_ */


### PR DESCRIPTION
Addressing https://github.com/arduino-libraries/ArduinoIoTCloud/issues/552. While using platformio build system some new structures are not included in the final binary, for this reason it is required for concrete encoder and decoder for cbor commands to be referenced in files that are referenced by the sketch entrypoint.