### PR TITLE
Using Secure Element Global instance

### DIFF
--- a/src/ArduinoIoTCloudTCP.cpp
+++ b/src/ArduinoIoTCloudTCP.cpp
@@ -90,7 +90,7 @@ int ArduinoIoTCloudTCP::begin(ConnectionHandler & connection, bool const enable_
   if(_authMode == ArduinoIoTAuthenticationMode::CERTIFICATE)
   {
 #if defined(BOARD_HAS_SECURE_ELEMENT)
-    if (!_selement.begin())
+    if (!SecureElement.begin())
     {
       DEBUG_ERROR("ArduinoIoTCloudTCP::%s could not initialize secure element.", __FUNCTION__);
   #if defined(ARDUINO_UNOWIFIR4)
@@ -100,14 +100,14 @@ int ArduinoIoTCloudTCP::begin(ConnectionHandler & connection, bool const enable_
   #endif
       return 0;
     }
-    if (!SElementArduinoCloudDeviceId::read(_selement, getDeviceId(), SElementArduinoCloudSlot::DeviceId))
+    if (!SElementArduinoCloudDeviceId::read(SecureElement, getDeviceId(), SElementArduinoCloudSlot::DeviceId))
     {
       DEBUG_ERROR("ArduinoIoTCloudTCP::%s could not read device id.", __FUNCTION__);
       return 0;
     }
     if (!_writeCertOnConnect) {
       /* No update pending read certificate stored in secure element */
-      if (!SElementArduinoCloudCertificate::read(_selement, _cert, SElementArduinoCloudSlot::CompressedCertificate))
+      if (!SElementArduinoCloudCertificate::read(SecureElement, _cert, SElementArduinoCloudSlot::CompressedCertificate))
       {
         DEBUG_ERROR("ArduinoIoTCloudTCP::%s could not read device certificate.", __FUNCTION__);
         return 0;
@@ -389,7 +389,7 @@ ArduinoIoTCloudTCP::State ArduinoIoTCloudTCP::handle_ConnectMqttBroker()
     /* A device certificate update was pending */
     if (_writeCertOnConnect)
     {
-      if (SElementArduinoCloudCertificate::write(_selement, _cert, SElementArduinoCloudSlot::CompressedCertificate))
+      if (SElementArduinoCloudCertificate::write(SecureElement, _cert, SElementArduinoCloudSlot::CompressedCertificate))
       {
         DEBUG_INFO("ArduinoIoTCloudTCP::%s device certificate update done.", __FUNCTION__);
         _writeCertOnConnect = false;
@@ -670,7 +670,7 @@ int ArduinoIoTCloudTCP::write(String const topic, byte const data[], int const l
 #if defined(BOARD_HAS_SECURE_ELEMENT)
 int ArduinoIoTCloudTCP::updateCertificate(String authorityKeyIdentifier, String serialNumber, String notBefore, String notAfter, String signature)
 {
-  if (!_selement.begin())
+  if (!SecureElement.begin())
   {
     DEBUG_ERROR("ArduinoIoTCloudTCP::%s could not initialize secure element.", __FUNCTION__);
 #if defined(ARDUINO_UNOWIFIR4)
@@ -680,13 +680,13 @@ int ArduinoIoTCloudTCP::updateCertificate(String authorityKeyIdentifier, String 
 #endif
     return 0;
   }
-  if (!SElementArduinoCloudDeviceId::read(_selement, getDeviceId(), SElementArduinoCloudSlot::DeviceId))
+  if (!SElementArduinoCloudDeviceId::read(SecureElement, getDeviceId(), SElementArduinoCloudSlot::DeviceId))
   {
     DEBUG_ERROR("ArduinoIoTCloudTCP::%s could not read device id.", __FUNCTION__);
     return 0;
   }
   /* read certificate stored in secure element to compare AUTHORITY_KEY_ID */
-  if (!SElementArduinoCloudCertificate::read(_selement, _cert, SElementArduinoCloudSlot::CompressedCertificate))
+  if (!SElementArduinoCloudCertificate::read(SecureElement, _cert, SElementArduinoCloudSlot::CompressedCertificate))
   {
     DEBUG_ERROR("ArduinoIoTCloudTCP::%s could not read device certificate.", __FUNCTION__);
     return 0;
@@ -697,11 +697,11 @@ int ArduinoIoTCloudTCP::updateCertificate(String authorityKeyIdentifier, String 
     return 0;
   }
   /* rebuild device certificate */
-  if (SElementArduinoCloudCertificate::rebuild(_selement, _cert, getDeviceId(), notBefore, notAfter, serialNumber, authorityKeyIdentifier, signature))
+  if (SElementArduinoCloudCertificate::rebuild(SecureElement, _cert, getDeviceId(), notBefore, notAfter, serialNumber, authorityKeyIdentifier, signature))
   {
     DEBUG_INFO("ArduinoIoTCloudTCP::%s request started.", __FUNCTION__);
 #if defined(BOARD_HAS_OFFLOADED_ECCX08)
-    if (SElementArduinoCloudCertificate::write(_selement, _cert, SElementArduinoCloudSlot::CompressedCertificate))
+    if (SElementArduinoCloudCertificate::write(SecureElement, _cert, SElementArduinoCloudSlot::CompressedCertificate))
     {
       DEBUG_INFO("ArduinoIoTCloudTCP::%s update done.", __FUNCTION__);
     }

--- a/src/ArduinoIoTCloudTCP.h
+++ b/src/ArduinoIoTCloudTCP.h
@@ -51,15 +51,6 @@ static constexpr uint16_t DEFAULT_BROKER_PORT_AUTO = 0;
 
 typedef bool (*onOTARequestCallbackFunc)(void);
 
-#if defined(BOARD_HAS_SECURE_ELEMENT)
-#ifdef SECURE_ELEMENT_GI
-using SecureElement_t = SecureElementClass;
-#else
-#warning "Please update Arduino_SecureElement library from library manager"
-using SecureElement_t = SecureElement;
-#endif
-#endif // BOARD_HAS_SECURE_ELEMENT
-
 /******************************************************************************
   CLASS DECLARATION
  ******************************************************************************/
@@ -154,7 +145,6 @@ class ArduinoIoTCloudTCP: public ArduinoIoTCloudClass
 #endif
 
 #if defined(BOARD_HAS_SECURE_ELEMENT)
-    SecureElement_t _selement;
     ECP256Certificate _cert;
     /* Flag used to store updated device certificate after broker connection has succeeded */
     bool _writeCertOnConnect;

--- a/src/utility/time/NTPUtils.cpp
+++ b/src/utility/time/NTPUtils.cpp
@@ -18,8 +18,8 @@
 #include "NTPUtils.h"
 
 #include <Arduino.h>
-#ifdef BOARD_HAS_ECCX08
-  #include <ArduinoECCX08.h>
+#ifdef BOARD_HAS_SECURE_ELEMENT
+  #include <Arduino_SecureElement.h>
 #endif
 
 /******************************************************************************
@@ -91,8 +91,8 @@ void NTPUtils::sendNTPpacket(UDP & udp)
 
 int NTPUtils::getRandomPort(int const min_port, int const max_port)
 {
-#if defined (BOARD_HAS_ECCX08)
-  return ECCX08.random(min_port, max_port);
+#if defined (BOARD_HAS_SECURE_ELEMENT)
+  return SecureElement.random(min_port, max_port);
 #elif defined (ARDUINO_ARCH_ESP8266) || (ARDUINO_ARCH_ESP32)
   /* Uses HW Random Number Generator */
   return random(min_port, max_port);


### PR DESCRIPTION
Generalization of Secure element usage, from ECCX08. Using Secure Element instance, instead of local one.

depends on:
- https://github.com/arduino-libraries/Arduino_SecureElement/pull/40
- https://github.com/arduino-libraries/ArduinoBearSSL/pull/109

This pr is meant to be merged on top of https://github.com/arduino-libraries/ArduinoIoTCloud/pull/600 and https://github.com/arduino-libraries/ArduinoIoTCloud/pull/601 and https://github.com/arduino-libraries/ArduinoIoTCloud/pull/602