### PR TITLE
Initial zephyr support for iotcloud

### DIFF
--- a/.github/workflows/compile-examples.yml
+++ b/.github/workflows/compile-examples.yml
@@ -94,7 +94,26 @@ jobs:
           - fqbn: "rp2040:rp2040:rpipicow"
             type: rp2040
             artifact-name-suffix: rp2040-rp2040-rpipicow
-
+          - fqbn: "arduino:zephyr_main:portentah7"
+            platform-name: arduino:zephyr_main
+            artifact-name-suffix: arduino-zephyr_main-portentah7
+            type: zephyr
+          - fqbn: "arduino:zephyr_main:portentac33"
+            platform-name: arduino:zephyr_main
+            artifact-name-suffix: arduino-zephyr_main-portentac33
+            type: zephyr
+          - fqbn: "arduino:zephyr_main:nicla_vision"
+            platform-name: arduino:zephyr_main
+            artifact-name-suffix: arduino-zephyr_main-nicla_vision
+            type: zephyr
+          - fqbn: "arduino:zephyr_main:giga"
+            platform-name: arduino:zephyr_main
+            artifact-name-suffix: arduino-zephyr_main-giga
+            type: zephyr
+          - fqbn: "arduino:zephyr_main:opta"
+            platform-name: arduino:zephyr_main
+            artifact-name-suffix: arduino-zephyr_main-opta
+            type: zephyr
 
         # make board type-specific customizations to the matrix jobs
         include:
@@ -318,6 +337,20 @@ jobs:
               # Install rp2040 platform via Boards Manager
               - name: rp2040:rp2040
                 source-url: https://github.com/earlephilhower/arduino-pico/releases/download/global/package_rp2040_index.json
+          # zephyr boards
+          - board:
+              type: zephyr
+            platforms: |
+              # Install zephyr_main platform via Boards Manager
+              - name: arduino:zephyr_main
+            libraries: |
+              - name: ArduinoBearSSL
+              - name: ArduinoECCX08
+              - name: Arduino_SE05X
+            sketch-paths: |
+              - examples/ArduinoIoTCloud-Advanced
+              - examples/ArduinoIoTCloud-Basic
+              - examples/ArduinoIoTCloud-Callbacks
 
     steps:
       - name: Checkout

--- a/library.properties
+++ b/library.properties
@@ -6,6 +6,6 @@ sentence=This library allows connecting to the Arduino IoT Cloud service.
 paragraph=It provides a ConnectionManager to handle connection/disconnection, property-change updates and events callbacks. The supported boards are MKR GSM, MKR1000 and WiFi101.
 category=Communication
 url=https://github.com/arduino-libraries/ArduinoIoTCloud
-architectures=mbed,samd,esp8266,mbed_nano,mbed_portenta,mbed_nicla,esp32,mbed_opta,mbed_giga,renesas_portenta,renesas_uno,mbed_edge,stm32
+architectures=mbed,samd,esp8266,mbed_nano,mbed_portenta,mbed_nicla,esp32,mbed_opta,mbed_giga,renesas_portenta,renesas_uno,mbed_edge,stm32,zephyr,zephyr_main
 includes=ArduinoIoTCloud.h
 depends=Arduino_ConnectionHandler,Arduino_DebugUtils,Arduino_SecureElement,ArduinoMqttClient,ArduinoECCX08,RTCZero,Adafruit SleepyDog Library,ArduinoHttpClient,Arduino_CloudUtils,ArduinoBearSSL,Arduino_NetworkConfigurator

--- a/src/AIoTC_Config.h
+++ b/src/AIoTC_Config.h
@@ -45,13 +45,15 @@
   AUTOMATICALLY CONFIGURED DEFINES
  ******************************************************************************/
 
-#if defined(ARDUINO_SAMD_MKRWIFI1010) || defined(ARDUINO_SAMD_NANO_33_IOT)
+#if (defined(ARDUINO_SAMD_MKRWIFI1010) || defined(ARDUINO_SAMD_NANO_33_IOT)) && \
+  !defined(ARDUINO_ARCH_ZEPHYR)
   #define OTA_STORAGE_SNU         (1)
 #else
   #define OTA_STORAGE_SNU         (0)
 #endif
 
-#if defined(ARDUINO_NANO_RP2040_CONNECT)
+#if (defined(ARDUINO_NANO_RP2040_CONNECT)) && \
+  !defined(ARDUINO_ARCH_ZEPHYR)
   #define OTA_STORAGE_SFU         (1)
 #else
   #define OTA_STORAGE_SFU         (0)
