### PR TITLE
Adding warning if SECURE_ELEMENT_GI is not defined

### DIFF
--- a/src/ArduinoIoTCloudTCP.h
+++ b/src/ArduinoIoTCloudTCP.h
@@ -55,6 +55,7 @@ typedef bool (*onOTARequestCallbackFunc)(void);
 #ifdef SECURE_ELEMENT_GI
 using SecureElement_t = SecureElementClass;
 #else
+#warning "Please update Arduino_SecureElement library from library manager"
 using SecureElement_t = SecureElement;
 #endif
 #endif // BOARD_HAS_SECURE_ELEMENT


### PR DESCRIPTION
Adding warning message when secure element doesn't define a global instance, in order to favor transition to next version of iot cloud and secure element interaction