### PR TITLE
Force sending the network configuration when it's updated via Serial

### DIFF
--- a/src/ArduinoIoTCloudTCP.cpp
+++ b/src/ArduinoIoTCloudTCP.cpp
@@ -216,6 +216,7 @@ void ArduinoIoTCloudTCP::update()
   switch (_state)
   {
   case State::ConfigPhy:            next_state = handle_ConfigPhy();            break;
+  case State::UpdatePhy:            next_state = handle_UpdatePhy();            break;
   case State::Init:                 next_state = handle_Init();                 break;
   case State::ConnectPhy:           next_state = handle_ConnectPhy();           break;
   case State::SyncTime:             next_state = handle_SyncTime();             break;
@@ -240,7 +241,7 @@ void ArduinoIoTCloudTCP::update()
    */
   #if NETWORK_CONFIGURATOR_ENABLED
   if(_configurator != nullptr && _state > State::Init && _configurator->update() == NetworkConfiguratorStates::UPDATING_CONFIG){
-    _state = State::ConfigPhy;
+    _state = State::UpdatePhy;
   }
   #endif
 
@@ -311,6 +312,19 @@ ArduinoIoTCloudTCP::State ArduinoIoTCloudTCP::handle_ConfigPhy()
       return State::Init;
     }
   return State::ConfigPhy;
+#else
+  return State::Init;
+#endif
+}
+
+ArduinoIoTCloudTCP::State ArduinoIoTCloudTCP::handle_UpdatePhy()
+{
+#if NETWORK_CONFIGURATOR_ENABLED
+  if(_configurator->update() == NetworkConfiguratorStates::CONFIGURED) {
+      _configurator->disconnectAgent();
+      return State::Disconnect;
+    }
+  return State::UpdatePhy;
 #else
   return State::Init;
 #endif

--- a/src/ArduinoIoTCloudTCP.h
+++ b/src/ArduinoIoTCloudTCP.h
@@ -122,6 +122,7 @@ class ArduinoIoTCloudTCP: public ArduinoIoTCloudClass
     enum class State
     {
       ConfigPhy,
+      UpdatePhy,
       Init,
       ConnectPhy,
       SyncTime,
@@ -178,6 +179,7 @@ class ArduinoIoTCloudTCP: public ArduinoIoTCloudClass
     inline String getTopic_datain   () { return ( getThingId().length() == 0) ? String("") : String("/a/t/" + getThingId() + "/e/i"); }
 
     State handle_ConfigPhy();
+    State handle_UpdatePhy();
     State handle_Init();
     State handle_ConnectPhy();
     State handle_SyncTime();


### PR DESCRIPTION
The current version does not transmit to the cloud the new network configuration after it has been update with the NetworkConfigurator via Serial.

The PR adds a new state `UpdatePhy` for updating the network configuration. When the network configurations are changed the board is put in `Disconnect` state.