@@ -63,13 +65,15 @@
   #define OTA_STORAGE_SSU         (0)
 #endif
 
-#if defined(ARDUINO_PORTENTA_H7_M7) || defined(ARDUINO_NICLA_VISION) || defined(ARDUINO_OPTA) || defined(ARDUINO_GIGA)
+#if (defined(ARDUINO_PORTENTA_H7_M7) || defined(ARDUINO_NICLA_VISION) || defined(ARDUINO_OPTA) || defined(ARDUINO_GIGA)) && \
+  !defined(ARDUINO_ARCH_ZEPHYR)
   #define OTA_STORAGE_PORTENTA_QSPI   (1)
 #else
   #define OTA_STORAGE_PORTENTA_QSPI   (0)
 #endif
 
-#if defined(ARDUINO_ARCH_ESP32) || defined(ARDUINO_UNOR4_WIFI)
+#if (defined(ARDUINO_ARCH_ESP32) || defined(ARDUINO_UNOR4_WIFI)) && \
+  !defined(ARDUINO_ARCH_ZEPHYR)
   #define OTA_STORAGE_ESP         (1)
 #endif
 
@@ -79,8 +83,8 @@
   #define OTA_ENABLED             (0)
 #endif
 
-#if defined(ARDUINO_SAMD_MKRGSM1400) || defined(ARDUINO_SAMD_MKR1000) ||   \
-  defined(ARDUINO_SAMD_MKRNB1500) || defined(ARDUINO_PORTENTA_H7_M7)      ||   \
+#if defined(ARDUINO_SAMD_MKRGSM1400) || defined(ARDUINO_SAMD_MKR1000) || \
+  defined(ARDUINO_SAMD_MKRNB1500) || defined(ARDUINO_PORTENTA_H7_M7) || \
   defined (ARDUINO_NANO_RP2040_CONNECT) || defined(ARDUINO_OPTA) || \
   defined(ARDUINO_GIGA)
   #define BOARD_HAS_ECCX08
@@ -123,6 +127,11 @@
   #define HAS_TCP
 #endif
 
+#if defined(ARDUINO_ARCH_ZEPHYR)
+  #define NETWORK_CONFIGURATOR_ENABLED (0)
+  #define HAS_TCP
+#endif
+
 #if defined(BOARD_HAS_SOFTSE) || defined(BOARD_HAS_OFFLOADED_ECCX08) || defined(BOARD_HAS_ECCX08) || defined(BOARD_HAS_SE050)
   #define BOARD_HAS_SECURE_ELEMENT
 #endif
@@ -131,9 +140,8 @@
   #define BOARD_USE_BEARSSL
 #endif
 
-#if (defined(ARDUINO_ARCH_SAMD) || defined(ARDUINO_ARCH_MBED) ||\
-     defined(ARDUINO_ARCH_RENESAS) || defined(ARDUINO_ARCH_ESP32)) &&\
-     !defined(ARDUINO_ARCH_ZEPHYR)
+#if defined(ARDUINO_ARCH_SAMD) || defined(ARDUINO_ARCH_MBED) ||\
+    defined(ARDUINO_ARCH_RENESAS) || defined(ARDUINO_ARCH_ESP32) || defined(ARDUINO_ARCH_ZEPHYR)
   #define BOARD_HAS_HW_RTC
 #endif
 
@@ -141,9 +149,10 @@
   #define BOARD_STM32H7
 #endif
 
-#if defined(ARDUINO_PORTENTA_H7_M7) || defined(ARDUINO_NICLA_VISION) || defined(ARDUINO_OPTA) || defined(ARDUINO_GIGA) \
+#if (defined(ARDUINO_PORTENTA_H7_M7) || defined(ARDUINO_NICLA_VISION) || defined(ARDUINO_OPTA) || defined(ARDUINO_GIGA) \
   || defined(ARDUINO_UNOR4_WIFI) || defined(ARDUINO_PORTENTA_C33) || defined(ARDUINO_NANO_RP2040_CONNECT) \
-  || defined(ARDUINO_SAMD_MKRWIFI1010) || defined(ARDUINO_SAMD_NANO_33_IOT)
+  || defined(ARDUINO_SAMD_MKRWIFI1010) || defined(ARDUINO_SAMD_NANO_33_IOT)) && \
+  !defined(ARDUINO_ARCH_ZEPHYR)
   #define NETWORK_CONFIGURATOR_ENABLED (1)
 #else
   #define NETWORK_CONFIGURATOR_ENABLED (0)

--- a/src/ArduinoIoTCloudTCP.h
+++ b/src/ArduinoIoTCloudTCP.h
@@ -28,9 +28,9 @@
 #endif
 
 #include <tls/utility/TLSClientMqtt.h>
-#include <tls/utility/TLSClientOta.h>
 
 #if OTA_ENABLED
+  #include <tls/utility/TLSClientOta.h>
   #include <ota/OTA.h>
 #endif
 

--- a/src/property/math_utils.h
+++ b/src/property/math_utils.h
@@ -21,9 +21,11 @@ namespace arduino { namespace math {
          * or if those two IEEE754 values are numbers or zero(which is handled on its own) exceed
          * a certain threshold
          */
+
+        using namespace std;
         return memcmp((uint8_t*)&a, (uint8_t*)&b, sizeof(b)) != 0 && (
-            (std::fpclassify(a) != FP_NORMAL && std::fpclassify(a) != FP_ZERO) ||
-            (std::fpclassify(b) != FP_NORMAL && std::fpclassify(b) != FP_ZERO) ||
+            (fpclassify(a) != FP_NORMAL && fpclassify(a) != FP_ZERO) ||
+            (fpclassify(b) != FP_NORMAL && fpclassify(b) != FP_ZERO) ||
             fabs(a - b) >= delta
         );
     }

--- a/src/utility/time/TimeService.cpp
+++ b/src/utility/time/TimeService.cpp
@@ -104,6 +104,17 @@ static inline unsigned long _getRTC() {
   return time(NULL);
 }
   #endif
+  #if defined(ARDUINO_ARCH_ZEPHYR)
+static inline void _setRTC(unsigned long time) {
+  struct timespec tspec = {(time_t)time, 0};
+	sys_clock_settime(SYS_CLOCK_REALTIME, &tspec);
+}
+static inline void _initRTC() {
+}
+static inline unsigned long _getRTC() {
+  return time(NULL);
+}
+  #endif
 #else /* !BOARD_HAS_HW_RTC */
   #pragma message "No hardware RTC implementation found, using soft RTC"
 static inline void _initRTC() {


### PR DESCRIPTION
This PR aims to keep track of the effort of adding zephyr support for iotcloud. 

This is currently being tested on a portentah7 with zephyr core at version https://github.com/andreagilardoni/ArduinoCore-zephyr/tree/iotcloud-integration-testing

This PR is meant to work on top of https://github.com/arduino-libraries/ArduinoIoTCloud/pull/599

The following PRs are required to be merged:
- https://github.com/arduino/ArduinoCore-zephyr/pull/368 to be included in `zephyr_main`
- arduino/ArduinoCore-zephyr/pull/356: for RAM and Flash expansion
- https://github.com/arduino/ArduinoCore-zephyr/pull/380/ to be included in `zephyr_main`
- https://github.com/arduino/ArduinoCore-zephyr/pull/463
- https://github.com/arduino/ArduinoCore-zephyr/pull/454

Tasks:
- [x] Cloud Connection
- [x] fix: `<err> i2c_ll_stm32_v2: i2c: speed above "fast" requires manual timing configuration`
- [ ] Ota
- [x] link_mode=dynamic
- [x] test nicla
- [x] test giga
- [x] test opta
- [x] test portentac33


Dependencies:
- https://github.com/arduino-libraries/Arduino_ConnectionHandler/pull/159
- https://github.com/arduino-libraries/ArduinoECCX08/pull/84
- https://github.com/arduino-libraries/ArduinoBearSSL/pull/107
- https://github.com/arduino-libraries/Arduino_CloudUtils/pull/35
- https://github.com/arduino-libraries/ArduinoMqttClient/pull/131 (not strictly required, but adds boards to ci)
- https://github.com/arduino-libraries/Arduino_SecureElement/pull/36 (not strictly required, but adds boards to ci)
- https://github.com/arduino-libraries/ArduinoECCX08/pull/87
- https://github.com/arduino-libraries/Arduino_SecureElement/pull/38
- https://github.com/arduino-libraries/Arduino_SecureElement/pull/39
- Publish of Arduino_SE05X library